### PR TITLE
Math parser leak fix

### DIFF
--- a/src/sbml/math/L3Parser.cpp
+++ b/src/sbml/math/L3Parser.cpp
@@ -1,8 +1,9 @@
-/* A Bison parser, made by GNU Bison 3.0.4.  */
+/* A Bison parser, made by GNU Bison 3.5.1.  */
 
 /* Bison implementation for Yacc-like parsers in C
 
-   Copyright (C) 1984, 1989-1990, 2000-2015 Free Software Foundation, Inc.
+   Copyright (C) 1984, 1989-1990, 2000-2015, 2018-2020 Free Software Foundation,
+   Inc.
 
    This program is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -40,11 +41,14 @@
    define necessary library symbols; they are noted "INFRINGES ON
    USER NAME SPACE" below.  */
 
+/* Undocumented macros, especially those whose name start with YY_,
+   are private implementation details.  Do not rely on them.  */
+
 /* Identify Bison output.  */
 #define YYBISON 1
 
 /* Bison version.  */
-#define YYBISON_VERSION "3.0.4"
+#define YYBISON_VERSION "3.5.1"
 
 /* Skeleton name.  */
 #define YYSKELETON_NAME "yacc.c"
@@ -59,12 +63,12 @@
 #define YYPULL 1
 
 /* "%code top" blocks.  */
-#line 61 "L3Parser.ypp" /* yacc.c:316  */
+#line 61 "L3Parser.ypp"
 
 
  /** @cond doxygenLibsbmlInternal */
 
-#line 68 "L3Parser.cpp" /* yacc.c:316  */
+#line 72 "L3Parser.cpp"
 /* Substitute the type names.  */
 #define YYSTYPE         SBML_YYSTYPE
 /* Substitute the variable and function names.  */
@@ -73,12 +77,11 @@
 #define yyerror         sbml_yyerror
 #define yydebug         sbml_yydebug
 #define yynerrs         sbml_yynerrs
-
 #define yylval          sbml_yylval
 #define yychar          sbml_yychar
 
-/* Copy the first part of user declarations.  */
-#line 66 "L3Parser.ypp" /* yacc.c:339  */
+/* First part of user prologue.  */
+#line 66 "L3Parser.ypp"
 
 /**
  *
@@ -356,13 +359,26 @@ LIBSBML_CPP_NAMESPACE_END
 #endif
 
 
-#line 360 "L3Parser.cpp" /* yacc.c:339  */
+#line 363 "L3Parser.cpp"
 
-# ifndef YY_NULLPTR
-#  if defined __cplusplus && 201103L <= __cplusplus
-#   define YY_NULLPTR nullptr
+# ifndef YY_CAST
+#  ifdef __cplusplus
+#   define YY_CAST(Type, Val) static_cast<Type> (Val)
+#   define YY_REINTERPRET_CAST(Type, Val) reinterpret_cast<Type> (Val)
 #  else
-#   define YY_NULLPTR 0
+#   define YY_CAST(Type, Val) ((Type) (Val))
+#   define YY_REINTERPRET_CAST(Type, Val) ((Type) (Val))
+#  endif
+# endif
+# ifndef YY_NULLPTR
+#  if defined __cplusplus
+#   if 201103L <= __cplusplus
+#    define YY_NULLPTR nullptr
+#   else
+#    define YY_NULLPTR 0
+#   endif
+#  else
+#   define YY_NULLPTR ((void*)0)
 #  endif
 # endif
 
@@ -410,10 +426,9 @@ extern int sbml_yydebug;
 
 /* Value type.  */
 #if ! defined SBML_YYSTYPE && ! defined SBML_YYSTYPE_IS_DECLARED
-
 union SBML_YYSTYPE
 {
-#line 345 "L3Parser.ypp" /* yacc.c:355  */
+#line 345 "L3Parser.ypp"
 
   ASTNode* astnode;
   char character;
@@ -423,9 +438,9 @@ union SBML_YYSTYPE
   double mantissa;
   long   rational;
 
-#line 427 "L3Parser.cpp" /* yacc.c:355  */
-};
+#line 442 "L3Parser.cpp"
 
+};
 typedef union SBML_YYSTYPE SBML_YYSTYPE;
 # define SBML_YYSTYPE_IS_TRIVIAL 1
 # define SBML_YYSTYPE_IS_DECLARED 1
@@ -438,36 +453,81 @@ int sbml_yyparse (void);
 
 
 
-/* Copy the second part of user declarations.  */
 
-#line 444 "L3Parser.cpp" /* yacc.c:358  */
 
 #ifdef short
 # undef short
 #endif
 
-#ifdef YYTYPE_UINT8
-typedef YYTYPE_UINT8 yytype_uint8;
-#else
-typedef unsigned char yytype_uint8;
+/* On compilers that do not define __PTRDIFF_MAX__ etc., make sure
+   <limits.h> and (if available) <stdint.h> are included
+   so that the code can choose integer types of a good width.  */
+
+#ifndef __PTRDIFF_MAX__
+# include <limits.h> /* INFRINGES ON USER NAME SPACE */
+# if defined __STDC_VERSION__ && 199901 <= __STDC_VERSION__
+#  include <stdint.h> /* INFRINGES ON USER NAME SPACE */
+#  define YY_STDINT_H
+# endif
 #endif
 
-#ifdef YYTYPE_INT8
-typedef YYTYPE_INT8 yytype_int8;
+/* Narrow types that promote to a signed type and that can represent a
+   signed or unsigned integer of at least N bits.  In tables they can
+   save space and decrease cache pressure.  Promoting to a signed type
+   helps avoid bugs in integer arithmetic.  */
+
+#ifdef __INT_LEAST8_MAX__
+typedef __INT_LEAST8_TYPE__ yytype_int8;
+#elif defined YY_STDINT_H
+typedef int_least8_t yytype_int8;
 #else
 typedef signed char yytype_int8;
 #endif
 
-#ifdef YYTYPE_UINT16
-typedef YYTYPE_UINT16 yytype_uint16;
+#ifdef __INT_LEAST16_MAX__
+typedef __INT_LEAST16_TYPE__ yytype_int16;
+#elif defined YY_STDINT_H
+typedef int_least16_t yytype_int16;
 #else
-typedef unsigned short int yytype_uint16;
+typedef short yytype_int16;
 #endif
 
-#ifdef YYTYPE_INT16
-typedef YYTYPE_INT16 yytype_int16;
+#if defined __UINT_LEAST8_MAX__ && __UINT_LEAST8_MAX__ <= __INT_MAX__
+typedef __UINT_LEAST8_TYPE__ yytype_uint8;
+#elif (!defined __UINT_LEAST8_MAX__ && defined YY_STDINT_H \
+       && UINT_LEAST8_MAX <= INT_MAX)
+typedef uint_least8_t yytype_uint8;
+#elif !defined __UINT_LEAST8_MAX__ && UCHAR_MAX <= INT_MAX
+typedef unsigned char yytype_uint8;
 #else
-typedef short int yytype_int16;
+typedef short yytype_uint8;
+#endif
+
+#if defined __UINT_LEAST16_MAX__ && __UINT_LEAST16_MAX__ <= __INT_MAX__
+typedef __UINT_LEAST16_TYPE__ yytype_uint16;
+#elif (!defined __UINT_LEAST16_MAX__ && defined YY_STDINT_H \
+       && UINT_LEAST16_MAX <= INT_MAX)
+typedef uint_least16_t yytype_uint16;
+#elif !defined __UINT_LEAST16_MAX__ && USHRT_MAX <= INT_MAX
+typedef unsigned short yytype_uint16;
+#else
+typedef int yytype_uint16;
+#endif
+
+#ifndef YYPTRDIFF_T
+# if defined __PTRDIFF_TYPE__ && defined __PTRDIFF_MAX__
+#  define YYPTRDIFF_T __PTRDIFF_TYPE__
+#  define YYPTRDIFF_MAXIMUM __PTRDIFF_MAX__
+# elif defined PTRDIFF_MAX
+#  ifndef ptrdiff_t
+#   include <stddef.h> /* INFRINGES ON USER NAME SPACE */
+#  endif
+#  define YYPTRDIFF_T ptrdiff_t
+#  define YYPTRDIFF_MAXIMUM PTRDIFF_MAX
+# else
+#  define YYPTRDIFF_T long
+#  define YYPTRDIFF_MAXIMUM LONG_MAX
+# endif
 #endif
 
 #ifndef YYSIZE_T
@@ -475,15 +535,27 @@ typedef short int yytype_int16;
 #  define YYSIZE_T __SIZE_TYPE__
 # elif defined size_t
 #  define YYSIZE_T size_t
-# elif ! defined YYSIZE_T
+# elif defined __STDC_VERSION__ && 199901 <= __STDC_VERSION__
 #  include <stddef.h> /* INFRINGES ON USER NAME SPACE */
 #  define YYSIZE_T size_t
 # else
