### PR TITLE
Add the ability to sort ListOf's by SId.

### DIFF
--- a/src/sbml/ListOf.cpp
+++ b/src/sbml/ListOf.cpp
@@ -687,13 +687,30 @@ ListOf::setExplicitlyListed(bool value)
 
 struct ListOfComparator
 {
-    // Compare 2 SBase* objects using name
+    // Compare 2 SBase* objects using the 'id' attribute, 
+    // then the results of 'getId' (which is sometimes different 
+    // from 'getId'), then name, then metaid.
     bool operator ()(const SBase* obj1, const SBase* obj2)
     {
         if (obj1 == NULL || obj2 == NULL) {
             return true;
         }
-        return obj1->getId() < obj2->getId();
+        if (obj1->getIdAttribute() == obj2->getIdAttribute()) {
+            if (obj1->getId() == obj2->getId()) {
+                if (obj1->getName() == obj2->getName()) {
+                    return obj1->getMetaId() < obj2->getMetaId();
+                }
+                else {
+                    return obj1->getName() < obj2->getName();
+                }
+            }
+            else {
+                return obj1->getId() < obj2->getId();
+            }
+        }
+        else {
+            return obj1->getIdAttribute() < obj2->getIdAttribute();
+        }
     }
 };
 

--- a/src/sbml/ListOf.cpp
+++ b/src/sbml/ListOf.cpp
@@ -685,6 +685,23 @@ ListOf::setExplicitlyListed(bool value)
   mExplicitlyListed = value;
 }
 
+struct ListOfComparator
+{
+    // Compare 2 SBase* objects using name
+    bool operator ()(const SBase* obj1, const SBase* obj2)
+    {
+        if (obj1 == NULL || obj2 == NULL) {
+            return true;
+        }
+        return obj1->getId() < obj2->getId();
+    }
+};
+
+void ListOf::sort()
+{
+    std::sort(mItems.begin(), mItems.end(), ListOfComparator());
+}
+
 
 /** @endcond */
 

