### PR TITLE
 issue #19: prevent delete of released memory

### DIFF
--- a/src/sbml/units/UnitFormulaFormatter.cpp
+++ b/src/sbml/units/UnitFormulaFormatter.cpp
@@ -1663,7 +1663,7 @@ UnitFormulaFormatter::getUnitDefinitionFromSpecies(const Species * species)
     {
       for (n = 0; n < model->getNumUnitDefinitions(); n++)
       {
-        if (!strcmp(units, model->getUnitDefinition(n)->getId().c_str()))
+        if (units == model->getUnitDefinition(n)->getId())
         {
           try
           {
@@ -1689,6 +1689,7 @@ UnitFormulaFormatter::getUnitDefinitionFromSpecies(const Species * species)
                        model->getUnitDefinition(n)->getUnit(p)->getOffset());
             unit = NULL;
           }
+          break;
         }
       }
     }
@@ -1798,7 +1799,7 @@ UnitFormulaFormatter::getUnitDefinitionFromSpecies(const Species * species)
     {
       for (n = 0; n < model->getNumUnitDefinitions(); n++)
       {
-        if (!strcmp(spatialUnits, model->getUnitDefinition(n)->getId().c_str()))
+        if (spatialUnits == model->getUnitDefinition(n)->getId())
         {
           for (p = 0; p < model->getUnitDefinition(n)->getNumUnits(); p++)
           {
@@ -1814,6 +1815,7 @@ UnitFormulaFormatter::getUnitDefinitionFromSpecies(const Species * species)
                         model->getUnitDefinition(n)->getUnit(p)->getOffset());
             unit = NULL;
           }
+          break;
         }
       }
     }
@@ -2595,8 +2597,16 @@ UnitFormulaFormatter::inferUnitDefinition(UnitDefinition* expectedUD,
         delete tempUD1;
         delete math;
         math = child1->deepCopy();
-        if (child1 != NULL) delete child1;
-        if (child2 != NULL) delete child2;
+        if (child1 != NULL) 
+        {
+           delete child1;
+           child1 = NULL;
+        }
+        if (child2 != NULL)
+        {
+          delete child2;
+          child2 = NULL;
+        }
         numChildren = math->getNumChildren();
         continue;
       }


### PR DESCRIPTION
## Description
 - sonar can't detect that the loop is only entered once, thus added break statement
 - ensure that child1 and child2 are set to NULL, as static analysis found a path, in which memory could be deleted twice


## Motivation and Context
 - freeeing released memory results in undefined behavior whereas deleting NULL is safe.
fixes #19 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have updated all documentation necessary.
- [ ] I have checked spelling in (new) comments.

## Testing
- [X] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested -->

