### PR TITLE
Spatial ParametricObject compression fixes

### DIFF
--- a/src/sbml/packages/spatial/sbml/ParametricObject.h
+++ b/src/sbml/packages/spatial/sbml/ParametricObject.h
@@ -1219,15 +1219,16 @@ public:
    * The "samples" attribute of this ParametricObject is returned in an int array (pointer) 
    * that is passed as argument to the method (this is needed while using SWIG to
    * convert int[] from C++ to Java). This method returns the uncompressed sample field.
+   * Will uncompress the samples if need be.
    *
    * @return void.
    */
   void getUncompressed(int* outputPoints) const;
 
   /**
-   * The "samples" attribute of this ParametricObject is returned in an int array (pointer) 
-   * that is passed as argument to the method (this is needed while using SWIG to
-   * convert int[] from C++ to Java). This method returns the uncompressed sample field.
+   * The "samples" attribute of this ParametricObject is returned in a std::vector of int
+   * that is passed as argument to the method. This method returns the uncompressed sample field.
+   * Will uncompress the samples if need be.
    *
    * @return void.
    */
@@ -1264,7 +1265,8 @@ public:
   int compress(int level);
 
   /**  
-   *  Returns the data of this image as uncompressed array of integers
+   * Returns the data of this image as uncompressed array of integers.
+   * Will uncompress the samples if need be.
    *
    * @param data the output array of integers (it will be allocated using
    *             malloc and will have to be freed using free)

--- a/src/sbml/packages/spatial/sbml/test/TestCompression.cpp
+++ b/src/sbml/packages/spatial/sbml/test/TestCompression.cpp
@@ -724,8 +724,10 @@ START_TEST(test_Compression_ParametricObject_2)
   parametricobj.getPointIndex(compressed_data);
   fail_unless(compressed_data == compressedvals);
 
+  // check that uncompressed values are correct
   int* uncompressed_array = NULL;
   size_t length;
+  // this method allocates memory
   parametricobj.getUncompressedData(uncompressed_array, length);
   fail_unless(length == values.size());
   for (size_t n = 0; n < length; n++)
@@ -733,9 +735,17 @@ START_TEST(test_Compression_ParametricObject_2)
     fail_unless(uncompressed_array[n] == values[n]);
   }
 
+  // this method expects the memory to already be allocated
+  parametricobj.getUncompressed(uncompressed_array);
+  for (size_t n = 0; n < length; n++)
+  {
+    fail_unless(uncompressed_array[n] == values[n]);
+  }
+  free(uncompressed_array);
+
   vector<int> uncompressed_vec;
   parametricobj.getUncompressed(uncompressed_vec);
-
+  fail_unless(uncompressed_vec == values);
 
   // Now uncompress the values
   parametricobj.uncompress();
@@ -747,8 +757,26 @@ START_TEST(test_Compression_ParametricObject_2)
 
   std::vector<int> uncompressed_data;
   parametricobj.getPointIndex(uncompressed_data);
-
   fail_unless(uncompressed_data == values);
+
+  // check again that uncompressed values are correct
+  uncompressed_vec.clear();
+  parametricobj.getUncompressed(uncompressed_vec);
+  fail_unless(uncompressed_vec == values);
+
+  parametricobj.getUncompressedData(uncompressed_array, length);
+  fail_unless(length == values.size());
+  for (size_t n = 0; n < length; n++)
+  {
+    fail_unless(uncompressed_array[n] == values[n]);
+  }
+
+  parametricobj.getUncompressed(uncompressed_array);
+  for (size_t n = 0; n < length; n++)
+  {
+    fail_unless(uncompressed_array[n] == values[n]);
+  }
+  free(uncompressed_array);
 
   //Now compress them again
   parametricobj.compress(9);


### PR DESCRIPTION
## Description
  - `getUncompressed(vector<int>&)`, `getUncompressedData(int*& data, size_t& length)`:
    - decompress compressed values if necessary
    - matches behaviour of `getUncompressed(int*)`
    - previously failing test now passes
  - `setCompression(CompressionKind_t)`: setting compression to existing value does nothing (i.e. don't call `freeCompressed()`, `freeUncompressed()`)
  - `setCompression(string)`: call `CompressionKind_t` overload instead of duplicating code
  - `setPointIndex()`: add calls to `freeCompressed()`, `freeUncompressed()` and `store()`
  - `setDataType(string)`: call `DataKind_t` overload instead of duplicating code
  - TestCompression.cpp: add some tests of the different `getUncompressed()` overloads

## Motivation and Context
Spatial compression tests were failing

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have updated all documentation necessary.
- [ ] I have checked spelling in (new) comments.

## Testing
- [X] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested -->

