### PR TITLE
 - issue #57: return the ListWrapper class, rather than a pointer to …

### DIFF
--- a/src/bindings/swig/comp-package.i
+++ b/src/bindings/swig/comp-package.i
@@ -50,10 +50,10 @@
 
 %extend Submodel
 {
-	ListWrapper<SBase>* getListOfAllInstantiatedElements()
+	ListWrapper<SBase> getListOfAllInstantiatedElements()
 	{
 		List* list = $self->getAllInstantiatedElements();
-		return new ListWrapper<SBase>(list);
+		return ListWrapper<SBase>(list);
 	}
 }
 

--- a/src/bindings/swig/libsbml.i
+++ b/src/bindings/swig/libsbml.i
@@ -480,7 +480,7 @@ LIBSBML_CPP_NAMESPACE_USE
 /**
  *
  * wraps "List* ASTNode::getListOfNodes(ASTNodePredicate)" function
- * as "ListWrapper<ASTNode>* ASTNode::getListOfNodes()" function
+ * as "ListWrapper<ASTNode> ASTNode::getListOfNodes()" function
  * which returns a list of all ASTNodes.
  *
  */
@@ -492,11 +492,9 @@ LIBSBML_CPP_NAMESPACE_USE
 
 %extend Model
 {
-   void renameIDs(ListWrapper<SBase>* elements, IdentifierTransformer *idTransformer)
+   void renameIDs(ListWrapper<SBase>& elements, IdentifierTransformer *idTransformer)
    {
-		if (!elements) return;
-
-		List *list = elements->getList();
+		List *list = elements.getList();
 		$self->renameIDs(list, idTransformer);
    }
 }
@@ -518,12 +516,14 @@ nested to an arbitrary depth.
 #endif
 %extend SBasePlugin
 {
-	ListWrapper<SBase>* getListOfAllElements(ElementFilter* filter=NULL)
+	ListWrapper<SBase> getListOfAllElements(ElementFilter* filter=NULL)
 	{
 		List* list = $self->getAllElements(filter);
-		return new ListWrapper<SBase>(list);
+		return ListWrapper<SBase>(list);
 	}
 }
+
+
 #ifndef SWIGRUBY
 %feature("docstring") SBase::getListOfAllElements "
 Returns an SBaseList of all child SBase objects, including those
@@ -534,12 +534,13 @@ nested to an arbitrary depth.
 #endif
 %extend SBase
 {
-	ListWrapper<SBase>* getListOfAllElements(ElementFilter* filter=NULL)
+	ListWrapper<SBase> getListOfAllElements(ElementFilter* filter=NULL)
 	{
 		List* list = $self->getAllElements(filter);
-		return new ListWrapper<SBase>(list);
+		return ListWrapper<SBase>(list);
 	}
 }
+
 
 #ifndef SWIGRUBY
 %feature("docstring") SBase::getListOfAllElementsFromPlugins "
@@ -559,12 +560,14 @@ plug-ins.
 #endif
 %extend SBase
 {
-	ListWrapper<SBase>* getListOfAllElementsFromPlugins(ElementFilter* filter=NULL)
+	ListWrapper<SBase> getListOfAllElementsFromPlugins(ElementFilter* filter=NULL)
 	{
 		List* list = $self->getAllElementsFromPlugins(filter);
-		return new ListWrapper<SBase>(list);
+		return ListWrapper<SBase>(list);
 	}
 }
+
+
 #ifndef SWIGRUBY
 
 %feature("docstring") ASTNode::getListOfNodes "
@@ -584,10 +587,10 @@ itself), and therefore should not be deleted.
 #endif
 %extend ASTNode
 {
-  ListWrapper<ASTNode>* getListOfNodes()
+  ListWrapper<ASTNode> getListOfNodes()
   {
     List *list = $self->getListOfNodes(ASTNode_true);
-    return new ListWrapper<ASTNode>(list);
+    return ListWrapper<ASTNode>(list);
   }
 }
 


### PR DESCRIPTION
…it, which will be freed by the  target language

## Description
In issue #57 , Fabian notices a memory leak that occurs, since we return a pointer to a listwrapper object, rather than the object itself. I've tried to combine the swig %extend syntax with %newobject, to go about without any changes, however, i was not successful in doing so. Comparing the generated code, the result is precisely what we want, we now get statements of form: 

`
  resultobj = SWIG_NewPointerObj((new ListWrapper< SBase >(static_cast< const ListWrapper< SBase >& >(result))), SWIGTYPE_p_ListWrapperT_SBase_t, SWIG_POINTER_OWN |  0 );
`

denoting that the pointer is owned by the target language. 

## Motivation and Context
fixes #57 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have updated all documentation necessary.
- [ ] I have checked spelling in (new) comments.

## Testing
- [ ] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested -->
I would feel better if someone else gives this a try, i have only tried python and C# bindings yet. 
