### PR TITLE
fix memory leak and add test

### DIFF
--- a/src/sbml/Model.cpp
+++ b/src/sbml/Model.cpp
@@ -159,7 +159,7 @@ Model::~Model ()
     }
     delete mFormulaUnitsData;
   }
-
+  mEvents.clear();
   mUnitsDataMap.clear();
 }
 

--- a/src/sbml/test/TestAttributeFunctions.cpp
+++ b/src/sbml/test/TestAttributeFunctions.cpp
@@ -1593,6 +1593,7 @@ START_TEST(test_Elements_Event)
   fail_unless(e->isSetTrigger() == false);
   fail_unless(e->getNumObjects("trigger") == 0);
 
+  delete t2;
   delete m;
 }
 END_TEST

--- a/src/sbml/test/TestSBMLConvert.c
+++ b/src/sbml/test/TestSBMLConvert.c
@@ -658,7 +658,9 @@ START_TEST (test_SBMLConvert_convertToL3_unit)
   fail_unless( SBMLDocument_setLevelAndVersionNonStrict(d, 3, 1) == 1, NULL);
 
   Unit_t *u1 = UnitDefinition_getUnit(Model_getUnitDefinition(m, 0), 0);
-
+  fail_unless(util_isEqual(Unit_getExponent(u1), 1.0));
+  fail_unless(Unit_getScale(u1) == 0);
+  fail_unless(util_isEqual(Unit_getMultiplier(u1), 1.0));
   fail_unless(Unit_hasRequiredAttributes(u1) == 1);
 
   SBMLDocument_free(d);


### PR DESCRIPTION
## Description
- TestSBMLConvert.c: check that Exponent, Scale and Multiplier are set to default values on upgrade to level 3 if not explicitly set
- Model.cpp: clear Events list in destructor
- TestAttributeFunctions.cpp: delete allocated memory

## Motivation and Context
Fix memory leak & add test to ensure that level 2 units with optional values that and are not explicitly set become explicitly set to their default level 2 values on upgrade to level 3

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have updated all documentation necessary.
- [ ] I have checked spelling in (new) comments.

## Testing
- [X] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested -->

