### PR TITLE
fix memory leaks

### DIFF
--- a/examples/c++/addCVTerms.cpp
+++ b/examples/c++/addCVTerms.cpp
@@ -106,6 +106,10 @@ main (int argc, char *argv[])
       s->addCVTerm(cv2);
       s->addCVTerm(cv1);
 
+      delete cv;
+      delete cv2;
+      delete cv1;
+
       writeSBML(d, argv[2]);
     }
   }

--- a/examples/c++/addCustomValidator.cpp
+++ b/examples/c++/addCustomValidator.cpp
@@ -136,15 +136,17 @@ main (int argc, char *argv[])
   SBMLDocument* document = readSBML(filename);
 
   // add a custom validator
-  document->addValidator(new MyCustomValidator());
+  MyCustomValidator* myCustomValidator = new MyCustomValidator();
+  document->addValidator(myCustomValidator);
+  delete myCustomValidator;
 
   // check consistency like before
   int numErrors = document->checkConsistency();
 
   // print errors and warnings
   document->printErrors();
+  delete document;
 
   // return number of errors
   return  numErrors;
-
 }

--- a/examples/c++/addModelHistory.cpp
+++ b/examples/c++/addModelHistory.cpp
@@ -122,7 +122,10 @@ main (int argc, char *argv[])
     status = d->getModel()->setModelHistory(h);
 	printStatus("Set model history:     ", status);
 
-  
+    delete h;
+    delete c;
+    delete date;
+    delete date2;
     writeSBML(d, argv[2]);
   }
 

--- a/examples/c++/addingEvidenceCodes_1.cpp
+++ b/examples/c++/addingEvidenceCodes_1.cpp
@@ -97,6 +97,7 @@ main (int argc, char *argv[])
       cv1->addResource("urn:miriam:obo.eco:ECO%3A0000183");
 
       r->addCVTerm(cv1);
+      delete cv1;
 
       CVTerm * cv2 = new CVTerm(BIOLOGICAL_QUALIFIER);
       cv2->setBiologicalQualifierType(BQB_IS);
@@ -104,6 +105,7 @@ main (int argc, char *argv[])
       cv2->addResource("urn:miriam:reactome:REACT_736");
 
       r->addCVTerm(cv2);
+      delete cv2;
 
       writeSBML(d, argv[2]);
     }

--- a/examples/c++/addingEvidenceCodes_2.cpp
+++ b/examples/c++/addingEvidenceCodes_2.cpp
@@ -97,6 +97,7 @@ main (int argc, char *argv[])
       cv1->addResource("urn:miriam:obo.go:GO%3A0005764");
 
       s->addCVTerm(cv1);
+      delete cv1;
 
       // now create the additional annotation
  

--- a/examples/c++/callExternalValidator.cpp
+++ b/examples/c++/callExternalValidator.cpp
@@ -113,6 +113,8 @@ main (int argc, char *argv[])
   // print errors and warnings
   document->printErrors();
 
+  delete document;
+
   // return number of errors
   return  numErrors;
 

--- a/examples/c++/convertReactions.cpp
+++ b/examples/c++/convertReactions.cpp
@@ -101,6 +101,8 @@ main (int argc, char *argv[])
     writeSBML(document, outputFile);
   }
 
+  delete document;
+
   return 0;
 }
 

--- a/examples/c++/getAllElementsWithNotes.cpp
+++ b/examples/c++/getAllElementsWithNotes.cpp
@@ -141,6 +141,7 @@ main (int argc, char* argv[])
 	cout << "    search time (ms): " << stop - start          << endl;
 	cout << " elements with notes: " << allElements->getSize() << endl;
 	
+    delete allElements;
     delete document;
     return errors;
 }

--- a/examples/c++/inferUnits.cpp
+++ b/examples/c++/inferUnits.cpp
@@ -73,8 +73,6 @@ LIBSBML_CPP_NAMESPACE_USE
 
     SBMLConverter* converter = 
            SBMLConverterRegistry::getInstance().getConverterFor(*props);
-  
-
     converter->setDocument(d);
 
     /* perform the conversion */
@@ -89,7 +87,11 @@ LIBSBML_CPP_NAMESPACE_USE
     d->printErrors(cout);
 
     writeSBML(d, argv[2]);
+    delete props;
+    delete converter;
   }
+
+  delete d;
 
   return 0;
 }

--- a/examples/c++/inlineFunctionDefintions.cpp
+++ b/examples/c++/inlineFunctionDefintions.cpp
@@ -102,6 +102,7 @@ main (int argc, char *argv[])
     writeSBML(document, outputFile);
   }
 
+  delete document;
   return 0;
 }
 

--- a/examples/c++/printSupported.cpp
+++ b/examples/c++/printSupported.cpp
@@ -61,7 +61,8 @@ main (int argc, char* argv[])
        const SBMLNamespaces *current = (const SBMLNamespaces *)supported->get(i);
        cout << "\tSBML Level " << current->getLevel() << " Version: " << current->getVersion() << endl;
   }
-  
+  SBMLNamespaces::freeSBMLNamespaces((List*)supported);
+
   cout << endl;
   cout << "LibSBML is compiled against: " << endl;
   if (isLibSBMLCompiledWith("expat"))

--- a/examples/c++/promoteParameters.cpp
+++ b/examples/c++/promoteParameters.cpp
@@ -78,6 +78,6 @@ LIBSBML_CPP_NAMESPACE_USE
 
     writeSBML(d, argv[2]);
   }
-
+  delete d;
   return 0;
 }

--- a/examples/c++/renameSId.cpp
+++ b/examples/c++/renameSId.cpp
@@ -131,6 +131,7 @@ main (int argc, char* argv[])
     // write to file
     writeSBMLToFile(document, output);
     
