### PR TITLE
version string is in conflict with the VERSION.txt file

### DIFF
--- a/src/sbml/common/libsbml-version.h
+++ b/src/sbml/common/libsbml-version.h
@@ -46,7 +46,7 @@
  *
  * A version string of the form "1.2.3".
  */
-#define LIBSBML_DOTTED_VERSION	"5.18.1"
+#define LIBSBML_DOTTED_VERSION	"5.18.3"
 
 
 /**
@@ -57,7 +57,7 @@
  * libSBML is released, making it easy to use less-than and greater-than
  * comparisons when testing versions numbers.
  */
-#define LIBSBML_VERSION		51801
+#define LIBSBML_VERSION		51803
 
 
 /**
@@ -65,7 +65,7 @@
  *
  * The numeric version as a string: version 1.2.3 becomes "10203".
  */
-#define LIBSBML_VERSION_STRING	"51801"
+#define LIBSBML_VERSION_STRING	"51803"
 
 
 LIBSBML_CPP_NAMESPACE_BEGIN
@@ -147,4 +147,3 @@ END_C_DECLS
 LIBSBML_CPP_NAMESPACE_END
 
 #endif  /* LIBSBML_VERSION_H */
-

--- a/src/sbml/common/libsbml-version.h.cmake
+++ b/src/sbml/common/libsbml-version.h.cmake
@@ -2,11 +2,8 @@
  * @file    libsbml-version.h
  * @brief   Define libSBML version numbers for access from client software.
  * @author  Michael Hucka
- *
- * $Id: libsbml-version.h.in 10126 2009-08-28 12:16:07Z sarahkeating $
- * $HeadURL: https://sbml.svn.sourceforge.net/svnroot/sbml/trunk/libsbml/src/common/libsbml-version.h.in $
- *
- *<!---------------------------------------------------------------------------
+ * 
+ * <!--------------------------------------------------------------------------
  * This file is part of libSBML.  Please visit http://sbml.org for more
  * information about SBML, and the latest version of libSBML.
  *
@@ -118,11 +115,11 @@ getLibSBMLVersionString ();
  *        "expat", "libxml", "xerces-c", "bzip2", "zip"
  * 
  * @return 0 in case the libSBML has not been compiled against 
- *         that library and non-zero otherwise (for libraries 
+ *         that library and nonzero otherwise (for libraries 
  *         that define an integer version number that number will 
  *         be returned).
  *
- * @see getLibSBMLDependencyVersionOf()
+ * @see getLibSBMLDependencyVersionOf(const char* option)
  */
 LIBSBML_EXTERN
 int 
@@ -139,7 +136,7 @@ isLibSBMLCompiledWith(const char* option);
  * @return NULL in case libSBML has not been compiled against 
  *         that library and a version string otherwise.
  *
- * @see isLibSBMLCompiledWith()
+ * @see isLibSBMLCompiledWith(const char* option)
  */
 LIBSBML_EXTERN
 const char* 

--- a/src/sbml/common/libsbml-version.h.in
+++ b/src/sbml/common/libsbml-version.h.in
@@ -115,7 +115,7 @@ getLibSBMLVersionString ();
  *        "expat", "libxml", "xerces-c", "bzip2", "zip"
  * 
  * @return 0 in case the libSBML has not been compiled against 
- *         that library and non-zero otherwise (for libraries 
+ *         that library and nonzero otherwise (for libraries 
  *         that define an integer version number that number will 
  *         be returned).
  *


### PR DESCRIPTION
## Description
Updated the libsbml-version.h, as well as the documentation strings in libsbml-version.h* files

## Motivation and Context
fixes #42 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have updated all documentation necessary.
- [ ] I have checked spelling in (new) comments.

## Testing
- [X] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested -->

