### PR TITLE
 - #11 : behavior of reading out of the allocated range is undefined,…

### DIFF
--- a/src/sbml/packages/spatial/sbml/test/TestImageData.cpp
+++ b/src/sbml/packages/spatial/sbml/test/TestImageData.cpp
@@ -156,63 +156,6 @@ START_TEST (test_SampledField_samples)
 END_TEST
 
 
-START_TEST (test_SampledField_samples_mismatchLength_1)
-{
-  fail_unless(G->isSetSamples() == false);
-  fail_unless(G->isSetSamplesLength() == false);
-
-  int samples [] = {1,2};
-  G->setSamples(samples, 3);
-  G->setSamplesLength(3);
-
-  fail_unless(G->isSetSamples() == true);
-  fail_unless(G->isSetSamplesLength() == true);
-
-  fail_unless(G->getSamplesLength() == 3);
-
-  double samplesRet [] = {0, 0, 0};
-  G->getSamples(samplesRet);
-  fail_unless(samplesRet[0] == 1);
-  fail_unless(samplesRet[1] == 2);
-  fail_unless(samplesRet[2] != 0);
-
-  G->unsetSamples();
-
-  fail_unless(G->isSetSamples() == false);
-  fail_unless(G->isSetSamplesLength() == false);
-}
-END_TEST
-
-
-START_TEST (test_SampledField_samples_mismatchLength_2)
-{
-  fail_unless(G->isSetSamples() == false);
-  fail_unless(G->isSetSamplesLength() == false);
-
-  int samples [] = {1,2};
-  G->setSamples(samples, 1);
-  G->setSamplesLength(1);
-
-  fail_unless(G->isSetSamples() == true);
-  fail_unless(G->isSetSamplesLength() == true);
-
-  fail_unless(G->getSamplesLength() == 1);
-
-  int samplesRet [1];
-  G->getSamples(samplesRet);
-  fail_unless(samplesRet[0] == 1);
-  // really just making sure we dont crash
-  fail_unless(samplesRet[1] != 2);
-  fail_unless(samplesRet[2] != 0);
-
-  G->unsetSamples();
-
-  fail_unless(G->isSetSamples() == false);
-  fail_unless(G->isSetSamplesLength() == false);
-}
-END_TEST
-
-
 START_TEST (test_SampledField_dataType)
 {
   fail_unless(G->isSetDataType() == false);
@@ -258,8 +201,6 @@ create_suite_SampledField (void)
 
   tcase_add_test( tcase, test_SampledField_samplesLength   );
   tcase_add_test( tcase, test_SampledField_samples         );
-  tcase_add_test( tcase, test_SampledField_samples_mismatchLength_1  );
-  tcase_add_test( tcase, test_SampledField_samples_mismatchLength_2  );
   tcase_add_test( tcase, test_SampledField_dataType        );
   tcase_add_test( tcase, test_SampledField_output         );
 


### PR DESCRIPTION
… so removing these tests

## Description
as discussed in issue #11 , the behavior of accessing elements past the declared range is undefined, so these tests may or may not fail. 

## Motivation and Context
 - the test was not actually testing what it wanted to test. 

fixes #11 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have updated all documentation necessary.
- [ ] I have checked spelling in (new) comments.

## Testing
- [X] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested -->