+    delete allElements;
     delete document;
     return errors;
 }

--- a/examples/c++/setIdFromNames.cpp
+++ b/examples/c++/setIdFromNames.cpp
@@ -277,6 +277,7 @@ main (int argc, char* argv[])
 	cout << "     write time (ms): " << stop - start          << endl;   
 	cout << endl;
 	
+    delete allElements;
     delete document;
     return errors;
 }

--- a/examples/c++/setNamesFromIds.cpp
+++ b/examples/c++/setNamesFromIds.cpp
@@ -154,6 +154,7 @@ main (int argc, char* argv[])
 	cout << "     write time (ms): " << stop - start          << endl;   
 	cout << endl;
 	
+    delete allElements;
     delete document;
     return errors;
 }

--- a/examples/c/addCVTerms.c
+++ b/examples/c/addCVTerms.c
@@ -102,6 +102,9 @@ main (int argc, char *argv[])
       SBase_addCVTerm((SBase_t*)s, cv2);
       SBase_addCVTerm((SBase_t*)s, cv1);
 
+      CVTerm_free(cv);
+      CVTerm_free(cv2);
+      CVTerm_free(cv1);
       writeSBML(d, argv[2]);
     }
   }

--- a/examples/c/addModelHistory.c
+++ b/examples/c/addModelHistory.c
@@ -83,7 +83,6 @@ main (int argc, char *argv[])
     return 2;
   }
 
-
   d      = readSBML(argv[1]);
   errors = SBMLDocument_getNumErrors(d);
 
@@ -124,6 +123,11 @@ main (int argc, char *argv[])
 	  printStatus("Set model history:     ", status);
   
     writeSBML(d, argv[2]);
+
+    Date_free(date);
+    Date_free(date2);
+    ModelCreator_free(c);
+    ModelHistory_free(h);
   }
 
   SBMLDocument_free(d);

--- a/examples/c/addingEvidenceCodes_1.c
+++ b/examples/c/addingEvidenceCodes_1.c
@@ -105,6 +105,8 @@ main (int argc, char *argv[])
       
       SBase_addCVTerm((SBase_t*)r, cv2);
 
+      CVTerm_free(cv1);
+      CVTerm_free(cv2);
       writeSBML(d, argv[2]);
     }
   }

--- a/examples/c/addingEvidenceCodes_2.c
+++ b/examples/c/addingEvidenceCodes_2.c
@@ -235,9 +235,11 @@ main (int argc, char *argv[])
       XMLAttributes_clear(resource_att);      
       XMLAttributes_add(resource_att, "rdf:resource", 
        "urn:miriam:pubmed:7017716");
+      XMLToken_free(li_token);
       li_token = XMLToken_createWithTripleAttr(li_triple, resource_att);
       XMLToken_setEnd(li_token);
 
+      XMLNode_free(li);
       li = XMLNode_createFromToken(li_token);
 
       XMLNode_addChild(bag, li);
@@ -279,6 +281,35 @@ main (int argc, char *argv[])
       SBase_appendAnnotation((SBase_t*)s, annotation);
 
       writeSBML(d, argv[2]);
+
+      XMLAttributes_free(blank_att);
+      XMLAttributes_free(resource_att);
+      XMLToken_free(RDF_token);
+      XMLToken_free(li_token);
+      XMLToken_free(object_token);
+      XMLToken_free(bag_token);
+      XMLToken_free(predicate_token);
+      XMLToken_free(statement_token);
+      XMLToken_free(subject_token);
+      XMLToken_free(bqbiol_token);
+      XMLTriple_free(RDF_triple);
+      XMLTriple_free(li_triple);
+      XMLTriple_free(object_triple);
+      XMLTriple_free(bag_triple);
+      XMLTriple_free(predicate_triple);
+      XMLTriple_free(statement_triple);
+      XMLTriple_free(subject_triple);
+      XMLTriple_free(bqbiol_triple);
+      XMLNode_free(object);
+      XMLNode_free(bag);
+      XMLNode_free(predicate);
+      XMLNode_free(li);
+      XMLNode_free(statement);
+      XMLNode_free(subject);
+      XMLNode_free(bqbiol);
+      XMLNode_free(annotation);
+      CVTerm_free(cv1);
+      XMLNamespaces_free(xmlns);
     }
   }
 

--- a/examples/c/createExampleSBML.c
+++ b/examples/c/createExampleSBML.c
@@ -682,6 +682,7 @@ SBMLDocument_t* createExampleInvolvingUnits()
 
   /* Temporary pointers (reused more than once below).*/
 
+  XMLNode_t* xmlNode;
   UnitDefinition_t* unitdef;
   Unit_t *unit;
 
@@ -1058,15 +1059,18 @@ SBMLDocument_t* createExampleInvolvingUnits()
   pTripple = XMLTriple_createWith("p", "", "xhtml");
   xmlAttr = XMLAttributes_create();
   notesXMLNode = XMLNode_createStartElement(pTripple, xmlAttr);
-
+  XMLTriple_free(pTripple);
+  XMLAttributes_free(xmlAttr);
   /* Adds a text element to the start element.*/
 
-  XMLNode_addChild( notesXMLNode, XMLNode_createTextNode(" ((vm * s2)/(km + s2)) * cell ")); 
+  xmlNode = XMLNode_createTextNode(" ((vm * s2)/(km + s2)) * cell ");
+  XMLNode_addChild(notesXMLNode, xmlNode);
+  XMLNode_free(xmlNode);
 
   /* Adds it to the kineticLaw object.*/
 
   SBase_setNotes( (SBase_t*) kl, notesXMLNode);