-#  define YYSIZE_T unsigned int
+#  define YYSIZE_T unsigned
 # endif
 #endif
 
-#define YYSIZE_MAXIMUM ((YYSIZE_T) -1)
+#define YYSIZE_MAXIMUM                                  \
+  YY_CAST (YYPTRDIFF_T,                                 \
+           (YYPTRDIFF_MAXIMUM < YY_CAST (YYSIZE_T, -1)  \
+            ? YYPTRDIFF_MAXIMUM                         \
+            : YY_CAST (YYSIZE_T, -1)))
+
+#define YYSIZEOF(X) YY_CAST (YYPTRDIFF_T, sizeof (X))
+
+/* Stored state numbers (used for stacks). */
+typedef yytype_int8 yy_state_t;
+
+/* State numbers in computations.  */
+typedef int yy_state_fast_t;
 
 #ifndef YY_
 # if defined YYENABLE_NLS && YYENABLE_NLS
@@ -497,30 +569,19 @@ typedef short int yytype_int16;
 # endif
 #endif
 
-#ifndef YY_ATTRIBUTE
-# if (defined __GNUC__                                               \
-      && (2 < __GNUC__ || (__GNUC__ == 2 && 96 <= __GNUC_MINOR__)))  \
-     || defined __SUNPRO_C && 0x5110 <= __SUNPRO_C
-#  define YY_ATTRIBUTE(Spec) __attribute__(Spec)
+#ifndef YY_ATTRIBUTE_PURE
+# if defined __GNUC__ && 2 < __GNUC__ + (96 <= __GNUC_MINOR__)
+#  define YY_ATTRIBUTE_PURE __attribute__ ((__pure__))
 # else
-#  define YY_ATTRIBUTE(Spec) /* empty */
+#  define YY_ATTRIBUTE_PURE
 # endif
 #endif
 
-#ifndef YY_ATTRIBUTE_PURE
-# define YY_ATTRIBUTE_PURE   YY_ATTRIBUTE ((__pure__))
-#endif
-
 #ifndef YY_ATTRIBUTE_UNUSED
-# define YY_ATTRIBUTE_UNUSED YY_ATTRIBUTE ((__unused__))
-#endif
-
-#if !defined _Noreturn \
-     && (!defined __STDC_VERSION__ || __STDC_VERSION__ < 201112)
-# if defined _MSC_VER && 1200 <= _MSC_VER
-#  define _Noreturn __declspec (noreturn)
+# if defined __GNUC__ && 2 < __GNUC__ + (7 <= __GNUC_MINOR__)
+#  define YY_ATTRIBUTE_UNUSED __attribute__ ((__unused__))
 # else
-#  define _Noreturn YY_ATTRIBUTE ((__noreturn__))
+#  define YY_ATTRIBUTE_UNUSED
 # endif
 #endif
 
@@ -531,13 +592,13 @@ typedef short int yytype_int16;
 # define YYUSE(E) /* empty */
 #endif
 
-#if defined __GNUC__ && 407 <= __GNUC__ * 100 + __GNUC_MINOR__
+#if defined __GNUC__ && ! defined __ICC && 407 <= __GNUC__ * 100 + __GNUC_MINOR__
 /* Suppress an incorrect diagnostic about yylval being uninitialized.  */
-# define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN \
-    _Pragma ("GCC diagnostic push") \
-    _Pragma ("GCC diagnostic ignored \"-Wuninitialized\"")\
+# define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN                            \
+    _Pragma ("GCC diagnostic push")                                     \
+    _Pragma ("GCC diagnostic ignored \"-Wuninitialized\"")              \
     _Pragma ("GCC diagnostic ignored \"-Wmaybe-uninitialized\"")
-# define YY_IGNORE_MAYBE_UNINITIALIZED_END \
+# define YY_IGNORE_MAYBE_UNINITIALIZED_END      \
     _Pragma ("GCC diagnostic pop")
 #else
 # define YY_INITIAL_VALUE(Value) Value
@@ -550,6 +611,20 @@ typedef short int yytype_int16;
 # define YY_INITIAL_VALUE(Value) /* Nothing. */
 #endif
 
+#if defined __cplusplus && defined __GNUC__ && ! defined __ICC && 6 <= __GNUC__
+# define YY_IGNORE_USELESS_CAST_BEGIN                          \
+    _Pragma ("GCC diagnostic push")                            \
+    _Pragma ("GCC diagnostic ignored \"-Wuseless-cast\"")
+# define YY_IGNORE_USELESS_CAST_END            \
+    _Pragma ("GCC diagnostic pop")
+#endif
+#ifndef YY_IGNORE_USELESS_CAST_BEGIN
+# define YY_IGNORE_USELESS_CAST_BEGIN
+# define YY_IGNORE_USELESS_CAST_END
+#endif
+
+
+#define YY_ASSERT(E) ((void) (0 && (E)))
 
 #if ! defined yyoverflow || YYERROR_VERBOSE
 
@@ -626,17 +701,17 @@ void free (void *); /* INFRINGES ON USER NAME SPACE */
 /* A type that is properly aligned for any stack member.  */
 union yyalloc
 {
-  yytype_int16 yyss_alloc;
+  yy_state_t yyss_alloc;
   YYSTYPE yyvs_alloc;
 };
 
 /* The size of the maximum gap between one aligned stack and the next.  */
-# define YYSTACK_GAP_MAXIMUM (sizeof (union yyalloc) - 1)
+# define YYSTACK_GAP_MAXIMUM (YYSIZEOF (union yyalloc) - 1)
 
 /* The size of an array large to enough to hold all stacks, each with
    N elements.  */
 # define YYSTACK_BYTES(N) \
