### PR TITLE
fix math transforms involving an undefined function

### DIFF
--- a/src/sbml/SBMLTransforms.cpp
+++ b/src/sbml/SBMLTransforms.cpp
@@ -652,12 +652,24 @@ SBMLTransforms::evaluateASTNode(const ASTNode * node, const IdValueMap& values, 
   case AST_FUNCTION:
     /* shouldnt get here */
     // but we do if math we are expanding uses a functionDefinition
-    lfd = m->getListOfFunctionDefinitions();
-    tempNode = node->deepCopy();
-    replaceFD(tempNode, lfd);
-    result = evaluateASTNode(tempNode, values, m);
-    delete tempNode;
-    break;
+    {
+        if(m != NULL){
+            lfd = m->getListOfFunctionDefinitions();
+        }
+        if (lfd != NULL && lfd->get(node->getName()) != NULL)
+        {
+            tempNode = node->deepCopy();
+            replaceFD(tempNode, lfd);
+            result = evaluateASTNode(tempNode, values, m);
+            delete tempNode;
+        }
+        else
+        {
+            result = numeric_limits<double>::quiet_NaN();
+        }
+        break;
+    }
+
   case AST_PLUS:
     if (node->getNumChildren() == 0)
     {

--- a/src/sbml/test/TestSBMLTransforms.cpp
+++ b/src/sbml/test/TestSBMLTransforms.cpp
@@ -784,6 +784,48 @@ START_TEST(test_SBMLTransforms_evaluateL3V2AST)
   fail_unless(util_isEqual(SBMLTransforms::evaluateASTNode(node), 27));
 
   delete node;
+  node = SBML_parseL3Formula("undefinedfunc(x)");
+  fail_unless(util_isNaN(SBMLTransforms::evaluateASTNode(node)));
+
+  delete node;
+  node = SBML_parseL3Formula("cos(undefinedfunc2(3.1))");
+  fail_unless(util_isNaN(SBMLTransforms::evaluateASTNode(node)));
+
+  delete node;
+}
+END_TEST
+
+
+START_TEST(test_SBMLTransforms_evaluateL3V2ASTWithModel)
+{
+  SBMLReader        reader;
+  SBMLDocument*     d;
+  Model*            m;
+  std::string filename(TestDataDirectory);
+  filename += "multiple-functions.xml";
+
+  d = reader.readSBML(filename);
+  if (d == NULL)
+  {
+    fail("readSBML(\"multiple-functions.xml\") returned a NULL pointer.");
+  }
+
+  m = d->getModel();
+
+  ASTNode * node;
+  node = SBML_parseL3Formula("undefinedfunc(x)");
+  fail_unless(util_isNaN(SBMLTransforms::evaluateASTNode(node, m)));
+
+  delete node;
+  node = SBML_parseL3Formula("f(2, g(1, undefinedfunc(0)))");
+  fail_unless(util_isNaN(SBMLTransforms::evaluateASTNode(node, m)));
+
+  delete node;
+  node = SBML_parseL3Formula("f(2, g(4, cos(0)))");
+  fail_unless(util_isEqual(SBMLTransforms::evaluateASTNode(node, m), 8));
+
+  delete node;
+  delete d;
 }
 END_TEST
 
@@ -922,6 +964,7 @@ create_suite_SBMLTransforms (void)
   tcase_add_test(tcase, test_SBMLTransforms_replaceIA);
   tcase_add_test(tcase, test_SBMLTransforms_replaceIA_species);
   tcase_add_test(tcase, test_SBMLTransforms_evaluateL3V2AST);
+  tcase_add_test(tcase, test_SBMLTransforms_evaluateL3V2ASTWithModel);
   tcase_add_test(tcase, test_SBMLTransforms_L3V2AssignmentNoMath);
   tcase_add_test(tcase, test_SBMLTransforms_StoichiometryMath);
 


### PR DESCRIPTION
## Description
- add check that function exists before calling replaceFD()
- if function doesn't exist, return NaN
- add tests

## Motivation and Context
- calling `evaluateASTNode` with an AST involving an undefined function would crash
- this was caused by an infinite `replaceFD()` recursion ending in a stack-overflow error

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have updated all documentation necessary.
- [ ] I have checked spelling in (new) comments.

## Testing
- [X] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested -->