-
+  XMLNode_free(notesXMLNode);
   /*---------------------------------------------------------------------------
    * Sets a math (ASTNode object) to the KineticLaw object.
    *---------------------------------------------------------------------------*/
@@ -1169,6 +1173,7 @@ SBMLDocument_t* createExampleInvolvingUnits()
   astMath = readMathMLFromString(mathXMLString);
   KineticLaw_setMath( kl, astMath);
   ASTNode_free(astMath);
+
 
 
   /* Returns the created SBMLDocument object.

--- a/examples/c/drawMath.c
+++ b/examples/c/drawMath.c
@@ -139,11 +139,10 @@ FormulaGraphvizFormatter_format (const ASTNode_t *node)
     {
       StringBuffer_append(p, ASTNode_getName(node));
     }
-    
     s = StringBuffer_toString(p);
   }
   
-  free(p);
+  StringBuffer_free(p);
 
   return s;
 }
@@ -192,7 +191,7 @@ FormulaGraphvizFormatter_getUniqueName (const ASTNode_t *node)
     s = StringBuffer_toString(p);
   }
 
-  free(p);
+  StringBuffer_free(p);
 
   return s;
 }
@@ -247,7 +246,7 @@ FormulaGraphvizFormatter_formatFunction (const ASTNode_t *node)
       break;
   }
 
-  free(p);
+  StringBuffer_free(p);
 
   return s;
 }
@@ -317,7 +316,7 @@ FormulaGraphvizFormatter_FunctionGetUniqueName (const ASTNode_t *node)
   
   s = StringBuffer_toString(p);
 
-  free(p);
+  StringBuffer_free(p);
 
   return s;
 }
@@ -362,7 +361,7 @@ FormulaGraphvizFormatter_formatOperator (const ASTNode_t *node)
       break;
   }
 
-  free(p);
+  StringBuffer_free(p);
 
   return s;
 }
@@ -437,7 +436,7 @@ FormulaGraphvizFormatter_OperatorGetUniqueName (const ASTNode_t *node)
   
   s = StringBuffer_toString(p);
 
-  free(p);
+  StringBuffer_free(p);
 
   return s;
 }
@@ -463,7 +462,7 @@ FormulaGraphvizFormatter_formatRational (const ASTNode_t *node)
 
   s = StringBuffer_toString(p);
 
-  free(p);
+  StringBuffer_free(p);
 
   return s;
 }
@@ -506,7 +505,7 @@ FormulaGraphvizFormatter_formatReal (const ASTNode_t *node)
     s = StringBuffer_toString(p);
   }
 
-  free(p);
+  StringBuffer_free(p);
 
   return s;
 }
@@ -581,6 +580,8 @@ FormulaGraphvizFormatter_visitFunction (const ASTNode_t *parent,
       StringBuffer_append(sb, name);
       StringBuffer_append(sb, ";\n");
     }
+    free(name);
+    free(uniqueName);
   }
 
   if (numChildren > 0)
@@ -706,7 +707,8 @@ FormulaGraphvizFormatter_visitOther (const ASTNode_t *parent,
     StringBuffer_append(sb, " [shape=box, label=");
     StringBuffer_append(sb, name);
     StringBuffer_append(sb, "];\n");
-    
+    free(uniqueName);
+
     FormulaGraphvizFormatter_visit( node, ASTNode_getLeftChild(node), sb );
   }
 
@@ -722,6 +724,8 @@ FormulaGraphvizFormatter_visitOther (const ASTNode_t *parent,
       StringBuffer_append(sb, name);
       StringBuffer_append(sb, ";\n");
     }
+    free(name);
+    free(uniqueName);
   }
 
   if (numChildren > 1)

--- a/examples/c/printRegisteredPackages.c
+++ b/examples/c/printRegisteredPackages.c
@@ -56,9 +56,11 @@ main (int argc, char* argv[])
   {
       printf("\t%s\n", (char*)List_get(list, i));      
   }
-    
+
   printf("\n");
 
+  List_freeItems(list, safe_free, void);
+  List_free(list);
   return 0;
 }
 

--- a/examples/c/printSupported.c
+++ b/examples/c/printSupported.c
@@ -77,6 +77,11 @@ main (int argc, char* argv[])
   
   printf("\n");
 
+  for (i = 0; i < length; i++)
+  {
+    SBMLNamespaces_free(supported[i]);
+  }
+  free(supported);
   return 0;
 }
 

--- a/examples/c/printUnits.c
+++ b/examples/c/printUnits.c
@@ -83,40 +83,34 @@ main (int argc, char *argv[])
   for (i = 0; i < Model_getNumSpecies(model); i++)
   {
     Species_t* s = Model_getSpecies(model, i);
-    printf("Species %d: %s\n"
-      , i
-      , UnitDefinition_printUnits(Species_getDerivedUnitDefinition(s), 0)
-    );    
+    char* u = UnitDefinition_printUnits(Species_getDerivedUnitDefinition(s), 0);
+    printf("Species %d: %s\n", i, u);
+    free(u);
   }
-
 
   for (i = 0; i < Model_getNumCompartments(model); i++)
   {
     Compartment_t *c = Model_getCompartment(model, i);
-    printf("Compartment %d: %s\n"
-      , i
-      , UnitDefinition_printUnits(Compartment_getDerivedUnitDefinition(c), 0)
-    );    
+    char* u = UnitDefinition_printUnits(Compartment_getDerivedUnitDefinition(c), 0);
+    printf("Compartment %d: %s\n", i, u);
+    free(u);
   }
 
   for (i = 0; i < Model_getNumParameters(model); i++)
   {
     Parameter_t *p = Model_getParameter(model, i);
-    printf("Parameter %d: %s\n"
-      , i
-      , UnitDefinition_printUnits(Parameter_getDerivedUnitDefinition(p), 0)
-    ); 
+    char* u = UnitDefinition_printUnits(Parameter_getDerivedUnitDefinition(p), 0);
+    printf("Parameter %d: %s\n", i, u);
+    free(u);
   }
 
 
   for (i = 0; i < Model_getNumInitialAssignments(model); i++)
   {
     InitialAssignment_t *ia = Model_getInitialAssignment(model, i);
-    printf("InitialAssignment %d: %s"
-      , i
-      , UnitDefinition_printUnits(InitialAssignment_getDerivedUnitDefinition(ia), 0)
-    ); 
-
+    char* u = UnitDefinition_printUnits(InitialAssignment_getDerivedUnitDefinition(ia), 0);
+    printf("InitialAssignment %d: %s", i, u);
+    free(u);
     printf("        undeclared units: %s", 
       (InitialAssignment_containsUndeclaredUnits(ia) ? "yes\n" : "no\n"));
   }
@@ -128,19 +122,21 @@ main (int argc, char *argv[])
 
     if (Event_isSetDelay(e))
     {
-      printf( "Delay: %s\n", 
-        UnitDefinition_printUnits(Delay_getDerivedUnitDefinition(Event_getDelay(e)), 0));
-      printf( "        undeclared units: %s", 
+        char* u = UnitDefinition_printUnits(Delay_getDerivedUnitDefinition(Event_getDelay(e)), 0);
+        printf( "Delay: %s\n", u);
+        printf( "        undeclared units: %s",
         (Delay_containsUndeclaredUnits(Event_getDelay(e)) ? "yes\n" : "no\n"));
+        free(u);
     }
       
     for (j = 0; j < Event_getNumEventAssignments(e); j++)
     {
       EventAssignment_t *ea = Event_getEventAssignment(e, j);
-         printf( "Delay: %s\n", 
-           UnitDefinition_printUnits(EventAssignment_getDerivedUnitDefinition(ea), 0));
+      char* u = UnitDefinition_printUnits(EventAssignment_getDerivedUnitDefinition(ea), 0);
+         printf( "Delay: %s\n", u);
       printf( "        undeclared units: %s", 
         (EventAssignment_containsUndeclaredUnits(ea) ? "yes\n" : "no\n"));
+      free(u);
     }
   }
 
@@ -153,10 +149,11 @@ main (int argc, char *argv[])
     if (Reaction_isSetKineticLaw(r))
     {
       KineticLaw_t *kl = Reaction_getKineticLaw(r);
-      printf( "Kinetic Law: %s\n", 
-        UnitDefinition_printUnits(KineticLaw_getDerivedUnitDefinition(kl), 0));
+      char* u = UnitDefinition_printUnits(KineticLaw_getDerivedUnitDefinition(kl), 0);
+      printf( "Kinetic Law: %s\n", u);
       printf( "        undeclared units: %s", 
         (KineticLaw_containsUndeclaredUnits(kl) ? "yes\n" : "no\n"));
+      free(u);
     }
 
     for (j = 0; j < Reaction_getNumReactants(r); j++)
@@ -166,11 +163,11 @@ main (int argc, char *argv[])
       if (SpeciesReference_isSetStoichiometryMath(sr))
       {
         StoichiometryMath_t* sm = SpeciesReference_getStoichiometryMath(sr);
-        printf( "Reactant stoichiometryMath %d: %s\n", 
-          j, 
-          UnitDefinition_printUnits(StoichiometryMath_getDerivedUnitDefinition(sm), 0));
+        char* u = UnitDefinition_printUnits(StoichiometryMath_getDerivedUnitDefinition(sm), 0);
+        printf( "Reactant stoichiometryMath %d: %s\n", j, u);
         printf( "        undeclared units: %s", 
           (StoichiometryMath_containsUndeclaredUnits(sm) ? "yes\n" : "no\n"));
+        free(u);
       }
     }
 
@@ -181,11 +178,11 @@ main (int argc, char *argv[])
       if (SpeciesReference_isSetStoichiometryMath(sr))
       {
         StoichiometryMath_t* sm = SpeciesReference_getStoichiometryMath(sr);
-        printf( "Product stoichiometryMath %d: %s\n", 
-          j, 
-          UnitDefinition_printUnits(StoichiometryMath_getDerivedUnitDefinition(sm), 0));
+        char* u = UnitDefinition_printUnits(StoichiometryMath_getDerivedUnitDefinition(sm), 0);
+        printf( "Product stoichiometryMath %d: %s\n", j, u);
         printf( "        undeclared units: %s", 
           (StoichiometryMath_containsUndeclaredUnits(sm) ? "yes\n" : "no\n"));
+        free(u);
       }
     }
   }
@@ -193,12 +190,11 @@ main (int argc, char *argv[])
   for (i = 0; i < Model_getNumRules(model); i++)
   {
     Rule_t *r = Model_getRule(model, i);
-
-   printf( "Rule %d: %s\n", 
-     j, 
-     UnitDefinition_printUnits(Rule_getDerivedUnitDefinition(r), 0));
-   printf( "        undeclared units: %s", 
+    char* u = UnitDefinition_printUnits(Rule_getDerivedUnitDefinition(r), 0);
+    printf( "Rule %d: %s\n", j, u);
+    printf( "        undeclared units: %s",
      (Rule_containsUndeclaredUnits(r) ? "yes\n" : "no\n"));
+    free(u);
   }
 
   SBMLDocument_free(document);

--- a/examples/c/promoteParameters.c
+++ b/examples/c/promoteParameters.c
@@ -76,7 +76,8 @@ int
     ConversionOption_setValue(option1, "true");
     ConversionOption_setDescription(option1, "Promotes all Local Parameters to Global ones");
     ConversionProperties_addOption(props, option1);
-   
+    ConversionOption_free(option1);
+
     /* perform the conversion */
     if (SBMLDocument_convert(doc, props) != LIBSBML_OPERATION_SUCCESS)
     {
@@ -86,8 +87,10 @@ int
 
     /* successfully completed, write the resulting file */
     writeSBML(doc, argv[2]);
+    ConversionProperties_free(props);
   }
 