-     ((N) * (sizeof (yytype_int16) + sizeof (YYSTYPE)) \
+     ((N) * (YYSIZEOF (yy_state_t) + YYSIZEOF (YYSTYPE)) \
       + YYSTACK_GAP_MAXIMUM)
 
 # define YYCOPY_NEEDED 1
@@ -649,11 +724,11 @@ union yyalloc
 # define YYSTACK_RELOCATE(Stack_alloc, Stack)                           \
     do                                                                  \
       {                                                                 \
-        YYSIZE_T yynewbytes;                                            \
+        YYPTRDIFF_T yynewbytes;                                         \
         YYCOPY (&yyptr->Stack_alloc, Stack, yysize);                    \
         Stack = &yyptr->Stack_alloc;                                    \
-        yynewbytes = yystacksize * sizeof (*Stack) + YYSTACK_GAP_MAXIMUM; \
-        yyptr += yynewbytes / sizeof (*yyptr);                          \
+        yynewbytes = yystacksize * YYSIZEOF (*Stack) + YYSTACK_GAP_MAXIMUM; \
+        yyptr += yynewbytes / YYSIZEOF (*yyptr);                        \
       }                                                                 \
     while (0)
 
@@ -665,12 +740,12 @@ union yyalloc
 # ifndef YYCOPY
 #  if defined __GNUC__ && 1 < __GNUC__
 #   define YYCOPY(Dst, Src, Count) \
-      __builtin_memcpy (Dst, Src, (Count) * sizeof (*(Src)))
+      __builtin_memcpy (Dst, Src, YY_CAST (YYSIZE_T, (Count)) * sizeof (*(Src)))
 #  else
 #   define YYCOPY(Dst, Src, Count)              \
       do                                        \
         {                                       \
-          YYSIZE_T yyi;                         \
+          YYPTRDIFF_T yyi;                      \
           for (yyi = 0; yyi < (Count); yyi++)   \
             (Dst)[yyi] = (Src)[yyi];            \
         }                                       \
@@ -693,17 +768,18 @@ union yyalloc
 /* YYNSTATES -- Number of states.  */
 #define YYNSTATES  79
 
-/* YYTRANSLATE[YYX] -- Symbol number corresponding to YYX as returned
-   by yylex, with out-of-bounds checking.  */
 #define YYUNDEFTOK  2
 #define YYMAXUTOK   265
 
+
+/* YYTRANSLATE(TOKEN-NUM) -- Symbol number corresponding to TOKEN-NUM
+   as returned by yylex, with out-of-bounds checking.  */
 #define YYTRANSLATE(YYX)                                                \
-  ((unsigned int) (YYX) <= YYMAXUTOK ? yytranslate[YYX] : YYUNDEFTOK)
+  (0 <= (YYX) && (YYX) <= YYMAXUTOK ? yytranslate[YYX] : YYUNDEFTOK)
 
 /* YYTRANSLATE[TOKEN-NUM] -- Symbol number corresponding to TOKEN-NUM
-   as returned by yylex, without out-of-bounds checking.  */
-static const yytype_uint8 yytranslate[] =
+   as returned by yylex.  */
+static const yytype_int8 yytranslate[] =
 {
        0,     2,     2,     2,     2,     2,     2,     2,     2,     2,
        2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
@@ -736,13 +812,13 @@ static const yytype_uint8 yytranslate[] =
 
 #if SBML_YYDEBUG
   /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
-static const yytype_uint16 yyrline[] =
+static const yytype_int16 yyrline[] =
 {
-       0,   378,   378,   379,   380,   381,   384,   385,   411,   412,
-     413,   424,   435,   436,   437,   447,   448,   481,   482,   483,
-     484,   485,   486,   487,   488,   489,   500,   511,   512,   524,
-     581,   594,   605,   616,   627,   637,   644,   651,   658,   665,
-     681,   682,   685,   686
+       0,   384,   384,   385,   386,   387,   390,   391,   417,   418,
+     419,   430,   441,   442,   443,   453,   454,   487,   488,   489,
+     490,   491,   492,   493,   494,   495,   506,   517,   518,   530,
+     587,   600,   611,   622,   633,   643,   650,   657,   664,   671,
+     687,   688,   691,   692
 };
 #endif
 
@@ -763,7 +839,7 @@ static const char *const yytname[] =
 # ifdef YYPRINT
 /* YYTOKNUM[NUM] -- (External) token number corresponding to the
    (internal) symbol number NUM (which must be that of a token).  */
-static const yytype_uint16 yytoknum[] =
+static const yytype_int16 yytoknum[] =
 {
        0,   256,   257,    38,   124,    60,    62,    61,    33,    45,
       43,    42,    47,    37,   258,   259,   260,    94,    91,   261,
@@ -772,14 +848,14 @@ static const yytype_uint16 yytoknum[] =
 };
 # endif
 
-#define YYPACT_NINF -24
+#define YYPACT_NINF (-24)
 
-#define yypact_value_is_default(Yystate) \
-  (!!((Yystate) == (-24)))
+#define yypact_value_is_default(Yyn) \
+  ((Yyn) == YYPACT_NINF)
 
-#define YYTABLE_NINF -4
+#define YYTABLE_NINF (-4)
 
-#define yytable_value_is_error(Yytable_value) \
+#define yytable_value_is_error(Yyn) \
   0
 
   /* YYPACT[STATE-NUM] -- Index in YYTABLE of the portion describing
@@ -799,7 +875,7 @@ static const yytype_int16 yypact[] =
   /* YYDEFACT[STATE-NUM] -- Default reduction number in state STATE-NUM.
      Performed when YYTABLE does not specify something else to do.  Zero
      means the default is an error.  */
-static const yytype_uint8 yydefact[] =
+static const yytype_int8 yydefact[] =
 {
        0,     4,     0,     0,     0,    35,    37,    36,    38,     7,
        0,     0,     0,     0,     6,    27,    16,    15,     0,     0,
@@ -888,7 +964,7 @@ static const yytype_int8 yycheck[] =
 
   /* YYSTOS[STATE-NUM] -- The (internal number of the) accessing
      symbol of state STATE-NUM.  */
-static const yytype_uint8 yystos[] =
+static const yytype_int8 yystos[] =
 {
        0,     1,     8,     9,    10,    19,    20,    21,    22,    23,
       24,    27,    32,    33,    34,    33,    33,    33,    24,    33,
@@ -901,7 +977,7 @@ static const yytype_uint8 yystos[] =
 };
 
   /* YYR1[YYN] -- Symbol number of symbol that rule YYN derives.  */
-static const yytype_uint8 yyr1[] =
+static const yytype_int8 yyr1[] =
 {
        0,    31,    32,    32,    32,    32,    33,    33,    33,    33,
       33,    33,    33,    33,    33,    33,    33,    33,    33,    33,
@@ -911,7 +987,7 @@ static const yytype_uint8 yyr1[] =
 };
 
   /* YYR2[YYN] -- Number of symbols on the right hand side of rule YYN.  */
-static const yytype_uint8 yyr2[] =
+static const yytype_int8 yyr2[] =
 {
        0,     2,     0,     1,     1,     2,     1,     1,     3,     3,
        3,     3,     3,     3,     3,     2,     2,     3,     3,     4,
@@ -933,22 +1009,22 @@ static const yytype_uint8 yyr2[] =
 
 #define YYRECOVERING()  (!!yyerrstatus)
 
-#define YYBACKUP(Token, Value)                                  \
-do                                                              \
-  if (yychar == YYEMPTY)                                        \
-    {                                                           \
-      yychar = (Token);                                         \
-      yylval = (Value);                                         \
-      YYPOPSTACK (yylen);                                       \
-      yystate = *yyssp;                                         \
-      goto yybackup;                                            \
-    }                                                           \
-  else                                                          \
-    {                                                           \
-      yyerror (YY_("syntax error: cannot back up")); \
-      YYERROR;                                                  \
-    }                                                           \
-while (0)
+#define YYBACKUP(Token, Value)                                    \
+  do                                                              \
+    if (yychar == YYEMPTY)                                        \
+      {                                                           \
+        yychar = (Token);                                         \
+        yylval = (Value);                                         \
+        YYPOPSTACK (yylen);                                       \
+        yystate = *yyssp;                                         \
+        goto yybackup;                                            \
+      }                                                           \
+    else                                                          \
+      {                                                           \
+        yyerror (YY_("syntax error: cannot back up")); \
+        YYERROR;                                                  \
+      }                                                           \
+  while (0)
 
 /* Error token number */
 #define YYTERROR        1
@@ -988,37 +1064,39 @@ do {                                                                      \
 } while (0)
 
 
-/*----------------------------------------.
-| Print this symbol's value on YYOUTPUT.  |
-`----------------------------------------*/
+/*-----------------------------------.
+| Print this symbol's value on YYO.  |
+`-----------------------------------*/
 
 static void
-yy_symbol_value_print (FILE *yyoutput, int yytype, YYSTYPE const * const yyvaluep)
+yy_symbol_value_print (FILE *yyo, int yytype, YYSTYPE const * const yyvaluep)
 {
-  FILE *yyo = yyoutput;
-  YYUSE (yyo);
+  FILE *yyoutput = yyo;
+  YYUSE (yyoutput);
   if (!yyvaluep)
     return;
 # ifdef YYPRINT
   if (yytype < YYNTOKENS)
-    YYPRINT (yyoutput, yytoknum[yytype], *yyvaluep);
+    YYPRINT (yyo, yytoknum[yytype], *yyvaluep);
 # endif
+  YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
   YYUSE (yytype);
+  YY_IGNORE_MAYBE_UNINITIALIZED_END
 }
 
 
-/*--------------------------------.
-| Print this symbol on YYOUTPUT.  |
-`--------------------------------*/
+/*---------------------------.
+| Print this symbol on YYO.  |
+`---------------------------*/
 
 static void
-yy_symbol_print (FILE *yyoutput, int yytype, YYSTYPE const * const yyvaluep)
+yy_symbol_print (FILE *yyo, int yytype, YYSTYPE const * const yyvaluep)
 {
-  YYFPRINTF (yyoutput, "%s %s (",
+  YYFPRINTF (yyo, "%s %s (",
              yytype < YYNTOKENS ? "token" : "nterm", yytname[yytype]);
 
-  yy_symbol_value_print (yyoutput, yytype, yyvaluep);
-  YYFPRINTF (yyoutput, ")");
+  yy_symbol_value_print (yyo, yytype, yyvaluep);
+  YYFPRINTF (yyo, ")");
 }
 
 /*------------------------------------------------------------------.
@@ -1027,7 +1105,7 @@ yy_symbol_print (FILE *yyoutput, int yytype, YYSTYPE const * const yyvaluep)
 `------------------------------------------------------------------*/
 
 static void
-yy_stack_print (yytype_int16 *yybottom, yytype_int16 *yytop)
+yy_stack_print (yy_state_t *yybottom, yy_state_t *yytop)
 {
   YYFPRINTF (stderr, "Stack now");
   for (; yybottom <= yytop; yybottom++)
@@ -1050,20 +1128,20 @@ do {                                                            \
 `------------------------------------------------*/
 
 static void
-yy_reduce_print (yytype_int16 *yyssp, YYSTYPE *yyvsp, int yyrule)
+yy_reduce_print (yy_state_t *yyssp, YYSTYPE *yyvsp, int yyrule)
 {
-  unsigned long int yylno = yyrline[yyrule];
+  int yylno = yyrline[yyrule];
   int yynrhs = yyr2[yyrule];
   int yyi;
-  YYFPRINTF (stderr, "Reducing stack by rule %d (line %lu):\n",
+  YYFPRINTF (stderr, "Reducing stack by rule %d (line %d):\n",
              yyrule - 1, yylno);
   /* The symbols being reduced.  */
   for (yyi = 0; yyi < yynrhs; yyi++)
     {
       YYFPRINTF (stderr, "   $%d = ", yyi + 1);
       yy_symbol_print (stderr,
-                       yystos[yyssp[yyi + 1 - yynrhs]],
-                       &(yyvsp[(yyi + 1) - (yynrhs)])
+                       yystos[+yyssp[yyi + 1 - yynrhs]],
+                       &yyvsp[(yyi + 1) - (yynrhs)]
                                               );
       YYFPRINTF (stderr, "\n");
     }
@@ -1107,13 +1185,13 @@ int yydebug;
 
 # ifndef yystrlen
 #  if defined __GLIBC__ && defined _STRING_H
-#   define yystrlen strlen
+#   define yystrlen(S) (YY_CAST (YYPTRDIFF_T, strlen (S)))
 #  else
 /* Return the length of YYSTR.  */
-static YYSIZE_T
+static YYPTRDIFF_T
 yystrlen (const char *yystr)
 {
-  YYSIZE_T yylen;
+  YYPTRDIFF_T yylen;
   for (yylen = 0; yystr[yylen]; yylen++)
     continue;
   return yylen;
@@ -1149,12 +1227,12 @@ yystpcpy (char *yydest, const char *yysrc)
    backslash-backslash).  YYSTR is taken from yytname.  If YYRES is
    null, do not copy; instead, return the length of what the result
    would have been.  */
-static YYSIZE_T
+static YYPTRDIFF_T
 yytnamerr (char *yyres, const char *yystr)
 {
   if (*yystr == '"')
     {
-      YYSIZE_T yyn = 0;
+      YYPTRDIFF_T yyn = 0;
       char const *yyp = yystr;
 
       for (;;)
@@ -1167,7 +1245,10 @@ yytnamerr (char *yyres, const char *yystr)
           case '\\':
             if (*++yyp != '\\')
               goto do_not_strip_quotes;
-            /* Fall through.  */
+            else
+              goto append;
+
+          append:
           default:
             if (yyres)
               yyres[yyn] = *yyp;
@@ -1182,10 +1263,10 @@ yytnamerr (char *yyres, const char *yystr)
     do_not_strip_quotes: ;
     }
 
-  if (! yyres)
+  if (yyres)
+    return yystpcpy (yyres, yystr) - yyres;
+  else
     return yystrlen (yystr);
-
-  return yystpcpy (yyres, yystr) - yyres;
 }
 # endif
 
@@ -1198,19 +1279,19 @@ yytnamerr (char *yyres, const char *yystr)
    *YYMSG_ALLOC to the required number of bytes.  Return 2 if the
    required number of bytes is too large to store.  */
 static int
-yysyntax_error (YYSIZE_T *yymsg_alloc, char **yymsg,
-                yytype_int16 *yyssp, int yytoken)
+yysyntax_error (YYPTRDIFF_T *yymsg_alloc, char **yymsg,
+                yy_state_t *yyssp, int yytoken)
 {
-  YYSIZE_T yysize0 = yytnamerr (YY_NULLPTR, yytname[yytoken]);
-  YYSIZE_T yysize = yysize0;
   enum { YYERROR_VERBOSE_ARGS_MAXIMUM = 5 };
   /* Internationalized format string. */
   const char *yyformat = YY_NULLPTR;
-  /* Arguments of yyformat. */
+  /* Arguments of yyformat: reported tokens (one for the "unexpected",
+     one per "expected"). */
   char const *yyarg[YYERROR_VERBOSE_ARGS_MAXIMUM];
-  /* Number of reported tokens (one for the "unexpected", one per
-     "expected"). */
+  /* Actual size of YYARG. */
   int yycount = 0;
+  /* Cumulated lengths of YYARG.  */
+  YYPTRDIFF_T yysize = 0;
 
   /* There are many possibilities here to consider:
      - If this state is a consistent state with a default action, then
@@ -1237,7 +1318,9 @@ yysyntax_error (YYSIZE_T *yymsg_alloc, char **yymsg,
   */
   if (yytoken != YYEMPTY)
     {
-      int yyn = yypact[*yyssp];
+      int yyn = yypact[+*yyssp];
+      YYPTRDIFF_T yysize0 = yytnamerr (YY_NULLPTR, yytname[yytoken]);
+      yysize = yysize0;
       yyarg[yycount++] = yytname[yytoken];
       if (!yypact_value_is_default (yyn))
         {
@@ -1262,11 +1345,12 @@ yysyntax_error (YYSIZE_T *yymsg_alloc, char **yymsg,
                   }
                 yyarg[yycount++] = yytname[yyx];
                 {
-                  YYSIZE_T yysize1 = yysize + yytnamerr (YY_NULLPTR, yytname[yyx]);
-                  if (! (yysize <= yysize1
-                         && yysize1 <= YYSTACK_ALLOC_MAXIMUM))
+                  YYPTRDIFF_T yysize1
+                    = yysize + yytnamerr (YY_NULLPTR, yytname[yyx]);
+                  if (yysize <= yysize1 && yysize1 <= YYSTACK_ALLOC_MAXIMUM)
+                    yysize = yysize1;
+                  else
                     return 2;
-                  yysize = yysize1;
                 }
               }
         }
@@ -1278,6 +1362,7 @@ yysyntax_error (YYSIZE_T *yymsg_alloc, char **yymsg,
       case N:                               \
         yyformat = S;                       \
       break
+    default: /* Avoid compiler warnings. */
       YYCASE_(0, YY_("syntax error"));
       YYCASE_(1, YY_("syntax error, unexpected %s"));
       YYCASE_(2, YY_("syntax error, unexpected %s, expecting %s"));
@@ -1288,10 +1373,13 @@ yysyntax_error (YYSIZE_T *yymsg_alloc, char **yymsg,
     }
 
   {
-    YYSIZE_T yysize1 = yysize + yystrlen (yyformat);
-    if (! (yysize <= yysize1 && yysize1 <= YYSTACK_ALLOC_MAXIMUM))
+    /* Don't count the "%s"s in the final size, but reserve room for
+       the terminator.  */
+    YYPTRDIFF_T yysize1 = yysize + (yystrlen (yyformat) - 2 * yycount) + 1;
+    if (yysize <= yysize1 && yysize1 <= YYSTACK_ALLOC_MAXIMUM)
+      yysize = yysize1;
+    else
       return 2;
-    yysize = yysize1;
   }
 
   if (*yymsg_alloc < yysize)
@@ -1317,8 +1405,8 @@ yysyntax_error (YYSIZE_T *yymsg_alloc, char **yymsg,
         }
       else
         {
-          yyp++;
-          yyformat++;
+          ++yyp;
+          ++yyformat;
         }
   }
   return 0;
@@ -1338,7 +1426,35 @@ yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep)
   YY_SYMBOL_PRINT (yymsg, yytype, yyvaluep, yylocationp);
 
   YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
-  YYUSE (yytype);
+  switch (yytype)
+    {
+    case 33: /* node  */
+#line 359 "L3Parser.ypp"
+            { delete(((*yyvaluep).astnode)); }
+#line 1435 "L3Parser.cpp"
+        break;
+
+    case 34: /* number  */
+#line 362 "L3Parser.ypp"
+            { delete(((*yyvaluep).astnode)); }
+#line 1441 "L3Parser.cpp"
+        break;
+
+    case 35: /* nodelist  */
+#line 360 "L3Parser.ypp"
+            { delete(((*yyvaluep).astnode)); }
+#line 1447 "L3Parser.cpp"
+        break;
+
+    case 36: /* nodesemicolonlist  */
+#line 361 "L3Parser.ypp"
+            { delete(((*yyvaluep).astnode)); }
+#line 1453 "L3Parser.cpp"
+        break;
+
+      default:
+        break;
+    }
   YY_IGNORE_MAYBE_UNINITIALIZED_END
 }
 
@@ -1361,7 +1477,7 @@ int yynerrs;
 int
 yyparse (void)
 {
-    int yystate;
+    yy_state_fast_t yystate;
     /* Number of tokens to shift before error messages enabled.  */
     int yyerrstatus;
 
@@ -1373,16 +1489,16 @@ yyparse (void)
        to reallocate them elsewhere.  */
 
     /* The state stack.  */
-    yytype_int16 yyssa[YYINITDEPTH];
-    yytype_int16 *yyss;
-    yytype_int16 *yyssp;
+    yy_state_t yyssa[YYINITDEPTH];
+    yy_state_t *yyss;
+    yy_state_t *yyssp;
 
     /* The semantic value stack.  */
     YYSTYPE yyvsa[YYINITDEPTH];
     YYSTYPE *yyvs;
     YYSTYPE *yyvsp;
 
-    YYSIZE_T yystacksize;
+    YYPTRDIFF_T yystacksize;
 
   int yyn;
   int yyresult;
@@ -1396,7 +1512,7 @@ yyparse (void)
   /* Buffer for error messages, and its allocated size.  */
   char yymsgbuf[128];
   char *yymsg = yymsgbuf;
-  YYSIZE_T yymsg_alloc = sizeof yymsgbuf;
+  YYPTRDIFF_T yymsg_alloc = sizeof yymsgbuf;
 #endif
 
 #define YYPOPSTACK(N)   (yyvsp -= (N), yyssp -= (N))
@@ -1417,46 +1533,54 @@ yyparse (void)
   yychar = YYEMPTY; /* Cause a token to be read.  */
   goto yysetstate;
 
+
 /*------------------------------------------------------------.
-| yynewstate -- Push a new state, which is found in yystate.  |
+| yynewstate -- push a new state, which is found in yystate.  |
 `------------------------------------------------------------*/
- yynewstate:
+yynewstate:
   /* In all cases, when you get here, the value and location stacks
      have just been pushed.  So pushing a state here evens the stacks.  */
   yyssp++;
 
- yysetstate:
-  *yyssp = yystate;
+
+/*--------------------------------------------------------------------.
+| yysetstate -- set current state (the top of the stack) to yystate.  |
+`--------------------------------------------------------------------*/
+yysetstate:
+  YYDPRINTF ((stderr, "Entering state %d\n", yystate));
+  YY_ASSERT (0 <= yystate && yystate < YYNSTATES);
+  YY_IGNORE_USELESS_CAST_BEGIN
+  *yyssp = YY_CAST (yy_state_t, yystate);
+  YY_IGNORE_USELESS_CAST_END
 
   if (yyss + yystacksize - 1 <= yyssp)
+#if !defined yyoverflow && !defined YYSTACK_RELOCATE
+    goto yyexhaustedlab;
+#else
     {
       /* Get the current used size of the three stacks, in elements.  */
-      YYSIZE_T yysize = yyssp - yyss + 1;
+      YYPTRDIFF_T yysize = yyssp - yyss + 1;
 
-#ifdef yyoverflow
+# if defined yyoverflow
       {
         /* Give user a chance to reallocate the stack.  Use copies of
            these so that the &'s don't force the real ones into
            memory.  */
+        yy_state_t *yyss1 = yyss;
         YYSTYPE *yyvs1 = yyvs;
-        yytype_int16 *yyss1 = yyss;
 
         /* Each stack pointer address is followed by the size of the
            data in use in that stack, in bytes.  This used to be a
            conditional around just the two extra args, but that might
            be undefined if yyoverflow is a macro.  */
         yyoverflow (YY_("memory exhausted"),
-                    &yyss1, yysize * sizeof (*yyssp),
-                    &yyvs1, yysize * sizeof (*yyvsp),
+                    &yyss1, yysize * YYSIZEOF (*yyssp),
+                    &yyvs1, yysize * YYSIZEOF (*yyvsp),
                     &yystacksize);
-
         yyss = yyss1;
         yyvs = yyvs1;
       }
-#else /* no yyoverflow */
-# ifndef YYSTACK_RELOCATE
-      goto yyexhaustedlab;
-# else
+# else /* defined YYSTACK_RELOCATE */
       /* Extend the stack our own way.  */
       if (YYMAXDEPTH <= yystacksize)
         goto yyexhaustedlab;
@@ -1465,42 +1589,43 @@ yyparse (void)
         yystacksize = YYMAXDEPTH;
 
       {
-        yytype_int16 *yyss1 = yyss;
+        yy_state_t *yyss1 = yyss;
         union yyalloc *yyptr =
-          (union yyalloc *) YYSTACK_ALLOC (YYSTACK_BYTES (yystacksize));
+          YY_CAST (union yyalloc *,
+                   YYSTACK_ALLOC (YY_CAST (YYSIZE_T, YYSTACK_BYTES (yystacksize))));
         if (! yyptr)
           goto yyexhaustedlab;
         YYSTACK_RELOCATE (yyss_alloc, yyss);
         YYSTACK_RELOCATE (yyvs_alloc, yyvs);
-#  undef YYSTACK_RELOCATE
+# undef YYSTACK_RELOCATE
         if (yyss1 != yyssa)
           YYSTACK_FREE (yyss1);
       }
 # endif
-#endif /* no yyoverflow */
 
       yyssp = yyss + yysize - 1;
       yyvsp = yyvs + yysize - 1;
 
-      YYDPRINTF ((stderr, "Stack size increased to %lu\n",
-                  (unsigned long int) yystacksize));
+      YY_IGNORE_USELESS_CAST_BEGIN
+      YYDPRINTF ((stderr, "Stack size increased to %ld\n",
+                  YY_CAST (long, yystacksize)));
+      YY_IGNORE_USELESS_CAST_END
 
       if (yyss + yystacksize - 1 <= yyssp)
         YYABORT;
     }
-
-  YYDPRINTF ((stderr, "Entering state %d\n", yystate));
+#endif /* !defined yyoverflow && !defined YYSTACK_RELOCATE */
 
   if (yystate == YYFINAL)
     YYACCEPT;
 
   goto yybackup;
 
+
 /*-----------.
 | yybackup.  |
 `-----------*/
 yybackup:
-
   /* Do appropriate processing given the current state.  Read a
      lookahead token if we need one and don't already have one.  */
 
@@ -1550,15 +1675,13 @@ yybackup:
 
   /* Shift the lookahead token.  */
   YY_SYMBOL_PRINT ("Shifting", yytoken, &yylval, &yylloc);
-
-  /* Discard the shifted token.  */
-  yychar = YYEMPTY;
-
   yystate = yyn;
   YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
   *++yyvsp = yylval;
   YY_IGNORE_MAYBE_UNINITIALIZED_END
 
+  /* Discard the shifted token.  */
+  yychar = YYEMPTY;
   goto yynewstate;
 
 
@@ -1573,7 +1696,7 @@ yydefault:
 
 
 /*-----------------------------.
-| yyreduce -- Do a reduction.  |
+| yyreduce -- do a reduction.  |
 `-----------------------------*/
 yyreduce:
   /* yyn is the number of a rule to reduce with.  */
@@ -1593,33 +1716,33 @@ yyreduce:
   YY_REDUCE_PRINT (yyn);
   switch (yyn)
     {
-        case 3:
-#line 379 "L3Parser.ypp" /* yacc.c:1646  */
-    {l3p->outputNode = (yyvsp[0].astnode);}
-#line 1600 "L3Parser.cpp" /* yacc.c:1646  */
+  case 3:
+#line 385 "L3Parser.ypp"
+                     {l3p->outputNode = (yyvsp[0].astnode);}
+#line 1723 "L3Parser.cpp"
     break;
 
   case 4:
-#line 380 "L3Parser.ypp" /* yacc.c:1646  */
-    {}
-#line 1606 "L3Parser.cpp" /* yacc.c:1646  */
+#line 386 "L3Parser.ypp"
+                      {}
+#line 1729 "L3Parser.cpp"
     break;
 
   case 5:
-#line 381 "L3Parser.ypp" /* yacc.c:1646  */
-    {delete (yyvsp[-1].astnode);}
-#line 1612 "L3Parser.cpp" /* yacc.c:1646  */
+#line 387 "L3Parser.ypp"
+                           {delete (yyvsp[-1].astnode);}
+#line 1735 "L3Parser.cpp"
     break;
 
   case 6:
-#line 384 "L3Parser.ypp" /* yacc.c:1646  */
-    {(yyval.astnode) = (yyvsp[0].astnode);}
-#line 1618 "L3Parser.cpp" /* yacc.c:1646  */
+#line 390 "L3Parser.ypp"
+                       {(yyval.astnode) = (yyvsp[0].astnode);}
+#line 1741 "L3Parser.cpp"
     break;
 
   case 7:
-#line 385 "L3Parser.ypp" /* yacc.c:1646  */
-    {
+#line 391 "L3Parser.ypp"
+                       {
                    (yyval.astnode) = new ASTNode();
                    string name(*(yyvsp[0].word));
                    (yyval.astnode)->setName(name.c_str());
@@ -1645,24 +1768,24 @@ yyreduce:
                      }
                    }
         }
-#line 1649 "L3Parser.cpp" /* yacc.c:1646  */
+#line 1772 "L3Parser.cpp"
     break;
 
   case 8:
-#line 411 "L3Parser.ypp" /* yacc.c:1646  */
-    {(yyval.astnode) = (yyvsp[-1].astnode);}
-#line 1655 "L3Parser.cpp" /* yacc.c:1646  */
+#line 417 "L3Parser.ypp"
+                              {(yyval.astnode) = (yyvsp[-1].astnode);}
+#line 1778 "L3Parser.cpp"
     break;
 
   case 9:
-#line 412 "L3Parser.ypp" /* yacc.c:1646  */
-    {(yyval.astnode) = new ASTNode(AST_POWER); (yyval.astnode)->addChild((yyvsp[-2].astnode)); (yyval.astnode)->addChild((yyvsp[0].astnode));}
-#line 1661 "L3Parser.cpp" /* yacc.c:1646  */
+#line 418 "L3Parser.ypp"
+                              {(yyval.astnode) = new ASTNode(AST_POWER); (yyval.astnode)->addChild((yyvsp[-2].astnode)); (yyval.astnode)->addChild((yyvsp[0].astnode));}
+#line 1784 "L3Parser.cpp"
     break;
 
   case 10:
-#line 413 "L3Parser.ypp" /* yacc.c:1646  */
-    {
+#line 419 "L3Parser.ypp"
+                              {
                   if ((yyvsp[-2].astnode)->getType()==AST_TIMES) {
                     (yyval.astnode) = (yyvsp[-2].astnode);
                     (yyval.astnode)->addChild((yyvsp[0].astnode));
@@ -1673,12 +1796,12 @@ yyreduce:
                     (yyval.astnode)->addChild((yyvsp[0].astnode));
                   }
                 }
-#line 1677 "L3Parser.cpp" /* yacc.c:1646  */
+#line 1800 "L3Parser.cpp"
     break;
 
   case 11:
-#line 424 "L3Parser.ypp" /* yacc.c:1646  */
-    {
+#line 430 "L3Parser.ypp"
+                              {
                   if ((yyvsp[-2].astnode)->getType()==AST_PLUS) {
                     (yyval.astnode) = (yyvsp[-2].astnode);
                     (yyval.astnode)->addChild((yyvsp[0].astnode));
@@ -1689,24 +1812,24 @@ yyreduce:
                     (yyval.astnode)->addChild((yyvsp[0].astnode));
                   }
                 }
-#line 1693 "L3Parser.cpp" /* yacc.c:1646  */
+#line 1816 "L3Parser.cpp"
     break;
 
   case 12:
-#line 435 "L3Parser.ypp" /* yacc.c:1646  */
-    {(yyval.astnode) = new ASTNode(AST_DIVIDE); (yyval.astnode)->addChild((yyvsp[-2].astnode)); (yyval.astnode)->addChild((yyvsp[0].astnode));}
-#line 1699 "L3Parser.cpp" /* yacc.c:1646  */
+#line 441 "L3Parser.ypp"
+                              {(yyval.astnode) = new ASTNode(AST_DIVIDE); (yyval.astnode)->addChild((yyvsp[-2].astnode)); (yyval.astnode)->addChild((yyvsp[0].astnode));}
+#line 1822 "L3Parser.cpp"
     break;
 
   case 13:
-#line 436 "L3Parser.ypp" /* yacc.c:1646  */
-    {(yyval.astnode) = new ASTNode(AST_MINUS); (yyval.astnode)->addChild((yyvsp[-2].astnode)); (yyval.astnode)->addChild((yyvsp[0].astnode));}
-#line 1705 "L3Parser.cpp" /* yacc.c:1646  */
+#line 442 "L3Parser.ypp"
+                              {(yyval.astnode) = new ASTNode(AST_MINUS); (yyval.astnode)->addChild((yyvsp[-2].astnode)); (yyval.astnode)->addChild((yyvsp[0].astnode));}
+#line 1828 "L3Parser.cpp"
     break;
 
   case 14:
-#line 437 "L3Parser.ypp" /* yacc.c:1646  */
-    {
+#line 443 "L3Parser.ypp"
+                              {
                   if (l3p->modulol3v2) {
                     (yyval.astnode) = new ASTNode(AST_FUNCTION_REM);
                     (yyval.astnode)->addChild((yyvsp[-2].astnode));
@@ -1716,18 +1839,18 @@ yyreduce:
                     (yyval.astnode) = l3p->createModuloTree((yyvsp[-2].astnode), (yyvsp[0].astnode));
                   }
                 }
-#line 1720 "L3Parser.cpp" /* yacc.c:1646  */
+#line 1843 "L3Parser.cpp"
     break;
 
   case 15:
-#line 447 "L3Parser.ypp" /* yacc.c:1646  */
-    {(yyval.astnode) = (yyvsp[0].astnode);}
-#line 1726 "L3Parser.cpp" /* yacc.c:1646  */
+#line 453 "L3Parser.ypp"
+                                     {(yyval.astnode) = (yyvsp[0].astnode);}
+#line 1849 "L3Parser.cpp"
     break;
 
   case 16:
-#line 448 "L3Parser.ypp" /* yacc.c:1646  */
-    {
+#line 454 "L3Parser.ypp"
+                                   {
                   if (l3p->collapseminus) {
                     if ((yyvsp[0].astnode)->getType()==AST_REAL) {
                       (yyval.astnode) = (yyvsp[0].astnode);
@@ -1760,60 +1883,60 @@ yyreduce:
                     (yyval.astnode)->addChild((yyvsp[0].astnode));
                   }
                 }
-#line 1764 "L3Parser.cpp" /* yacc.c:1646  */
+#line 1887 "L3Parser.cpp"
     break;
 
   case 17:
-#line 481 "L3Parser.ypp" /* yacc.c:1646  */
-    {(yyval.astnode) = l3p->combineRelationalElements((yyvsp[-2].astnode), (yyvsp[0].astnode), AST_RELATIONAL_GT);}
-#line 1770 "L3Parser.cpp" /* yacc.c:1646  */
+#line 487 "L3Parser.ypp"
+                              {(yyval.astnode) = l3p->combineRelationalElements((yyvsp[-2].astnode), (yyvsp[0].astnode), AST_RELATIONAL_GT);}
+#line 1893 "L3Parser.cpp"
     break;
 
   case 18:
-#line 482 "L3Parser.ypp" /* yacc.c:1646  */
-    {(yyval.astnode) = l3p->combineRelationalElements((yyvsp[-2].astnode), (yyvsp[0].astnode), AST_RELATIONAL_LT);}
-#line 1776 "L3Parser.cpp" /* yacc.c:1646  */
+#line 488 "L3Parser.ypp"
+                              {(yyval.astnode) = l3p->combineRelationalElements((yyvsp[-2].astnode), (yyvsp[0].astnode), AST_RELATIONAL_LT);}
+#line 1899 "L3Parser.cpp"
     break;
 
   case 19:
-#line 483 "L3Parser.ypp" /* yacc.c:1646  */
-    {(yyval.astnode) = l3p->combineRelationalElements((yyvsp[-3].astnode), (yyvsp[0].astnode), AST_RELATIONAL_GEQ);}
-#line 1782 "L3Parser.cpp" /* yacc.c:1646  */
+#line 489 "L3Parser.ypp"
+                                  {(yyval.astnode) = l3p->combineRelationalElements((yyvsp[-3].astnode), (yyvsp[0].astnode), AST_RELATIONAL_GEQ);}
+#line 1905 "L3Parser.cpp"
     break;
 
   case 20:
-#line 484 "L3Parser.ypp" /* yacc.c:1646  */
-    {(yyval.astnode) = l3p->combineRelationalElements((yyvsp[-3].astnode), (yyvsp[0].astnode), AST_RELATIONAL_LEQ);}
-#line 1788 "L3Parser.cpp" /* yacc.c:1646  */
+#line 490 "L3Parser.ypp"
+                                  {(yyval.astnode) = l3p->combineRelationalElements((yyvsp[-3].astnode), (yyvsp[0].astnode), AST_RELATIONAL_LEQ);}
+#line 1911 "L3Parser.cpp"
     break;
 
   case 21:
-#line 485 "L3Parser.ypp" /* yacc.c:1646  */
-    {(yyval.astnode) = l3p->combineRelationalElements((yyvsp[-3].astnode), (yyvsp[0].astnode), AST_RELATIONAL_EQ);}
-#line 1794 "L3Parser.cpp" /* yacc.c:1646  */
+#line 491 "L3Parser.ypp"
+                                  {(yyval.astnode) = l3p->combineRelationalElements((yyvsp[-3].astnode), (yyvsp[0].astnode), AST_RELATIONAL_EQ);}
+#line 1917 "L3Parser.cpp"
     break;
 
   case 22:
-#line 486 "L3Parser.ypp" /* yacc.c:1646  */
-    {(yyval.astnode) = l3p->combineRelationalElements((yyvsp[-3].astnode), (yyvsp[0].astnode), AST_RELATIONAL_NEQ);}
-#line 1800 "L3Parser.cpp" /* yacc.c:1646  */
+#line 492 "L3Parser.ypp"
+                                  {(yyval.astnode) = l3p->combineRelationalElements((yyvsp[-3].astnode), (yyvsp[0].astnode), AST_RELATIONAL_NEQ);}
+#line 1923 "L3Parser.cpp"
     break;
 
   case 23:
-#line 487 "L3Parser.ypp" /* yacc.c:1646  */
-    {(yyval.astnode) = l3p->combineRelationalElements((yyvsp[-3].astnode), (yyvsp[0].astnode), AST_RELATIONAL_NEQ);}
-#line 1806 "L3Parser.cpp" /* yacc.c:1646  */
+#line 493 "L3Parser.ypp"
+                                  {(yyval.astnode) = l3p->combineRelationalElements((yyvsp[-3].astnode), (yyvsp[0].astnode), AST_RELATIONAL_NEQ);}
+#line 1929 "L3Parser.cpp"
     break;
 
   case 24:
-#line 488 "L3Parser.ypp" /* yacc.c:1646  */
-    {(yyval.astnode) = l3p->combineRelationalElements((yyvsp[-3].astnode), (yyvsp[0].astnode), AST_RELATIONAL_NEQ);}
-#line 1812 "L3Parser.cpp" /* yacc.c:1646  */
+#line 494 "L3Parser.ypp"
+                                  {(yyval.astnode) = l3p->combineRelationalElements((yyvsp[-3].astnode), (yyvsp[0].astnode), AST_RELATIONAL_NEQ);}
+#line 1935 "L3Parser.cpp"
     break;
 
   case 25:
-#line 489 "L3Parser.ypp" /* yacc.c:1646  */
-    {
+#line 495 "L3Parser.ypp"
+                                  {
                   if ((yyvsp[-3].astnode)->getType()==AST_LOGICAL_AND) {
                     (yyval.astnode) = (yyvsp[-3].astnode);
                     (yyval.astnode)->addChild((yyvsp[0].astnode));
@@ -1824,12 +1947,12 @@ yyreduce:
                     (yyval.astnode)->addChild((yyvsp[0].astnode));
                   }
                 }
-#line 1828 "L3Parser.cpp" /* yacc.c:1646  */
+#line 1951 "L3Parser.cpp"
     break;
 
   case 26:
-#line 500 "L3Parser.ypp" /* yacc.c:1646  */
-    {
+#line 506 "L3Parser.ypp"
+                                  {
                   if ((yyvsp[-3].astnode)->getType()==AST_LOGICAL_OR) {
                     (yyval.astnode) = (yyvsp[-3].astnode);
                     (yyval.astnode)->addChild((yyvsp[0].astnode));
@@ -1840,18 +1963,18 @@ yyreduce:
                     (yyval.astnode)->addChild((yyvsp[0].astnode));
                   }
                 }
-#line 1844 "L3Parser.cpp" /* yacc.c:1646  */
+#line 1967 "L3Parser.cpp"
     break;
 
   case 27:
-#line 511 "L3Parser.ypp" /* yacc.c:1646  */
-    {(yyval.astnode) = new ASTNode(AST_LOGICAL_NOT); (yyval.astnode)->addChild((yyvsp[0].astnode));}
-#line 1850 "L3Parser.cpp" /* yacc.c:1646  */
+#line 517 "L3Parser.ypp"
+                                   {(yyval.astnode) = new ASTNode(AST_LOGICAL_NOT); (yyval.astnode)->addChild((yyvsp[0].astnode));}
+#line 1973 "L3Parser.cpp"
     break;
 
   case 28:
-#line 512 "L3Parser.ypp" /* yacc.c:1646  */
-    {
+#line 518 "L3Parser.ypp"
+                               {
                    (yyval.astnode) = new ASTNode(AST_FUNCTION);
                    string name(*(yyvsp[-2].word));
                    (yyval.astnode)->setName((yyvsp[-2].word)->c_str());
@@ -1863,12 +1986,12 @@ yyreduce:
                      if (l3p->checkNumArguments((yyval.astnode))) YYABORT;
                    }
         }
-#line 1867 "L3Parser.cpp" /* yacc.c:1646  */
+#line 1990 "L3Parser.cpp"
     break;
 
   case 29:
-#line 524 "L3Parser.ypp" /* yacc.c:1646  */
-    {
+#line 530 "L3Parser.ypp"
+                                        {
                    (yyval.astnode) = (yyvsp[-1].astnode);
                    string name(*(yyvsp[-3].word));
                    (yyval.astnode)->setName((yyvsp[-3].word)->c_str());
@@ -1925,12 +2048,12 @@ yyreduce:
                    if (type == AST_LAMBDA) l3p->fixLambdaArguments((yyval.astnode));
                    if (l3p->checkNumArguments((yyval.astnode))) YYABORT;
         }
-#line 1929 "L3Parser.cpp" /* yacc.c:1646  */
+#line 2052 "L3Parser.cpp"
     break;
 
   case 30:
-#line 581 "L3Parser.ypp" /* yacc.c:1646  */
-    {
+#line 587 "L3Parser.ypp"
+                                      {
                   vector<ASTNode*> allnodes;
                   allnodes.push_back((yyvsp[-3].astnode));
                   allnodes.push_back((yyvsp[-1].astnode));
@@ -1943,12 +2066,12 @@ yyreduce:
                   }
                   if (l3p->checkNumArgumentsForPackage((yyval.astnode))) YYABORT;
                 }
-#line 1947 "L3Parser.cpp" /* yacc.c:1646  */
+#line 2070 "L3Parser.cpp"
     break;
 
   case 31:
-#line 594 "L3Parser.ypp" /* yacc.c:1646  */
-    {
+#line 600 "L3Parser.ypp"
+                             {
                   vector<ASTNode*> allnodes;
                   allnodes.push_back((yyvsp[-2].astnode));
                   (yyval.astnode) = l3p->parsePackageInfix(INFIX_SYNTAX_NAMED_SQUARE_BRACKETS, &allnodes);
@@ -1959,12 +2082,12 @@ yyreduce:
                   }
                   if (l3p->checkNumArgumentsForPackage((yyval.astnode))) YYABORT;
                 }
-#line 1963 "L3Parser.cpp" /* yacc.c:1646  */
+#line 2086 "L3Parser.cpp"
     break;
 
   case 32:
-#line 605 "L3Parser.ypp" /* yacc.c:1646  */
-    {
+#line 611 "L3Parser.ypp"
+                                  {
                   vector<ASTNode*> allnodes;
                   allnodes.push_back((yyvsp[-1].astnode));
                   (yyval.astnode) = l3p->parsePackageInfix(INFIX_SYNTAX_CURLY_BRACES, &allnodes);
@@ -1975,12 +2098,12 @@ yyreduce:
                   }
                   if (l3p->checkNumArgumentsForPackage((yyval.astnode))) YYABORT;
                 }
-#line 1979 "L3Parser.cpp" /* yacc.c:1646  */
+#line 2102 "L3Parser.cpp"
     break;
 
   case 33:
-#line 616 "L3Parser.ypp" /* yacc.c:1646  */
-    {
+#line 622 "L3Parser.ypp"
+                                           {
                   vector<ASTNode*> allnodes;
                   allnodes.push_back((yyvsp[-1].astnode));
                   (yyval.astnode) = l3p->parsePackageInfix(INFIX_SYNTAX_CURLY_BRACES_SEMICOLON, &allnodes);
@@ -1991,12 +2114,12 @@ yyreduce:
                   }
                   if (l3p->checkNumArgumentsForPackage((yyval.astnode))) YYABORT;
                 }
-#line 1995 "L3Parser.cpp" /* yacc.c:1646  */
+#line 2118 "L3Parser.cpp"
     break;
 
   case 34:
-#line 627 "L3Parser.ypp" /* yacc.c:1646  */
-    {
+#line 633 "L3Parser.ypp"
+                         {
                   (yyval.astnode) = l3p->parsePackageInfix(INFIX_SYNTAX_CURLY_BRACES);
                   if ((yyval.astnode) == NULL) {
                     l3p->setError("No package is enabled that can interpret empty curly braces, so formulas of the form '{}' are disallowed.");
@@ -2004,60 +2127,60 @@ yyreduce:
                   }
                   if (l3p->checkNumArgumentsForPackage((yyval.astnode))) YYABORT;
                 }
-#line 2008 "L3Parser.cpp" /* yacc.c:1646  */
+#line 2131 "L3Parser.cpp"
     break;
 
   case 35:
-#line 637 "L3Parser.ypp" /* yacc.c:1646  */
-    {
+#line 643 "L3Parser.ypp"
+                       {
                   (yyval.astnode) = new ASTNode(); 
                   (yyval.astnode)->setValue((yyvsp[0].numdouble)); 
 //                  if(l3p->useDimensionless) {
 //                    $$->setUnits("dimensionless");
 //                  }
                 }
-#line 2020 "L3Parser.cpp" /* yacc.c:1646  */
+#line 2143 "L3Parser.cpp"
     break;
 
   case 36:
-#line 644 "L3Parser.ypp" /* yacc.c:1646  */
-    {
+#line 650 "L3Parser.ypp"
+                           {
                   (yyval.astnode) = new ASTNode();
                   (yyval.astnode)->setValue((yyvsp[0].mantissa), l3p->exponent); 
 //                  if(l3p->useDimensionless) {
 //                    $$->setUnits("dimensionless");
 //                  }
                 }
-#line 2032 "L3Parser.cpp" /* yacc.c:1646  */
+#line 2155 "L3Parser.cpp"
     break;
 
   case 37:
-#line 651 "L3Parser.ypp" /* yacc.c:1646  */
-    {
+#line 657 "L3Parser.ypp"
+                        {
                   (yyval.astnode) = new ASTNode(); 
                   (yyval.astnode)->setValue((yyvsp[0].numlong)); 
 //                  if(l3p->useDimensionless) {
 //                    $$->setUnits("dimensionless");
 //                  }
                 }
-#line 2044 "L3Parser.cpp" /* yacc.c:1646  */
+#line 2167 "L3Parser.cpp"
     break;
 
   case 38:
-#line 658 "L3Parser.ypp" /* yacc.c:1646  */
-    {
+#line 664 "L3Parser.ypp"
+                         {
                   (yyval.astnode) = new ASTNode(); 
                   (yyval.astnode)->setValue((yyvsp[0].rational), l3p->denominator);
 //                  if(l3p->useDimensionless) {
 //                    $$->setUnits("dimensionless");
 //                  }
                 }
-#line 2056 "L3Parser.cpp" /* yacc.c:1646  */
+#line 2179 "L3Parser.cpp"
     break;
 
   case 39:
-#line 665 "L3Parser.ypp" /* yacc.c:1646  */
-    {
+#line 671 "L3Parser.ypp"
+                              {
                   (yyval.astnode) = (yyvsp[-1].astnode);
                   if ((yyval.astnode)->getUnits() != "") {
                     l3p->setError("Can't use " + *(yyvsp[0].word) + " as a unit, because the unit is already set for this number.");
@@ -2071,35 +2194,36 @@ yyreduce:
                   }
                   (yyval.astnode)->setUnits(*(yyvsp[0].word));
                }
-#line 2075 "L3Parser.cpp" /* yacc.c:1646  */
+#line 2198 "L3Parser.cpp"
     break;
 
   case 40:
-#line 681 "L3Parser.ypp" /* yacc.c:1646  */
-    {(yyval.astnode) = new ASTNode(AST_FUNCTION); (yyval.astnode)->addChild((yyvsp[0].astnode));}
-#line 2081 "L3Parser.cpp" /* yacc.c:1646  */
+#line 687 "L3Parser.ypp"
+                     {(yyval.astnode) = new ASTNode(AST_FUNCTION); (yyval.astnode)->addChild((yyvsp[0].astnode));}
+#line 2204 "L3Parser.cpp"
     break;
 
   case 41:
-#line 682 "L3Parser.ypp" /* yacc.c:1646  */
-    {(yyval.astnode) = (yyvsp[-2].astnode);  (yyval.astnode)->addChild((yyvsp[0].astnode));}
-#line 2087 "L3Parser.cpp" /* yacc.c:1646  */
+#line 688 "L3Parser.ypp"
+                                  {(yyval.astnode) = (yyvsp[-2].astnode);  (yyval.astnode)->addChild((yyvsp[0].astnode));}
+#line 2210 "L3Parser.cpp"
     break;
 
   case 42:
-#line 685 "L3Parser.ypp" /* yacc.c:1646  */
-    {(yyval.astnode) = new ASTNode(AST_FUNCTION); (yyval.astnode)->addChild((yyvsp[-2].astnode)); (yyval.astnode)->addChild((yyvsp[0].astnode));}
-#line 2093 "L3Parser.cpp" /* yacc.c:1646  */
+#line 691 "L3Parser.ypp"
+                                         {(yyval.astnode) = new ASTNode(AST_FUNCTION); (yyval.astnode)->addChild((yyvsp[-2].astnode)); (yyval.astnode)->addChild((yyvsp[0].astnode));}
+#line 2216 "L3Parser.cpp"
     break;
 
   case 43:
-#line 686 "L3Parser.ypp" /* yacc.c:1646  */
-    {(yyval.astnode) = (yyvsp[-2].astnode);  (yyval.astnode)->addChild((yyvsp[0].astnode));}
-#line 2099 "L3Parser.cpp" /* yacc.c:1646  */
+#line 692 "L3Parser.ypp"
+                                               {(yyval.astnode) = (yyvsp[-2].astnode);  (yyval.astnode)->addChild((yyvsp[0].astnode));}
+#line 2222 "L3Parser.cpp"
     break;
 
 
-#line 2103 "L3Parser.cpp" /* yacc.c:1646  */
+#line 2226 "L3Parser.cpp"
+
       default: break;
     }
   /* User semantic actions sometimes alter yychar, and that requires
@@ -2124,14 +2248,13 @@ yyreduce:
   /* Now 'shift' the result of the reduction.  Determine what state
      that goes to, based on the state we popped back to and the rule
      number reduced by.  */
-
-  yyn = yyr1[yyn];
-
-  yystate = yypgoto[yyn - YYNTOKENS] + *yyssp;
-  if (0 <= yystate && yystate <= YYLAST && yycheck[yystate] == *yyssp)
-    yystate = yytable[yystate];
-  else
-    yystate = yydefgoto[yyn - YYNTOKENS];
+  {
+    const int yylhs = yyr1[yyn] - YYNTOKENS;
+    const int yyi = yypgoto[yylhs] + *yyssp;
+    yystate = (0 <= yyi && yyi <= YYLAST && yycheck[yyi] == *yyssp
+               ? yytable[yyi]
+               : yydefgoto[yylhs]);
+  }
 
   goto yynewstate;
 
@@ -2163,7 +2286,7 @@ yyerrlab:
           {
             if (yymsg != yymsgbuf)
               YYSTACK_FREE (yymsg);
-            yymsg = (char *) YYSTACK_ALLOC (yymsg_alloc);
+            yymsg = YY_CAST (char *, YYSTACK_ALLOC (YY_CAST (YYSIZE_T, yymsg_alloc)));
             if (!yymsg)
               {
                 yymsg = yymsgbuf;
@@ -2214,12 +2337,10 @@ yyerrlab:
 | yyerrorlab -- error raised explicitly by YYERROR.  |
 `---------------------------------------------------*/
 yyerrorlab:
-
-  /* Pacify compilers like GCC when the user code never invokes
-     YYERROR and the label yyerrorlab therefore never appears in user
-     code.  */
-  if (/*CONSTCOND*/ 0)
-     goto yyerrorlab;
+  /* Pacify compilers when the user code never invokes YYERROR and the
+     label yyerrorlab therefore never appears in user code.  */
+  if (0)
+    YYERROR;
 
   /* Do not reclaim the symbols of the rule whose action triggered
      this YYERROR.  */
@@ -2281,12 +2402,14 @@ yyacceptlab:
   yyresult = 0;
   goto yyreturn;
 
+
 /*-----------------------------------.
 | yyabortlab -- YYABORT comes here.  |
 `-----------------------------------*/
 yyabortlab:
   yyresult = 1;
   goto yyreturn;
+
 
 #if !defined yyoverflow || YYERROR_VERBOSE
 /*-------------------------------------------------.
@@ -2298,6 +2421,10 @@ yyexhaustedlab:
   /* Fall through.  */
 #endif
 
+
+/*-----------------------------------------------------.
+| yyreturn -- parsing is finished, return the result.  |
+`-----------------------------------------------------*/
 yyreturn:
   if (yychar != YYEMPTY)
     {
@@ -2314,7 +2441,7 @@ yyreturn:
   while (yyssp != yyss)
     {
       yydestruct ("Cleanup: popping",
-                  yystos[*yyssp], yyvsp);
+                  yystos[+*yyssp], yyvsp);
       YYPOPSTACK (1);
     }
 #ifndef yyoverflow
@@ -2327,7 +2454,7 @@ yyreturn:
 #endif
   return yyresult;
 }
-#line 689 "L3Parser.ypp" /* yacc.c:1906  */
+#line 695 "L3Parser.ypp"
 
 
 

--- a/src/sbml/math/L3Parser.ypp
+++ b/src/sbml/math/L3Parser.ypp
@@ -355,6 +355,12 @@ LIBSBML_CPP_NAMESPACE_END
 
 %type <astnode> node nodelist nodesemicolonlist number
 
+/* Ensure ASTNode objects allocated with new are cleaned up if parsing is unsuccessful */
+%destructor { delete($$); } node
+%destructor { delete($$); } nodelist
+%destructor { delete($$); } nodesemicolonlist
+%destructor { delete($$); } number
+
 %left '&' '|'         /* Boolean functions and, or */
 %left '<' '>' '=' '!' /* Boolean comparison functions (gt, lt, eq, etc.) */
 %left '-' '+'


### PR DESCRIPTION
## Description
  - add destructors for ASTNode objects to L3Parser so that ASTNode objects are not leaked when parsing is unsuccessful
  - rerun bison to regenerate L3Parser.cpp

## Motivation and Context
  - L3Parser.cpp leaks memory when a parse is unsuccessful (e.g. invalid syntax)
  - this is because ASTNode objects are allocated with new during the parse
  - but bison doesn't have a [destructor](https://www.gnu.org/software/bison/manual/html_node/Destructor-Decl.html) defined for them
  - so the allocated memory is not freed after a failed parse

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have updated all documentation necessary.
- [ ] I have checked spelling in (new) comments.

## Testing
- [X] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested -->

