### PR TITLE
 - issue #21: ensure that the element is not deleted prior to returni…

### DIFF
--- a/src/sbml/Event.cpp
+++ b/src/sbml/Event.cpp
@@ -1750,20 +1750,20 @@ Event::removeChildObject(const std::string& elementName, const std::string& id)
   if (elementName == "trigger")
   {
     Trigger* t = getTrigger();
-    if(unsetTrigger() == LIBSBML_OPERATION_SUCCESS)
-      return t;
+    mTrigger = NULL;
+    return t;
   }
   else if (elementName == "priority")
   {
     Priority* t = getPriority();
-    if (unsetPriority() == LIBSBML_OPERATION_SUCCESS)
-      return t;
+    mPriority = NULL;
+    return t;
   }
   else if (elementName == "delay")
   {
     Delay* t = getDelay();
-    if (unsetDelay() == LIBSBML_OPERATION_SUCCESS)
-      return t;
+    mDelay = NULL;
+    return t;
   }
   else if (elementName == "eventAssignment")
   {


### PR DESCRIPTION
…ng the ptr

## Description
instead of calling the unset methods, the internal ptr should be set to NULL, and the object returned to the caller. 
fixes #21 

## Motivation and Context
- this is required, otherwise the ptr returned by removeChildObject for trigger, delay and priority would be invalid

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have updated all documentation necessary.
- [ ] I have checked spelling in (new) comments.

## Testing
- [X] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested -->