--- a/src/sbml/ListOf.cpp
+++ b/src/sbml/ListOf.cpp
@@ -692,25 +692,27 @@ struct ListOfComparator
     // from 'getId'), then name, then metaid.
     bool operator ()(const SBase* obj1, const SBase* obj2)
     {
-        if (obj1 == NULL || obj2 == NULL) {
+        if (obj1 == NULL || obj2 == NULL) 
+        {
             return true;
         }
-        if (obj1->getIdAttribute() == obj2->getIdAttribute()) {
-            if (obj1->getId() == obj2->getId()) {
-                if (obj1->getName() == obj2->getName()) {
+
+        if (obj1->getIdAttribute() == obj2->getIdAttribute()) 
+        {
+            if (obj1->getId() == obj2->getId()) 
+            {
+                if (obj1->getName() == obj2->getName()) 
+                {
                     return obj1->getMetaId() < obj2->getMetaId();
                 }
-                else {
-                    return obj1->getName() < obj2->getName();
-                }
+
+                return obj1->getName() < obj2->getName();
             }
-            else {
-                return obj1->getId() < obj2->getId();
-            }
+
+            return obj1->getId() < obj2->getId();
         }
-        else {
-            return obj1->getIdAttribute() < obj2->getIdAttribute();
-        }
+        
+        return obj1->getIdAttribute() < obj2->getIdAttribute();
     }
 };
 

--- a/src/sbml/ListOf.h
+++ b/src/sbml/ListOf.h
@@ -606,6 +606,15 @@ public:
   /** @endcond */
 
   /** @cond doxygenLibsbmlInternal */
+  /**
+   * Sort the ListOf by the element SId.
+   * 
+   * If the SIds are not set (or equal), sort by the result of 
+   * the 'getId' function (which is different from the 'id' 
+   * attribute for some elements such as rules), then by the
+   * 'name' attribute, and finally by the metaids.  If none 
+   * are set, the items are considered to be sorted.
+   */
   void sort();
   /** @endcond */
 

--- a/src/sbml/ListOf.h
+++ b/src/sbml/ListOf.h
@@ -604,6 +604,11 @@ public:
 
 
   /** @endcond */
+
+  /** @cond doxygenLibsbmlInternal */
+  void sort();
+  /** @endcond */
+
 protected:
   /** @cond doxygenLibsbmlInternal */
   typedef std::vector<SBase*>           ListItem;

--- a/src/sbml/test/TestListOf.c
+++ b/src/sbml/test/TestListOf.c
@@ -243,6 +243,74 @@ START_TEST(test_ListOf_sort)
 END_TEST
 
 
+START_TEST(test_ListOf_sort_meta)
+{
+    ListOf_t* lo = (ListOf_t*)ListOf_create(2, 4);
+
+    Species_t* sp = Species_create(2, 4);
+    sp->setMetaId("z");
+    ListOf_append(lo, sp);
+
+    sp->setMetaId("a");
+    ListOf_append(lo, sp);
+
+    sp->setMetaId("n");
+    ListOf_append(lo, sp);
+
+    lo->sort();
+    SBase_t* child = ListOf_get(lo, 0);
+    fail_unless(child->getMetaId() == "a");
+    child = ListOf_get(lo, 1);
+    fail_unless(child->getMetaId() == "n");
+    child = ListOf_get(lo, 2);
+    fail_unless(child->getMetaId() == "z");
+
+    Species_free(sp);
+    ListOf_free(lo);
+}
+END_TEST
+
+
+START_TEST(test_ListOf_sort_rules)
+{
+    ListOf_t* lo = (ListOf_t*)ListOf_create(3, 2);
+
+    Rule_t* rr = Rule_createRate(3, 2);
+    rr->setVariable("z");
+    rr->setIdAttribute("a");
+    ListOf_append(lo, rr);
+
+    rr->setVariable("a");
+    rr->setIdAttribute("z");
+    ListOf_append(lo, rr);
+
+    rr->setVariable("q");
+    rr->unsetIdAttribute();
+    ListOf_append(lo, rr);
+
+    rr->setVariable("n");
+    ListOf_append(lo, rr);
+
+    lo->sort();
+    SBase_t* child = ListOf_get(lo, 0);
+    fail_unless(child->getIdAttribute() == "");
+    fail_unless(child->getId() == "n");
+    child = ListOf_get(lo, 1);
+    fail_unless(child->getIdAttribute() == "");
+    fail_unless(child->getId() == "q");
+    child = ListOf_get(lo, 2);
+    fail_unless(child->getIdAttribute() == "a");
+    fail_unless(child->getId() == "z");
+    child = ListOf_get(lo, 3);
+    fail_unless(child->getIdAttribute() == "z");
+    fail_unless(child->getId() == "a");
+
+    Rule_free(rr);
+    ListOf_free(lo);
+}
+END_TEST
+
+
 
 
 Suite *
@@ -258,6 +326,8 @@ create_suite_ListOf (void)
   tcase_add_test(tcase, test_ListOf_clear     );
   tcase_add_test(tcase, test_ListOf_append    );
   tcase_add_test(tcase, test_ListOf_sort      );
+  tcase_add_test(tcase, test_ListOf_sort_meta );
+  tcase_add_test(tcase, test_ListOf_sort_rules);
 
   suite_add_tcase(suite, tcase);
 

--- a/src/sbml/test/TestListOf.c
+++ b/src/sbml/test/TestListOf.c
@@ -215,6 +215,36 @@ START_TEST (test_ListOf_append)
 }
 END_TEST
 
+START_TEST(test_ListOf_sort)
+{
+    ListOf_t* lo = (ListOf_t*)ListOf_create(2, 4);
+
+    Species_t* sp = Species_create(2, 4);
+    sp->setId("z");
+    ListOf_append(lo, sp);
+
+    sp->setId("a");
+    ListOf_append(lo, sp);
+
+    sp->setId("n");
+    ListOf_append(lo, sp);
+
+    lo->sort();
+    SBase_t* child = ListOf_get(lo, 0);
+    fail_unless(child->getId() == "a");
+    child = ListOf_get(lo, 1);
+    fail_unless(child->getId() == "n");
+    child = ListOf_get(lo, 2);
+    fail_unless(child->getId() == "z");
+
+    Species_free(sp);
+    ListOf_free(lo);
+}
+END_TEST
+
+
+
+
 Suite *
 create_suite_ListOf (void) 
 { 
@@ -227,7 +257,8 @@ create_suite_ListOf (void)
   tcase_add_test(tcase, test_ListOf_remove    );
   tcase_add_test(tcase, test_ListOf_clear     );
   tcase_add_test(tcase, test_ListOf_append    );
- 
+  tcase_add_test(tcase, test_ListOf_sort      );
+
   suite_add_tcase(suite, tcase);
 
   return suite;


### PR DESCRIPTION
In my tests of Antimony, I round-trip stuff through SBML, and the order sometimes changes.  I need a function like this to sort the lists so I can do simple before-and-after comparisons.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ X] I have updated all documentation necessary.
- [ X] I have checked spelling in (new) comments.

## Testing
- [X] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested -->

