### PR TITLE
 - issue #27 : prevent writing name, if none is defined

### DIFF
--- a/src/sbml/math/MathML.cpp
+++ b/src/sbml/math/MathML.cpp
@@ -1540,7 +1540,8 @@ writeCSymbol(const ASTNode& node, XMLOutputStream& stream, SBMLNamespaces *sbmln
   stream.writeAttribute( "encoding"     , text );
   stream.writeAttribute( "definitionURL", url  );
 
-  stream << " " << node.getName() << " ";
+  if (node.getName() != NULL)
+    stream << " " << node.getName() << " ";
 
   stream.endElement("csymbol");
   stream.setAutoIndent(true);

--- a/src/sbml/math/test/TestWriteMathMLFromAST.cpp
+++ b/src/sbml/math/test/TestWriteMathMLFromAST.cpp
@@ -381,6 +381,22 @@ START_TEST (test_MathMLFromAST_csymbol_time)
 }
 END_TEST
 
+START_TEST (test_MathMLFromAST_csymbol_time_no_name)
+{
+  const char* expected = wrapMathML
+  (
+    "  <csymbol encoding=\"text\" "
+    "definitionURL=\"http://www.sbml.org/sbml/symbols/time\"/>\n"
+  );
+
+  N = new ASTNode(AST_NAME_TIME);
+
+  S = writeMathMLToString(N);
+  
+  fail_unless( equals(expected, S) );
+}
+END_TEST
+
 
 START_TEST (test_MathMLFromAST_csymbol_rateof)
 {
@@ -1836,6 +1852,7 @@ create_suite_WriteMathMLFromAST ()
   tcase_add_test( tcase, test_MathMLFromAST_csymbol_delay         );
   tcase_add_test( tcase, test_MathMLFromAST_csymbol_rateof        );
   tcase_add_test( tcase, test_MathMLFromAST_csymbol_time          );
+  tcase_add_test( tcase, test_MathMLFromAST_csymbol_time_no_name  );
   tcase_add_test( tcase, test_MathMLFromAST_generic_csymbol       );
   tcase_add_test( tcase, test_MathMLFromAST_constant_true         );
   tcase_add_test( tcase, test_MathMLFromAST_constant_false        );


### PR DESCRIPTION
## Description
 - when writing csymbols, check for the name before writing it, otherwise a logic error is thrown by std::string constructor

## Motivation and Context
fixes #27 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have updated all documentation necessary.
- [ ] I have checked spelling in (new) comments.

## Testing
- [X] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested -->

