### PR TITLE
Fix memory leak in KineticLaw and UncertParameter.

### DIFF
--- a/src/sbml/KineticLaw.cpp
+++ b/src/sbml/KineticLaw.cpp
@@ -1814,7 +1814,8 @@ KineticLaw::readOtherXML (XMLInputStream& stream)
     // the following assumes that the SBML Namespaces object is valid
     if (stream.getSBMLNamespaces() == NULL)
     {
-      stream.setSBMLNamespaces(new SBMLNamespaces(getLevel(), getVersion()));
+        SBMLNamespaces sbmlns(getLevel(), getVersion());
+        stream.setSBMLNamespaces(&sbmlns);
     }
 
     delete mMath;

--- a/src/sbml/packages/distrib/sbml/UncertParameter.cpp
+++ b/src/sbml/packages/distrib/sbml/UncertParameter.cpp
@@ -1738,7 +1738,8 @@ UncertParameter::readOtherXML(XMLInputStream& stream)
     const std::string prefix = checkMathMLNamespace(elem);
     if (stream.getSBMLNamespaces() == NULL)
     {
-      stream.setSBMLNamespaces(new SBMLNamespaces(getLevel(), getVersion()));
+      SBMLNamespaces sbmlns(getLevel(), getVersion());
+      stream.setSBMLNamespaces(&sbmlns);
     }
 
     delete mMath;


### PR DESCRIPTION
'setSBMLNamespaces' uses a clone of the passed-in SBMLNamespaces, so if you use 'new', you leak it.  This uses a local variable instead, which is automatically cleaned up afterwards.