+  SBMLDocument_free(doc);
   return 0;
 }
 

--- a/src/sbml/SBMLDocument.cpp
+++ b/src/sbml/SBMLDocument.cpp
@@ -214,6 +214,11 @@ SBMLDocument::SBMLDocument (SBMLNamespaces* sbmlns) :
   }
   int SBMLDocument::clearValidators()
   {
+    list<SBMLValidator*>::iterator it;
+    for (it = mValidators.begin(); it != mValidators.end(); it++)
+    {
+      delete *it;
+    }
     mValidators.clear();
     return LIBSBML_OPERATION_SUCCESS;
   }
@@ -246,6 +251,7 @@ SBMLDocument::~SBMLDocument ()
     delete mInternalValidator;
   if (mModel != NULL)
   delete mModel;
+  clearValidators();
 }
 
 

--- a/src/sbml/SBMLNamespaces.cpp
+++ b/src/sbml/SBMLNamespaces.cpp
@@ -879,10 +879,8 @@ SBMLNamespaces_getSupportedNamespaces(int *length)
   
    *length = (int) supported->getSize();
   SBMLNamespaces_t ** result = (SBMLNamespaces_t**)safe_malloc(sizeof(SBMLNamespaces_t*)*((unsigned long)(*length)));
-  //memset(result, 0, sizeof(SBMLNamespaces_t*)*((unsigned long)*length));
   for (int i = 0; i < *length; i++)
   {
-    result[i] = (SBMLNamespaces_t*)safe_malloc(sizeof(SBMLNamespaces_t*));
     result[i] = ((SBMLNamespaces*)supported->get((unsigned int)i))->clone();
   }
   SBMLNamespaces::freeSBMLNamespaces(const_cast<List*>(supported));

