### PR TITLE
 - issue #15: creating a py3 compatible script as well so that the me…

### DIFF
--- a/src/bindings/python/patch-python.cmake
+++ b/src/bindings/python/patch-python.cmake
@@ -48,3 +48,34 @@ endif()
 
 file(APPEND  "${WRAPPER_FILE}" "${SOURCECODE}")
 
+
+file(READ "${WRAPPER_FILE}" "${SOURCECODE}")
+
+file(WRITE "${BIN_DIRECTORY}/libsbml2.py" "${init_script}")
+
+string(REPLACE 
+  "class SBase(_object):"
+  "class SBase(_object, metaclass=AutoProperty):"
+  init3_script "${init_script}"
+)
+
+string(REPLACE 
+  "class SBase(object):"
+  "class SBase(object, metaclass=AutoProperty):"
+  init3_script "${init3_script}"
+)
+
+string(REPLACE 
+  "class SBasePlugin(_object):"
+  "class SBasePlugin(_object, metaclass=AutoProperty):"
+  init3_script "${init3_script}"
+)
+
+string(REPLACE 
+  "class SBasePlugin(object):"
+  "class SBasePlugin(object, metaclass=AutoProperty):"
+  init3_script "${init3_script}"
+)
+
+
+file(WRITE ${BIN_DIRECTORY}/libsbml3.py "${init3_script}")


### PR DESCRIPTION
## Motivation and Context

by automatically creating a python 3 compatible init script, the autoproperties work as needed. this is automatically picked up by the scripts for python-libsbml and python-libsbml-experimental. 


## Description
 - added some cmake manipulation of the swig generated python 2 file, to transform the metaclass code for python 3.x
- fixes #15 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have updated all documentation necessary.
- [ ] I have checked spelling in (new) comments.

## Testing
- [X] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested -->

