### PR TITLE
use "C" locale version of strtod

### DIFF
--- a/src/sbml/test/TestUnit.c
+++ b/src/sbml/test/TestUnit.c
@@ -41,6 +41,7 @@
 #include <sbml/xml/XMLNamespaces.h>
 #include <sbml/SBMLDocument.h>
 
+#include <locale.h>
 #include <check.h>
 
 
@@ -378,6 +379,38 @@ START_TEST (test_Unit_createWithNS )
 END_TEST
 
 
+START_TEST (test_Unit_merge)
+{
+  char *old_locale;
+  old_locale = safe_strdup(setlocale(LC_ALL, NULL));
+  setlocale(LC_ALL, "de_DE.UTF-8");
+  Unit_t *u1 = Unit_create(2, 3);
+  Unit_setKind(u1, UNIT_KIND_LITRE);
+  Unit_setExponent(u1, 1.00);
+  Unit_setScale(u1, -3);
+  Unit_setMultiplier(u1, 1.00);
+
+  Unit_t *u2 = Unit_create(2, 3);
+  Unit_setKind(u2, UNIT_KIND_LITRE);
+  Unit_setExponent(u2, -1);
+  Unit_setScale(u2, -3);
+  Unit_setMultiplier(u2, 1);
+
+  Unit_merge(u1, u2);
+
+  fail_unless(Unit_getKind(u1) == UNIT_KIND_LITRE);
+  fail_unless(util_isEqual(Unit_getExponent(u1), 0.0));
+  fail_unless(Unit_getScale(u1) == 0);
+  fail_unless(util_isEqual(Unit_getMultiplier(u1), 1.0));
+
+  Unit_free(u1);
+  Unit_free(u2);
+  setlocale(LC_ALL, old_locale);
+  safe_free(old_locale);
+}
+END_TEST
+
+
 Suite *
 create_suite_Unit (void)
 {
@@ -395,6 +428,7 @@ create_suite_Unit (void)
   tcase_add_test( tcase, test_Unit_set_get_unset    );
   tcase_add_test( tcase, test_Unit_unset    );
   tcase_add_test( tcase, test_Unit_createWithNS         );
+  tcase_add_test( tcase, test_Unit_merge      );
 
   suite_add_tcase(suite, tcase);
 


### PR DESCRIPTION
## Description
- Unit.cpp:
  - use `c_locale_strtod()` instead of `strtod()`
  - refactor code fragment used in many places to truncate double precision into `truncateDoublePrecision()`
- TestUnit.c: add test of `Unit::merge()` using "de_DE.UTF-8" locale

## Motivation and Context
If the locale is e.g. "de_DE.UTF-8", then upgrade of a level 2 model to level 3 can produce `nan` in the `Multiplier` of a `Unit` (and hence the upgrade fails due to inconsistent units). This is due to `strtod` being locale dependent - for example in this locale the decimal separator is "," and the string "0.1" is parsed as the number 0.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have updated all documentation necessary.
- [ ] I have checked spelling in (new) comments.

## Testing
- [X] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested -->