--- a/src/sbml/annotation/test/TestSyncAnnotation.cpp
+++ b/src/sbml/annotation/test/TestSyncAnnotation.cpp
@@ -1622,6 +1622,7 @@ START_TEST(test_SyncAnnotation_ordering_bug_1)
   fail_unless(equals(expected, sbml));
 
   free(sbml);
+  delete cv;
   delete c;
 }
 END_TEST
@@ -1670,6 +1671,7 @@ START_TEST(test_SyncAnnotation_ordering_bug_2)
   fail_unless(equals(expected, sbml));
 
   free(sbml);
+  delete cv;
   delete c;
 }
 END_TEST

--- a/src/sbml/conversion/ConversionOption.cpp
+++ b/src/sbml/conversion/ConversionOption.cpp
@@ -271,6 +271,12 @@ ConversionOption_create(const char* key)
   return new ConversionOption(key);
 }
 
+LIBSBML_EXTERN
+void
+ConversionOption_free(ConversionOption_t* co)
+{
+  delete co;
+}
 
 LIBSBML_EXTERN
 ConversionOption_t*

--- a/src/sbml/conversion/ConversionOption.h
+++ b/src/sbml/conversion/ConversionOption.h
@@ -447,6 +447,17 @@ ConversionOption_t*
 ConversionOption_create(const char* key);
 
 /**
+ * Destroys this ConversionOption_t.
+ *
+ * @param co ConversionOption_t structure to be freed.
+ *
+ * @memberof ConversionOption_t
+ */
+LIBSBML_EXTERN
+void
+ConversionOption_free(ConversionOption_t* co);
+
+/**
  * Creates and returns a deep copy of the ConversionOption_t structure.
  *
  * @param co the conversion option to clone.

--- a/src/sbml/conversion/ConversionProperties.cpp
+++ b/src/sbml/conversion/ConversionProperties.cpp
@@ -407,6 +407,13 @@ ConversionProperties_clone(const ConversionProperties_t* cp)
 }
 
 LIBSBML_EXTERN
+void
+ConversionProperties_free(ConversionProperties_t* cp)
+{
+    delete cp;
+}
+
+LIBSBML_EXTERN
 int
 ConversionProperties_getBoolValue(const ConversionProperties_t* cp, const char* key)
 {

--- a/src/sbml/conversion/ConversionProperties.h
+++ b/src/sbml/conversion/ConversionProperties.h
@@ -453,6 +453,15 @@ ConversionProperties_t*
 ConversionProperties_clone(const ConversionProperties_t* cp);
 
 /**
+ * Destroys this conversion properties structure
+ *
+ * @memberof ConversionProperties_t
+ */
+LIBSBML_EXTERN
+void
+ConversionProperties_free(ConversionProperties_t* cp);
+
+/**
  * Returns the value as boolean for a given option in the properties
  * structure.
  *

--- a/src/sbml/conversion/SBMLReactionConverter.cpp
+++ b/src/sbml/conversion/SBMLReactionConverter.cpp
@@ -441,6 +441,7 @@ SBMLReactionConverter::createRateRule(const std::string &spId, ASTNode *math)
     if (success == LIBSBML_OPERATION_SUCCESS)
     {
       success = rr->setMath(new_math);
+      delete new_math;
     }
   }
 
@@ -460,6 +461,12 @@ SBMLReactionConverter::replaceReactions()
     success == LIBSBML_OPERATION_SUCCESS && it != mRateRulesMap.end(); ++it)
   {
     success = createRateRule((*it).first, (*it).second);
+  }
+
+  // deallocate memory
+  for (it = mRateRulesMap.begin(); it != mRateRulesMap.end(); ++it)
+  {
+    delete (*it).second;
   }
 
   if (success != LIBSBML_OPERATION_SUCCESS)

--- a/src/sbml/math/test/TestL3FormulaParser.cpp
+++ b/src/sbml/math/test/TestL3FormulaParser.cpp
@@ -3512,14 +3512,14 @@ START_TEST(test_SBML_parseL3Formula_named_lambda_arguments1)
   ASTNode_t *c = ASTNode_getChild(r, 0);
   fail_unless(ASTNode_getType(c) == AST_NAME);
   fail_unless(!strcmp(ASTNode_getName(c), "time"));
-  fail_unless(!strcmp(ASTNode_getDefinitionURLString(c), ""));
+  fail_unless(c->getDefinitionURLString() == "");
 
   c = ASTNode_getChild(r, 1);
   fail_unless(ASTNode_getType(c) == AST_PLUS);
   ASTNode_t *c2 = ASTNode_getChild(c, 0);
   fail_unless(ASTNode_getType(c2) == AST_NAME);
   fail_unless(!strcmp(ASTNode_getName(c2), "time"));
-  fail_unless(!strcmp(ASTNode_getDefinitionURLString(c2), ""));
+  fail_unless(c2->getDefinitionURLString() == "");
   c2 = ASTNode_getChild(c, 1);
   fail_unless(ASTNode_getType(c2) == AST_INTEGER);
   fail_unless(ASTNode_getValue(c2) == 2);
@@ -3539,23 +3539,23 @@ START_TEST(test_SBML_parseL3Formula_named_lambda_arguments2)
   ASTNode_t *c = ASTNode_getChild(r, 0);
   fail_unless(ASTNode_getType(c) == AST_NAME);
   fail_unless(!strcmp(ASTNode_getName(c), "time"));
-  fail_unless(!strcmp(ASTNode_getDefinitionURLString(c), ""));
+  fail_unless(c->getDefinitionURLString() == "");
 
   c = ASTNode_getChild(r, 1);
   fail_unless(ASTNode_getType(c) == AST_NAME);
   fail_unless(!strcmp(ASTNode_getName(c), "avogadro"));
-  fail_unless(!strcmp(ASTNode_getDefinitionURLString(c), ""));
+  fail_unless(c->getDefinitionURLString() == "");
 
   c = ASTNode_getChild(r, 2);
   fail_unless(ASTNode_getType(c) == AST_PLUS);
   ASTNode_t *c2 = ASTNode_getChild(c, 0);
   fail_unless(ASTNode_getType(c2) == AST_NAME);
   fail_unless(!strcmp(ASTNode_getName(c2), "time"));
-  fail_unless(!strcmp(ASTNode_getDefinitionURLString(c2), ""));
+  fail_unless(c2->getDefinitionURLString() == "");
   c2 = ASTNode_getChild(c, 1);
   fail_unless(ASTNode_getType(c2) == AST_NAME);
   fail_unless(!strcmp(ASTNode_getName(c2), "avogadro"));
-  fail_unless(!strcmp(ASTNode_getDefinitionURLString(c2), ""));
+  fail_unless(c2->getDefinitionURLString() == "");
 
   ASTNode_free(r);
 
@@ -3572,23 +3572,23 @@ START_TEST(test_SBML_parseL3Formula_named_lambda_arguments3)
   ASTNode_t *c = ASTNode_getChild(r, 0);
   fail_unless(ASTNode_getType(c) == AST_NAME);
   fail_unless(!strcmp(ASTNode_getName(c), "true"));
-  fail_unless(!strcmp(ASTNode_getDefinitionURLString(c), ""));
+  fail_unless(c->getDefinitionURLString() == "");
 
   c = ASTNode_getChild(r, 1);
   fail_unless(ASTNode_getType(c) == AST_NAME);
   fail_unless(!strcmp(ASTNode_getName(c), "false"));
-  fail_unless(!strcmp(ASTNode_getDefinitionURLString(c), ""));
+  fail_unless(c->getDefinitionURLString() == "");
 
   c = ASTNode_getChild(r, 2);
   fail_unless(ASTNode_getType(c) == AST_PLUS);
   ASTNode_t *c2 = ASTNode_getChild(c, 0);
   fail_unless(ASTNode_getType(c2) == AST_NAME);
   fail_unless(!strcmp(ASTNode_getName(c2), "true"));
-  fail_unless(!strcmp(ASTNode_getDefinitionURLString(c2), ""));
+  fail_unless(c2->getDefinitionURLString() == "");
   c2 = ASTNode_getChild(c, 1);
   fail_unless(ASTNode_getType(c2) == AST_NAME);
   fail_unless(!strcmp(ASTNode_getName(c2), "false"));
-  fail_unless(!strcmp(ASTNode_getDefinitionURLString(c2), ""));
+  fail_unless(c2->getDefinitionURLString() == "");
 
   ASTNode_free(r);
 
@@ -3605,23 +3605,23 @@ START_TEST(test_SBML_parseL3Formula_named_lambda_arguments4)
   ASTNode_t *c = ASTNode_getChild(r, 0);
   fail_unless(ASTNode_getType(c) == AST_NAME);
   fail_unless(!strcmp(ASTNode_getName(c), "pi"));
-  fail_unless(!strcmp(ASTNode_getDefinitionURLString(c), ""));
+  fail_unless(c->getDefinitionURLString() == "");
 
   c = ASTNode_getChild(r, 1);
   fail_unless(ASTNode_getType(c) == AST_NAME);
   fail_unless(!strcmp(ASTNode_getName(c), "exponentiale"));
-  fail_unless(!strcmp(ASTNode_getDefinitionURLString(c), ""));
+  fail_unless(c->getDefinitionURLString() == "");
 
   c = ASTNode_getChild(r, 2);
   fail_unless(ASTNode_getType(c) == AST_PLUS);
   ASTNode_t *c2 = ASTNode_getChild(c, 0);
   fail_unless(ASTNode_getType(c2) == AST_NAME);
   fail_unless(!strcmp(ASTNode_getName(c2), "pi"));
-  fail_unless(!strcmp(ASTNode_getDefinitionURLString(c2), ""));
+  fail_unless(c2->getDefinitionURLString() == "");
   c2 = ASTNode_getChild(c, 1);
   fail_unless(ASTNode_getType(c2) == AST_NAME);
   fail_unless(!strcmp(ASTNode_getName(c2), "exponentiale"));
-  fail_unless(!strcmp(ASTNode_getDefinitionURLString(c2), ""));
+  fail_unless(c2->getDefinitionURLString() == "");
 
   ASTNode_free(r);
 
@@ -3638,32 +3638,32 @@ START_TEST(test_SBML_parseL3Formula_named_lambda_arguments5)
   ASTNode_t *c = ASTNode_getChild(r, 0);
   fail_unless(ASTNode_getType(c) == AST_NAME);
   fail_unless(!strcmp(ASTNode_getName(c), "time"));
-  fail_unless(!strcmp(ASTNode_getDefinitionURLString(c), ""));
+  fail_unless(c->getDefinitionURLString() == "");
 
   c = ASTNode_getChild(r, 1);
   fail_unless(ASTNode_getType(c) == AST_NAME);
   fail_unless(!strcmp(ASTNode_getName(c), "avogadro"));
-  fail_unless(!strcmp(ASTNode_getDefinitionURLString(c), ""));
+  fail_unless(c->getDefinitionURLString() == "");
 
   c = ASTNode_getChild(r, 2);
   fail_unless(ASTNode_getType(c) == AST_NAME);
   fail_unless(!strcmp(ASTNode_getName(c), "true"));
-  fail_unless(!strcmp(ASTNode_getDefinitionURLString(c), ""));
+  fail_unless(c->getDefinitionURLString() == "");
 
   c = ASTNode_getChild(r, 3);
   fail_unless(ASTNode_getType(c) == AST_NAME);
   fail_unless(!strcmp(ASTNode_getName(c), "false"));
-  fail_unless(!strcmp(ASTNode_getDefinitionURLString(c), ""));
+  fail_unless(c->getDefinitionURLString() == "");
 
   c = ASTNode_getChild(r, 4);
   fail_unless(ASTNode_getType(c) == AST_NAME);
   fail_unless(!strcmp(ASTNode_getName(c), "pi"));
-  fail_unless(!strcmp(ASTNode_getDefinitionURLString(c), ""));
+  fail_unless(c->getDefinitionURLString() == "");
 
   c = ASTNode_getChild(r, 5);
   fail_unless(ASTNode_getType(c) == AST_NAME);
   fail_unless(!strcmp(ASTNode_getName(c), "exponentiale"));
-  fail_unless(!strcmp(ASTNode_getDefinitionURLString(c), ""));
+  fail_unless(c->getDefinitionURLString() == "");
 
   c = ASTNode_getChild(r, 6);
   fail_unless(ASTNode_getType(c) == AST_PLUS);
@@ -3671,27 +3671,27 @@ START_TEST(test_SBML_parseL3Formula_named_lambda_arguments5)
   ASTNode_t *c2 = ASTNode_getChild(c, 0);
   fail_unless(ASTNode_getType(c2) == AST_NAME);
   fail_unless(!strcmp(ASTNode_getName(c2), "time"));
-  fail_unless(!strcmp(ASTNode_getDefinitionURLString(c2), ""));
+  fail_unless(c2->getDefinitionURLString() == "");
   c2 = ASTNode_getChild(c, 1);
   fail_unless(ASTNode_getType(c2) == AST_NAME);
   fail_unless(!strcmp(ASTNode_getName(c2), "avogadro"));
-  fail_unless(!strcmp(ASTNode_getDefinitionURLString(c2), ""));
+  fail_unless(c2->getDefinitionURLString() == "");
   c2 = ASTNode_getChild(c, 2);
   fail_unless(ASTNode_getType(c2) == AST_NAME);
   fail_unless(!strcmp(ASTNode_getName(c2), "true"));
-  fail_unless(!strcmp(ASTNode_getDefinitionURLString(c2), ""));
+  fail_unless(c2->getDefinitionURLString() == "");
   c2 = ASTNode_getChild(c, 3);
   fail_unless(ASTNode_getType(c2) == AST_NAME);
   fail_unless(!strcmp(ASTNode_getName(c2), "false"));
-  fail_unless(!strcmp(ASTNode_getDefinitionURLString(c2), ""));
+  fail_unless(c2->getDefinitionURLString() == "");
   c2 = ASTNode_getChild(c, 4);
   fail_unless(ASTNode_getType(c2) == AST_NAME);
   fail_unless(!strcmp(ASTNode_getName(c2), "pi"));
-  fail_unless(!strcmp(ASTNode_getDefinitionURLString(c2), ""));
+  fail_unless(c2->getDefinitionURLString() == "");
   c2 = ASTNode_getChild(c, 5);
   fail_unless(ASTNode_getType(c2) == AST_NAME);
   fail_unless(!strcmp(ASTNode_getName(c2), "exponentiale"));
-  fail_unless(!strcmp(ASTNode_getDefinitionURLString(c2), ""));
+  fail_unless(c2->getDefinitionURLString() == "");
 
   ASTNode_free(r);
 
@@ -3708,14 +3708,14 @@ START_TEST(test_SBML_parseL3Formula_named_lambda_arguments6)
   ASTNode_t *c = ASTNode_getChild(r, 0);
   fail_unless(ASTNode_getType(c) == AST_NAME);
   fail_unless(!strcmp(ASTNode_getName(c), "time"));
-  fail_unless(!strcmp(ASTNode_getDefinitionURLString(c), ""));
+  fail_unless(c->getDefinitionURLString() == "");
 
   c = ASTNode_getChild(r, 1);
   fail_unless(ASTNode_getType(c) == AST_PLUS);
   ASTNode_t *c2 = ASTNode_getChild(c, 0);
   fail_unless(ASTNode_getType(c2) == AST_NAME);
   fail_unless(!strcmp(ASTNode_getName(c2), "time"));
-  fail_unless(!strcmp(ASTNode_getDefinitionURLString(c2), ""));
+  fail_unless(c2->getDefinitionURLString() == "");
   c2 = ASTNode_getChild(c, 1);
   fail_unless(ASTNode_getType(c2) == AST_CONSTANT_PI);
 

--- a/src/sbml/packages/spatial/extension/test/TestReadSpatialExtension.cpp
+++ b/src/sbml/packages/spatial/extension/test/TestReadSpatialExtension.cpp
@@ -661,7 +661,7 @@ END_TEST
   string test1 = dataToString(array1, field->getNumSamples1(), length1);
   //fail_unless(test1 == expected);
 
-  double* result = new double[length1]; 
+  double* result = NULL;
   size_t resultLength;
   field->getUncompressedData(result, resultLength);
 

--- a/src/sbml/packages/spatial/sbml/test/TestImageData.cpp
+++ b/src/sbml/packages/spatial/sbml/test/TestImageData.cpp
@@ -156,63 +156,6 @@ START_TEST (test_SampledField_samples)
 END_TEST
 
 
-START_TEST (test_SampledField_samples_mismatchLength_1)
-{
-  fail_unless(G->isSetSamples() == false);
-  fail_unless(G->isSetSamplesLength() == false);
-
-  int samples [] = {1,2};
-  G->setSamples(samples, 3);
-  G->setSamplesLength(3);
-
-  fail_unless(G->isSetSamples() == true);
-  fail_unless(G->isSetSamplesLength() == true);
-
-  fail_unless(G->getSamplesLength() == 3);
-
-  double samplesRet [] = {0, 0, 0};
-  G->getSamples(samplesRet);
-  fail_unless(samplesRet[0] == 1);
-  fail_unless(samplesRet[1] == 2);
-  fail_unless(samplesRet[2] != 0);
-
-  G->unsetSamples();
-
-  fail_unless(G->isSetSamples() == false);
-  fail_unless(G->isSetSamplesLength() == false);
-}
-END_TEST
-
-
-START_TEST (test_SampledField_samples_mismatchLength_2)
-{
-  fail_unless(G->isSetSamples() == false);
-  fail_unless(G->isSetSamplesLength() == false);
-
-  int samples [] = {1,2};
-  G->setSamples(samples, 1);
-  G->setSamplesLength(1);
-
-  fail_unless(G->isSetSamples() == true);
-  fail_unless(G->isSetSamplesLength() == true);
-
-  fail_unless(G->getSamplesLength() == 1);
-
-  int samplesRet [1];
-  G->getSamples(samplesRet);
-  fail_unless(samplesRet[0] == 1);
-  // really just making sure we dont crash
-  fail_unless(samplesRet[1] != 2);
-  fail_unless(samplesRet[2] != 0);
-
-  G->unsetSamples();
-
-  fail_unless(G->isSetSamples() == false);
-  fail_unless(G->isSetSamplesLength() == false);
-}
-END_TEST
-
-
 START_TEST (test_SampledField_dataType)
 {
   fail_unless(G->isSetDataType() == false);
@@ -258,8 +201,6 @@ create_suite_SampledField (void)
 
   tcase_add_test( tcase, test_SampledField_samplesLength   );
   tcase_add_test( tcase, test_SampledField_samples         );
-  tcase_add_test( tcase, test_SampledField_samples_mismatchLength_1  );
-  tcase_add_test( tcase, test_SampledField_samples_mismatchLength_2  );
   tcase_add_test( tcase, test_SampledField_dataType        );
   tcase_add_test( tcase, test_SampledField_output         );
 

--- a/src/sbml/validator/constraints/ConsistencyConstraints.cpp
+++ b/src/sbml/validator/constraints/ConsistencyConstraints.cpp
@@ -441,8 +441,10 @@ START_CONSTRAINT(99304, FunctionDefinition, fd)
     const ASTNode * child = math->getChild(i);
     if (child->getType() != AST_NAME)
     {
+      char* element = SBML_formulaToL3String(child);
       msg = "The <functionDefinition> with id '" + fd.getId() + "' contains"
-        " a <bvar> element " + SBML_formulaToL3String(child) + " that is not a <ci> element.";
+        " a <bvar> element " + element + " that is not a <ci> element.";
+      free(element);
       fail = true;
     }
 


### PR DESCRIPTION
## Description

  - SBMLDocument::clearValidators()
    - free memory allocated for the validators
  - SBMLNamespaces_getSupportedNamespaces()
    - remove unnecessary malloc
  - SBMLReactionConverter::replaceReactions()
    - free memory allocated for the reactions
  - SBMLReactionConverter::createRateRule()
    - delete temporary
  - fix leaks in some tests

also free all allocated memory in the example c & c++ programs, added a couple of new functions to allow this:

- ConversionOption_free()
- ConversionProperties_free()

## Motivation and Context
Fixes memory leaks in libsbml and in the testsuite

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have updated all documentation necessary.
- [ ] I have checked spelling in (new) comments.

## Testing
- [X] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested -->

