### PR TITLE
Memory fixes

### DIFF
--- a/src/sbml/extension/test/TestPackage.cpp
+++ b/src/sbml/extension/test/TestPackage.cpp
@@ -82,7 +82,9 @@ static
 	"Test"
 };
 
+LIBSBML_CPP_NAMESPACE_BEGIN
 template class SBMLExtensionNamespaces<TestExtension>;
+LIBSBML_CPP_NAMESPACE_END
 
 TestExtension::TestExtension ()
 {

--- a/src/sbml/packages/spatial/sbml/SampledField.cpp
+++ b/src/sbml/packages/spatial/sbml/SampledField.cpp
@@ -188,6 +188,7 @@ SampledField::clone() const
  */
 SampledField::~SampledField()
 {
+  freeCompressed();
   freeUncompressed();
 }
 
@@ -2064,6 +2065,7 @@ void SampledField::store() const
     if (mSamplesUncompressed == NULL) {
       mSamplesUncompressed = readSamplesFromString<double>(mSamples, mSamplesUncompressedLength);
       size_t alt_length;
+      free(mSamplesUncompressedInt);
       mSamplesUncompressedInt = readSamplesFromString<int>(mSamples, alt_length);
       if (alt_length != mSamplesUncompressedLength)
       {
@@ -2193,6 +2195,8 @@ SampledField::getUncompressed(double* outputPoints) const
 void
 SampledField::freeUncompressed() const
 {
+  free(mSamplesUncompressedInt);
+  mSamplesUncompressedInt = NULL;
   if (mSamplesUncompressed != NULL)
   {
     free(mSamplesUncompressed);

--- a/src/sbml/packages/spatial/sbml/SpatialPoints.cpp
+++ b/src/sbml/packages/spatial/sbml/SpatialPoints.cpp
@@ -252,6 +252,7 @@ SpatialPoints::getArrayData(int* outArray) const
     int* samples = readSamplesFromString<int>(mArrayData, length);
     if (length != mArrayDataUncompressedLength)
     {
+      free(samples);
       return LIBSBML_OPERATION_FAILED;
     }
 

--- a/src/sbml/packages/spatial/sbml/test/TestCompression.cpp
+++ b/src/sbml/packages/spatial/sbml/test/TestCompression.cpp
@@ -160,7 +160,7 @@ START_TEST(test_Compression_SampledField_2)
   for (size_t n = 0; n < values.size(); n++) {
     fail_unless(values[n] == uncompressed_data[n]);
   }
-  free(uncompressed_data);
+  delete[] uncompressed_data;
   fail_unless(field.getUncompressedLength() == values.size());
 
   uncompressed_data = NULL;
@@ -208,7 +208,7 @@ START_TEST(test_Compression_SampledField_3)
   for (size_t n = 0; n < values.size(); n++) {
     fail_unless(values[n] == uncompressed_data[n]);
   }
-  free(uncompressed_data);
+  delete[] uncompressed_data;
   fail_unless(field.getUncompressedLength() == values.size());
 
   uncompressed_data = NULL;
@@ -250,7 +250,7 @@ START_TEST(test_Compression_SampledField_4)
   for (size_t n = 0; n < values.size(); n++) {
     fail_unless(values[n] == doubles[n]);
   }
-  free(doubles);
+  delete[] doubles;
 
   vector<double> doublevec;
   field.getSamples(doublevec);
@@ -261,7 +261,7 @@ START_TEST(test_Compression_SampledField_4)
   for (size_t n = 0; n < values.size(); n++) {
     fail_unless(static_cast<float>(values[n]) == floats[n]);
   }
-  free(floats);
+  delete[] floats;
 
   vector<float> floatvec;
   field.getSamples(floatvec);
@@ -273,7 +273,7 @@ START_TEST(test_Compression_SampledField_4)
 
   int* ints = new int[values.size()];
   fail_unless(field.getSamples(ints) == LIBSBML_OPERATION_FAILED);
-  free(ints);
+  delete[] ints;
 
   vector<int> intvec;
   field.getSamples(intvec);
@@ -312,7 +312,7 @@ START_TEST(test_Compression_SampledField_5)
   for (size_t n = 0; n < values.size(); n++) {
     fail_unless(values[n] == doubles[n]);
   }
-  free(doubles);
+  delete[] doubles;
 
   vector<double> doublevec;
   field.getSamples(doublevec);
@@ -323,7 +323,7 @@ START_TEST(test_Compression_SampledField_5)
   for (size_t n = 0; n < values.size(); n++) {
     fail_unless(static_cast<float>(values[n]) == floats[n]);
   }
-  free(floats);
+  delete[] floats;
 
   vector<float> floatvec;
   field.getSamples(floatvec);
@@ -338,7 +338,7 @@ START_TEST(test_Compression_SampledField_5)
   for (size_t n = 0; n < compressedvals.size(); n++) {
     fail_unless(compressedvals[n] == ints[n]);
   }
-  free(ints);
+  delete[] ints;
 
   vector<int> intvec;
   field.getSamples(intvec);
@@ -452,7 +452,7 @@ START_TEST(test_Compression_SpatialPoints_2)
   for (size_t n = 0; n < values.size(); n++) {
     fail_unless(values[n] == uncompressed_data[n]);
   }
-  free(uncompressed_data);
+  delete[] uncompressed_data;
   fail_unless(points.getUncompressedLength() == values.size());
 
   uncompressed_data = NULL;
@@ -499,7 +499,7 @@ START_TEST(test_Compression_SpatialPoints_3)
   for (size_t n = 0; n < values.size(); n++) {
     fail_unless(values[n] == uncompressed_data[n]);
   }
-  free(uncompressed_data);
+  delete[] uncompressed_data;
   fail_unless(points.getUncompressedLength() == values.size());
 
   uncompressed_data = NULL;
@@ -540,7 +540,7 @@ START_TEST(test_Compression_SpatialPoints_4)
   for (size_t n = 0; n < values.size(); n++) {
     fail_unless(values[n] == doubles[n]);
   }
-  free(doubles);
+  delete[] doubles;
 
   vector<double> doublevec;
   points.getArrayData(doublevec);
@@ -551,7 +551,7 @@ START_TEST(test_Compression_SpatialPoints_4)
   for (size_t n = 0; n < values.size(); n++) {
     fail_unless(static_cast<float>(values[n]) == floats[n]);
   }
-  free(floats);
+  delete[] floats;
 
   vector<float> floatvec;
   points.getArrayData(floatvec);
@@ -563,7 +563,7 @@ START_TEST(test_Compression_SpatialPoints_4)
 
   int* ints = new int[values.size()];
   fail_unless(points.getArrayData(ints) == LIBSBML_OPERATION_FAILED);
-  free(ints);
+  delete[] ints;
 
   vector<int> intvec;
   points.getArrayData(intvec);
@@ -601,7 +601,7 @@ START_TEST(test_Compression_SpatialPoints_5)
   for (size_t n = 0; n < values.size(); n++) {
     fail_unless(values[n] == doubles[n]);
   }
-  free(doubles);
+  delete[] doubles;
 
   vector<double> doublevec;
   points.getArrayData(doublevec);
@@ -612,7 +612,7 @@ START_TEST(test_Compression_SpatialPoints_5)
   for (size_t n = 0; n < values.size(); n++) {
     fail_unless(static_cast<float>(values[n]) == floats[n]);
   }
-  free(floats);
+  delete[] floats;
 
   vector<float> floatvec;
   points.getArrayData(floatvec);
@@ -627,7 +627,7 @@ START_TEST(test_Compression_SpatialPoints_5)
   for (size_t n = 0; n < compressedvals.size(); n++) {
     fail_unless(compressedvals[n] == ints[n]);
   }
-  free(ints);
+  delete[] ints;
 
   vector<int> intvec;
   points.getArrayData(intvec);

--- a/src/sbml/packages/spatial/sbml/test/TestCompression.cpp
+++ b/src/sbml/packages/spatial/sbml/test/TestCompression.cpp
@@ -724,7 +724,7 @@ START_TEST(test_Compression_ParametricObject_2)
   parametricobj.getPointIndex(compressed_data);
   fail_unless(compressed_data == compressedvals);
 
-  int* uncompressed_array = new int[parametricobj.getUncompressedLength()];
+  int* uncompressed_array = NULL;
   size_t length;
   parametricobj.getUncompressedData(uncompressed_array, length);
   fail_unless(length == values.size());

--- a/src/sbml/packages/spatial/sbml/test/TestParametricObject.cpp
+++ b/src/sbml/packages/spatial/sbml/test/TestParametricObject.cpp
@@ -220,13 +220,14 @@ START_TEST(test_ParametricObject_uncompressInternal)
 
   size_t len = G->getUncompressedLength();
   fail_unless(len == 9);
-  int* result = (int*)malloc(sizeof(int) * len);
+  int* result = NULL;
   G->getUncompressedData(result, len);
 
   for (size_t i = 0; i < len; i++)
   {
     fail_unless(result[i] == points[i]);
   }
+  free(result);
 
 }
 END_TEST

--- a/src/sbml/packages/spatial/sbml/test/TestSpatialPoints.cpp
+++ b/src/sbml/packages/spatial/sbml/test/TestSpatialPoints.cpp
@@ -221,13 +221,14 @@ START_TEST(test_SpatialPoints_uncompressInternal)
 
   size_t len = G->getUncompressedLength();
   fail_unless(len == 9);
-  double* result = (double*)malloc(sizeof(double) * len);
+  double* result = NULL;
   G->getUncompressedData(result, len);
 
   for (size_t i = 0; i < len; i++)
   {
     fail_unless(result[i] == points[i]);
   }
+  free(result);
 
 }
 END_TEST

--- a/src/sbml/packages/spatial/validator/constraints/SpatialConsistencyConstraints.cpp
+++ b/src/sbml/packages/spatial/validator/constraints/SpatialConsistencyConstraints.cpp
@@ -2444,8 +2444,8 @@ START_CONSTRAINT(SpatialSampledFieldFloatArrayDataMustMatch, SampledField, sf)
   pre(sf.isSetDataType());
   pre(sf.getDataType() == SPATIAL_DATAKIND_FLOAT);
   SampledField* sf_nc = const_cast<SampledField*>(&sf);
-  size_t len = sf_nc->getUncompressedLength();
-  double* data = new double[len];
+  size_t len;
+  double* data = NULL;
   sf_nc->getUncompressedData(data, len);
   for (size_t d = 0; d < len; d++) {
     double val = data[d];
@@ -2476,8 +2476,8 @@ START_CONSTRAINT(SpatialSampledFieldUIntArrayDataNotNegative, SampledField, sf)
   pre(sf.isSetDataType());
   pre(sf.getDataType() == SPATIAL_DATAKIND_UINT || sf.getDataType() == SPATIAL_DATAKIND_UINT8 || sf.getDataType() == SPATIAL_DATAKIND_UINT16 || sf.getDataType() == SPATIAL_DATAKIND_UINT32);
   SampledField* sf_nc = const_cast<SampledField*>(&sf);
-  size_t len = sf_nc->getUncompressedLength();
-  double* data = new double[len];
+  size_t len;
+  double* data = NULL;
   sf_nc->getUncompressedData(data, len);
   for (size_t d = 0; d < len; d++) {
     double val = data[d];
@@ -2509,8 +2509,8 @@ START_CONSTRAINT(SpatialSampledFieldIntArrayDataIntegers, SampledField, sf)
   pre(sf.isSetDataType());
   pre(sf.getDataType() == SPATIAL_DATAKIND_INT || sf.getDataType() == SPATIAL_DATAKIND_UINT || sf.getDataType() == SPATIAL_DATAKIND_UINT8 || sf.getDataType() == SPATIAL_DATAKIND_UINT16 || sf.getDataType() == SPATIAL_DATAKIND_UINT32);
   SampledField* sf_nc = const_cast<SampledField*>(&sf);
-  size_t len = sf_nc->getUncompressedLength();
-  double* data = new double[len];
+  size_t len;
+  double* data = NULL;
   sf_nc->getUncompressedData(data, len);
   for (size_t d = 0; d < len; d++) {
     double ival, val = data[d];


### PR DESCRIPTION
## Description
Fix various memory leaks:

- replace mismatched new[]/free pairs with new[]/delete[]
- free allocated memory & set pointer to NULL
- getUncompressedData() allocates memory with malloc, so
  - don't allocate memory before calling it (otherwise this allocated memory leaks)
  - do deallocate with free() afterwards (otherwise the memory allocated by the function leaks)

Also:
  - add missing libsbml namespace (to fix compilation error when using `WITH_CPP_NAMESPACE=ON`)

## Motivation and Context
Running the test suite with [ASAN](https://clang.llvm.org/docs/AddressSanitizer.html) enabled reported various memory leaks, with the above changes there are no reported leaks.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have updated all documentation necessary.
- [ ] I have checked spelling in (new) comments.

## Testing
- [X] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested -->

