### PR TITLE
Fix the allowed argument list for cauchy and laplace.

### DIFF
--- a/src/sbml/packages/distrib/extension/DistribASTPlugin.cpp
+++ b/src/sbml/packages/distrib/extension/DistribASTPlugin.cpp
@@ -54,16 +54,17 @@ LIBSBML_CPP_NAMESPACE_BEGIN
 void
 DistribASTPlugin::populateNodeTypes()
 {
-  vector<unsigned int> one, two, onethree, twofour, onetwofour;
+  vector<unsigned int> one, two, onethree, twofour, twoonefour;
   one.push_back(1);
   two.push_back(2);
   onethree.push_back(1);
   onethree.push_back(3);
   twofour.push_back(2);
   twofour.push_back(4);
-  onetwofour.push_back(1);
-  onetwofour.push_back(2);
-  onetwofour.push_back(4);
+  //The first argument should be 'the number of allowed arguments in the old annotation version'.
+  twoonefour.push_back(2);
+  twoonefour.push_back(1);
+  twoonefour.push_back(4);
 
   ASTNodeValues_t node;
   node.type = AST_DISTRIB_FUNCTION_NORMAL;
@@ -107,7 +108,7 @@ DistribASTPlugin::populateNodeTypes()
   node.csymbolURL = "http://www.sbml.org/sbml/symbols/distrib/cauchy";
   node.isFunction = true;
   node.allowedChildrenType = ALLOWED_CHILDREN_EXACTLY;
-  node.numAllowedChildren = onetwofour;
+  node.numAllowedChildren = twoonefour;
 
   mPkgASTNodeValues.push_back(node);
 
@@ -143,7 +144,7 @@ DistribASTPlugin::populateNodeTypes()
   node.csymbolURL = "http://www.sbml.org/sbml/symbols/distrib/laplace";
   node.isFunction = true;
   node.allowedChildrenType = ALLOWED_CHILDREN_EXACTLY;
-  node.numAllowedChildren = onetwofour;
+  node.numAllowedChildren = twoonefour;
 
   mPkgASTNodeValues.push_back(node);
 


### PR DESCRIPTION
The distrib-to-annotation converter assumes that the first element in the 'number of allowed arguments' list is 'the number of children allowed in the old annotations-only version'.  Since that's '2' for cauchy and laplace, the argument list for those functions is changed here to [2, 1, 4] from [1, 2, 4], so that the converter works.

This is tested in test_distrib_util, though I'm not sure if it's being run right now, since it was failing?

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ X] I have updated all documentation necessary.
- [ X] I have checked spelling in (new) comments.

## Testing
- [X] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested -->

