### PR TITLE
Issue 474 distrib flattening

### DIFF
--- a/src/sbml/SBase.cpp
+++ b/src/sbml/SBase.cpp
@@ -236,10 +236,8 @@ SBase::prependStringToAllIdentifiers(const std::string& prefix)
   }
 
 
-  // for historical reasons some things like Rules will
-  // return an id but not set one
-  // so if we are going to bail on this we should have done
-  // anything else first
+  // Must use 'IdAttribute' functions since some elements like rules 
+  // return a different value for 'Id' functions alone.
 
   if (isSetIdAttribute())
   {

--- a/src/sbml/packages/comp/extension/CompModelPlugin.cpp
+++ b/src/sbml/packages/comp/extension/CompModelPlugin.cpp
@@ -651,16 +651,12 @@ void CompModelPlugin::resetPorts()
       port->unsetMetaIdRef();
       port->unsetUnitRef();
       int type = referenced->getTypeCode();
-      if (referenced->isSetId() && 
-          type != SBML_INITIAL_ASSIGNMENT &&
-          type != SBML_ASSIGNMENT_RULE &&
-          type != SBML_RATE_RULE &&
-          type != SBML_EVENT_ASSIGNMENT) {
+      if (referenced->isSetIdAttribute()) {
         if (type==SBML_UNIT_DEFINITION) {
-          port->setUnitRef(referenced->getId());
+          port->setUnitRef(referenced->getIdAttribute());
         }
         else {
-          port->setIdRef(referenced->getId());
+          port->setIdRef(referenced->getIdAttribute());
         }
       }
       else if (referenced->isSetMetaId()) {
@@ -895,8 +891,8 @@ int CompModelPlugin::saveAllReferencedElements(set<SBase*> uniqueRefs, set<SBase
             if (uniqueRefs.insert(rbParent).second == false) {
               if (doc) {
                 string error = "Error discovered in CompModelPlugin::saveAllReferencedElements when checking " + modname + ": a <" + rbParent->getElementName() + "> ";
-                if (direct->isSetId()) {
-                  error += "with the id '" + rbParent->getId() + "'";
+                if (direct->isSetIdAttribute()) {
+                  error += "with the id '" + rbParent->getIdAttribute() + "'";
                   if (rbParent->isSetMetaId()) {
                     error += ", and the metaid '" + rbParent->getMetaId() + "'";
                   }
@@ -930,8 +926,8 @@ int CompModelPlugin::saveAllReferencedElements(set<SBase*> uniqueRefs, set<SBase
                   error += "multiple <deletion>, <replacedElement>, and/or <port> elements";
                 }
                 error += " point directly to the <" + direct->getElementName() + "> ";
-                if (direct->isSetId()) {
-                  error += "with the id '" + direct->getId() + "'";
+                if (direct->isSetIdAttribute()) {
+                  error += "with the id '" + direct->getIdAttribute() + "'";
                   if (direct->isSetMetaId()) {
                     error += ", and the metaid '" + direct->getMetaId() + "'";
                   }
@@ -1087,7 +1083,7 @@ void CompModelPlugin::findUniqueSubmodPrefixes(vector<string>& submodids, List* 
           assert(false);
           continue;
         }
-        if (element->isSetId() && element->getId().find(fullprefix.str())==0) {
+        if (element->isSetIdAttribute() && element->getIdAttribute().find(fullprefix.str())==0) {
           done = false;
           continue;
         }

--- a/src/sbml/packages/comp/extension/test/test-data/exchangetest2_flat_ports.xml
+++ b/src/sbml/packages/comp/extension/test/test-data/exchangetest2_flat_ports.xml
@@ -233,7 +233,11 @@
         <math xmlns="http://www.w3.org/1998/Math/MathML">
           <apply>
             <times/>
-            <ci> X </ci>
+            <apply>
+              <divide/>
+              <ci> X </ci>
+              <ci> cf </ci>
+            </apply>
             <ci> cf </ci>
           </apply>
         </math>
@@ -277,7 +281,11 @@
         </trigger>
         <priority>
           <math xmlns="http://www.w3.org/1998/Math/MathML">
-            <ci> Q </ci>
+            <apply>
+              <divide/>
+              <ci> Q </ci>
+              <ci> cf </ci>
+            </apply>
           </math>
         </priority>
         <listOfEventAssignments>
@@ -304,7 +312,11 @@
         </trigger>
         <priority>
           <math xmlns="http://www.w3.org/1998/Math/MathML">
-            <ci> R </ci>
+            <apply>
+              <divide/>
+              <ci> R </ci>
+              <ci> cf </ci>
+            </apply>
           </math>
         </priority>
         <listOfEventAssignments>

--- a/src/sbml/packages/comp/util/test/test-data/distrib_deletion.xml
+++ b/src/sbml/packages/comp/util/test/test-data/distrib_deletion.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created by libAntimony version v2.13.0 with libSBML version 5.18.1. -->
+<sbml xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" xmlns:distrib="http://www.sbml.org/sbml/level3/version1/distrib/version1" xmlns="http://www.sbml.org/sbml/level3/version2/core" level="3" version="2" comp:required="true" distrib:required="true">
+  <model metaid="bar" id="bar">
+    <comp:listOfSubmodels>
+      <comp:submodel comp:id="A" comp:modelRef="foo">
+        <comp:listOfDeletions>
+          <comp:deletion comp:idRef="a_mean"/>
+        </comp:listOfDeletions>
+      </comp:submodel>
+    </comp:listOfSubmodels>
+  </model>
+  <comp:listOfModelDefinitions>
+    <comp:modelDefinition metaid="foo" id="foo">
+      <listOfParameters>
+        <parameter id="a" constant="true">
+          <distrib:listOfUncertainties>
+            <distrib:uncertainty>
+              <distrib:uncertParameter distrib:id="a_mean" distrib:value="5" distrib:type="mean"/>
+            </distrib:uncertainty>
+          </distrib:listOfUncertainties>
+        </parameter>
+      </listOfParameters>
+    </comp:modelDefinition>
+  </comp:listOfModelDefinitions>
+</sbml>

--- a/src/sbml/packages/comp/util/test/test-data/distrib_deletion2.xml
+++ b/src/sbml/packages/comp/util/test/test-data/distrib_deletion2.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created by libAntimony version v2.13.0 with libSBML version 5.18.1. -->
+<sbml xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" xmlns:distrib="http://www.sbml.org/sbml/level3/version1/distrib/version1" xmlns="http://www.sbml.org/sbml/level3/version2/core" level="3" version="2" comp:required="true" distrib:required="true">
+  <model metaid="bar" id="bar">
+    <comp:listOfSubmodels>
+      <comp:submodel comp:id="A" comp:modelRef="foo">
+        <comp:listOfDeletions>
+          <comp:deletion comp:idRef="uncert1"/>
+        </comp:listOfDeletions>
+      </comp:submodel>
+    </comp:listOfSubmodels>
+  </model>
+  <comp:listOfModelDefinitions>
+    <comp:modelDefinition metaid="foo" id="foo">
+      <listOfParameters>
+        <parameter id="a" constant="true">
+          <distrib:listOfUncertainties>
+            <distrib:uncertainty distrib:id="uncert1">
+              <distrib:uncertParameter distrib:id="a_mean" distrib:value="5" distrib:type="mean"/>
+            </distrib:uncertainty>
+          </distrib:listOfUncertainties>
+        </parameter>
+      </listOfParameters>
+    </comp:modelDefinition>
+  </comp:listOfModelDefinitions>
+</sbml>

--- a/src/sbml/packages/comp/util/test/test-data/distrib_deletion2_flat.xml
+++ b/src/sbml/packages/comp/util/test/test-data/distrib_deletion2_flat.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sbml xmlns:distrib="http://www.sbml.org/sbml/level3/version1/distrib/version1" xmlns="http://www.sbml.org/sbml/level3/version2/core" level="3" version="2" distrib:required="true">
+  <model metaid="bar" id="bar">
+    <listOfParameters>
+      <parameter id="A__a" constant="true"/>
+    </listOfParameters>
+  </model>
+</sbml>

--- a/src/sbml/packages/comp/util/test/test-data/distrib_deletion_flat.xml
+++ b/src/sbml/packages/comp/util/test/test-data/distrib_deletion_flat.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sbml xmlns:distrib="http://www.sbml.org/sbml/level3/version1/distrib/version1" xmlns="http://www.sbml.org/sbml/level3/version2/core" level="3" version="2" distrib:required="true">
+  <model metaid="bar" id="bar">
+    <listOfParameters>
+      <parameter id="A__a" constant="true">
+        <distrib:listOfUncertainties>
+          <distrib:uncertainty/>
+        </distrib:listOfUncertainties>
+      </parameter>
+    </listOfParameters>
+  </model>
+</sbml>

--- a/src/sbml/packages/comp/util/test/test-data/distrib_mathml.xml
+++ b/src/sbml/packages/comp/util/test/test-data/distrib_mathml.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created by libAntimony version v2.13.0 with libSBML version 5.18.1. -->
+<sbml xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" xmlns:distrib="http://www.sbml.org/sbml/level3/version1/distrib/version1" xmlns="http://www.sbml.org/sbml/level3/version2/core" level="3" version="2" comp:required="true" distrib:required="true">
+  <model metaid="parent" id="parent">
+    <comp:listOfSubmodels>
+      <comp:submodel comp:id="mod" comp:modelRef="test"/>
+    </comp:listOfSubmodels>
+  </model>
+  <comp:listOfModelDefinitions>
+    <comp:modelDefinition metaid="test" id="test">
+      <listOfParameters>
+        <parameter id="A" constant="true"/>
+      </listOfParameters>
+      <listOfInitialAssignments>
+        <initialAssignment symbol="A">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/distrib/normal"> normal </csymbol>
+              <cn type="integer"> 1 </cn>
+              <cn> 0.5 </cn>
+            </apply>
+          </math>
+        </initialAssignment>
+      </listOfInitialAssignments>
+    </comp:modelDefinition>
+  </comp:listOfModelDefinitions>
+</sbml>

--- a/src/sbml/packages/comp/util/test/test-data/distrib_mathml_flat.xml
+++ b/src/sbml/packages/comp/util/test/test-data/distrib_mathml_flat.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sbml xmlns:distrib="http://www.sbml.org/sbml/level3/version1/distrib/version1" xmlns="http://www.sbml.org/sbml/level3/version2/core" level="3" version="2" distrib:required="true">
+  <model metaid="parent" id="parent">
+    <listOfParameters>
+      <parameter id="mod__A" constant="true"/>
+    </listOfParameters>
+    <listOfInitialAssignments>
+      <initialAssignment symbol="mod__A">
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <apply>
+            <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/distrib/normal"> normal </csymbol>
+            <cn type="integer"> 1 </cn>
+            <cn> 0.5 </cn>
+          </apply>
+        </math>
+      </initialAssignment>
+    </listOfInitialAssignments>
+  </model>
+</sbml>

--- a/src/sbml/packages/comp/util/test/test-data/distrib_replacedBy.xml
+++ b/src/sbml/packages/comp/util/test/test-data/distrib_replacedBy.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created by libAntimony version v2.13.0 with libSBML version 5.18.1. -->
+<sbml xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" xmlns:distrib="http://www.sbml.org/sbml/level3/version1/distrib/version1" xmlns="http://www.sbml.org/sbml/level3/version2/core" level="3" version="2" comp:required="true" distrib:required="true">
+  <model metaid="bar" id="bar">
+    <listOfParameters>
+      <parameter id="b" constant="true">
+        <comp:replacedBy comp:idRef="a" comp:submodelRef="A"/>
+        <distrib:listOfUncertainties>
+          <distrib:uncertainty>
+            <distrib:uncertParameter distrib:value="3" distrib:type="mean"/>
+          </distrib:uncertainty>
+        </distrib:listOfUncertainties>
+      </parameter>
+    </listOfParameters>
+    <comp:listOfSubmodels>
+      <comp:submodel comp:id="A" comp:modelRef="foo"/>
+    </comp:listOfSubmodels>
+  </model>
+  <comp:listOfModelDefinitions>
+    <comp:modelDefinition metaid="foo" id="foo">
+      <listOfParameters>
+        <parameter id="a" constant="true">
+          <distrib:listOfUncertainties>
+            <distrib:uncertainty>
+              <distrib:uncertParameter distrib:value="5" distrib:type="mean"/>
+            </distrib:uncertainty>
+          </distrib:listOfUncertainties>
+        </parameter>
+      </listOfParameters>
+    </comp:modelDefinition>
+  </comp:listOfModelDefinitions>
+</sbml>

--- a/src/sbml/packages/comp/util/test/test-data/distrib_replacedBy_flat.xml
+++ b/src/sbml/packages/comp/util/test/test-data/distrib_replacedBy_flat.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sbml xmlns:distrib="http://www.sbml.org/sbml/level3/version1/distrib/version1" xmlns="http://www.sbml.org/sbml/level3/version2/core" level="3" version="2" distrib:required="true">
+  <model metaid="bar" id="bar">
+    <listOfParameters>
+      <parameter id="b" constant="true">
+        <distrib:listOfUncertainties>
+          <distrib:uncertainty>
+            <distrib:uncertParameter distrib:value="5" distrib:type="mean"/>
+          </distrib:uncertainty>
+        </distrib:listOfUncertainties>
+      </parameter>
+    </listOfParameters>
+  </model>
+</sbml>

--- a/src/sbml/packages/comp/util/test/test-data/distrib_uncert1.xml
+++ b/src/sbml/packages/comp/util/test/test-data/distrib_uncert1.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created by libAntimony version v2.13.0 with libSBML version 5.18.1. -->
+<sbml xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" xmlns:distrib="http://www.sbml.org/sbml/level3/version1/distrib/version1" xmlns="http://www.sbml.org/sbml/level3/version2/core" level="3" version="2" comp:required="true" distrib:required="true">
+  <model metaid="bar" id="bar">
+    <comp:listOfSubmodels>
+      <comp:submodel comp:id="A" comp:modelRef="foo"/>
+    </comp:listOfSubmodels>
+  </model>
+  <comp:listOfModelDefinitions>
+    <comp:modelDefinition metaid="foo" id="foo">
+      <listOfParameters>
+        <parameter id="a" constant="true">
+          <distrib:listOfUncertainties>
+            <distrib:uncertainty>
+              <distrib:uncertParameter distrib:value="5" distrib:type="mean"/>
+            </distrib:uncertainty>
+          </distrib:listOfUncertainties>
+        </parameter>
+      </listOfParameters>
+    </comp:modelDefinition>
+  </comp:listOfModelDefinitions>
+</sbml>

--- a/src/sbml/packages/comp/util/test/test-data/distrib_uncert1_flat.xml
+++ b/src/sbml/packages/comp/util/test/test-data/distrib_uncert1_flat.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sbml xmlns:distrib="http://www.sbml.org/sbml/level3/version1/distrib/version1" xmlns="http://www.sbml.org/sbml/level3/version2/core" level="3" version="2" distrib:required="true">
+  <model metaid="bar" id="bar">
+    <listOfParameters>
+      <parameter id="A__a" constant="true">
+        <distrib:listOfUncertainties>
+          <distrib:uncertainty>
+            <distrib:uncertParameter distrib:value="5" distrib:type="mean"/>
+          </distrib:uncertainty>
+        </distrib:listOfUncertainties>
+      </parameter>
+    </listOfParameters>
+  </model>
+</sbml>

--- a/src/sbml/packages/comp/util/test/test-data/distrib_uncert2.xml
+++ b/src/sbml/packages/comp/util/test/test-data/distrib_uncert2.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Created by libAntimony version v2.13.0 with libSBML version 5.18.1. -->
+<sbml xmlns:comp="http://www.sbml.org/sbml/level3/version1/comp/version1" xmlns:distrib="http://www.sbml.org/sbml/level3/version1/distrib/version1" xmlns="http://www.sbml.org/sbml/level3/version2/core" level="3" version="2" comp:required="true" distrib:required="true">
+  <model metaid="bar" id="bar">
+    <listOfParameters>
+      <parameter id="b" constant="true">
+        <comp:listOfReplacedElements>
+          <comp:replacedElement comp:idRef="a" comp:submodelRef="A"/>
+        </comp:listOfReplacedElements>
+        <distrib:listOfUncertainties>
+          <distrib:uncertainty>
+            <distrib:uncertParameter distrib:value="3" distrib:type="mean"/>
+          </distrib:uncertainty>
+        </distrib:listOfUncertainties>
+      </parameter>
+    </listOfParameters>
+    <comp:listOfSubmodels>
+      <comp:submodel comp:id="A" comp:modelRef="foo"/>
+    </comp:listOfSubmodels>
+  </model>
+  <comp:listOfModelDefinitions>
+    <comp:modelDefinition metaid="foo" id="foo">
+      <listOfParameters>
+        <parameter id="a" constant="true">
+          <distrib:listOfUncertainties>
+            <distrib:uncertainty>
+              <distrib:uncertParameter distrib:value="5" distrib:type="mean"/>
+            </distrib:uncertainty>
+          </distrib:listOfUncertainties>
+        </parameter>
+      </listOfParameters>
+    </comp:modelDefinition>
+  </comp:listOfModelDefinitions>
+</sbml>

--- a/src/sbml/packages/comp/util/test/test-data/distrib_uncert2_flat.xml
+++ b/src/sbml/packages/comp/util/test/test-data/distrib_uncert2_flat.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sbml xmlns:distrib="http://www.sbml.org/sbml/level3/version1/distrib/version1" xmlns="http://www.sbml.org/sbml/level3/version2/core" level="3" version="2" distrib:required="true">
+  <model metaid="bar" id="bar">
+    <listOfParameters>
+      <parameter id="b" constant="true">
+        <distrib:listOfUncertainties>
+          <distrib:uncertainty>
+            <distrib:uncertParameter distrib:value="3" distrib:type="mean"/>
+          </distrib:uncertainty>
+        </distrib:listOfUncertainties>
+      </parameter>
+    </listOfParameters>
+  </model>
+</sbml>

--- a/src/sbml/packages/comp/util/test/test-data/exchangetest2_flat.xml
+++ b/src/sbml/packages/comp/util/test/test-data/exchangetest2_flat.xml
@@ -233,7 +233,11 @@
         <math xmlns="http://www.w3.org/1998/Math/MathML">
           <apply>
             <times/>
-            <ci> X </ci>
+            <apply>
+              <divide/>
+              <ci> X </ci>
+              <ci> cf </ci>
+            </apply>
             <ci> cf </ci>
           </apply>
         </math>
@@ -277,7 +281,11 @@
         </trigger>
         <priority>
           <math xmlns="http://www.w3.org/1998/Math/MathML">
-            <ci> Q </ci>
+            <apply>
+              <divide/>
+              <ci> Q </ci>
+              <ci> cf </ci>
+            </apply>
           </math>
         </priority>
         <listOfEventAssignments>
@@ -304,7 +312,11 @@
         </trigger>
         <priority>
           <math xmlns="http://www.w3.org/1998/Math/MathML">
-            <ci> R </ci>
+            <apply>
+              <divide/>
+              <ci> R </ci>
+              <ci> cf </ci>
+            </apply>
           </math>
         </priority>
         <listOfEventAssignments>

--- a/src/sbml/packages/distrib/extension/DistribSBMLDocumentPlugin.cpp
+++ b/src/sbml/packages/distrib/extension/DistribSBMLDocumentPlugin.cpp
@@ -138,7 +138,7 @@ DistribSBMLDocumentPlugin::accept(SBMLVisitor& v) const
 bool
 DistribSBMLDocumentPlugin::isCompFlatteningImplemented() const
 {
-  return false;
+  return true;
 }
 
 /** @endcond */

--- a/src/sbml/packages/distrib/sbml/UncertParameter.cpp
+++ b/src/sbml/packages/distrib/sbml/UncertParameter.cpp
@@ -769,23 +769,54 @@ UncertParameter::removeUncertParameter(unsigned int n)
 }
 
 
-/*
- * @copydoc doc_renamesidref_common
- */
 void
 UncertParameter::renameSIdRefs(const std::string& oldid,
                                const std::string& newid)
 {
+  DistribBase::renameSIdRefs(oldid, newid);
   if (isSetVar() && mVar == oldid)
   {
     setVar(newid);
   }
 
-  if (isSetUnits() && mUnits == oldid)
+  if (isSetMath()) 
   {
-    setUnits(newid);
+      mMath->renameSIdRefs(oldid, newid);
   }
 }
+
+void
+UncertParameter::renameUnitSIdRefs(const std::string& oldid, const std::string& newid)
+{
+    DistribBase::renameUnitSIdRefs(oldid, newid);
+
+    if (isSetUnits() && mUnits == oldid)
+    {
+        setUnits(newid);
+    }
+
+    if (isSetMath()) 
+    {
+        mMath->renameUnitSIdRefs(oldid, newid);
+    }
+}
+
+/** @cond doxygenLibsbmlInternal */
+void
+UncertParameter::replaceSIDWithFunction(const std::string& id, const ASTNode* function)
+{
+    if (isSetMath()) {
+        if (mMath->getType() == AST_NAME && mMath->getName() == id) {
+            delete mMath;
+            mMath = function->deepCopy();
+        }
+        else {
+            mMath->replaceIDWithFunction(id, function);
+        }
+    }
+}
+/** @endcond */
+
 
 
 /*

--- a/src/sbml/packages/distrib/sbml/UncertParameter.h
+++ b/src/sbml/packages/distrib/sbml/UncertParameter.h
@@ -734,6 +734,20 @@ public:
 
 
   /**
+   * @copydoc doc_renameunitsidref_common
+   */
+  virtual void renameUnitSIdRefs(const std::string& oldid, const std::string& newid);
+
+
+  /** @cond doxygenLibsbmlInternal */
+  /**
+   * Replace all nodes with the name 'id' from the child 'math' object with the provided function.
+   *
+   */
+  virtual void replaceSIDWithFunction(const std::string& id, const ASTNode* function);
+  /** @endcond */
+
+  /**
    * Returns the XML element name of this UncertParameter object.
    *
    * For UncertParameter, the XML element name is always @c "uncertParameter".

--- a/src/sbml/packages/distrib/sbml/UncertSpan.cpp
+++ b/src/sbml/packages/distrib/sbml/UncertSpan.cpp
@@ -369,6 +369,7 @@ UncertSpan::unsetValueUpper()
 void
 UncertSpan::renameSIdRefs(const std::string& oldid, const std::string& newid)
 {
+  UncertParameter::renameSIdRefs(oldid, newid);
   if (isSetVarLower() && mVarLower == oldid)
   {
     setVarLower(newid);


### PR DESCRIPTION
This addresses https://sourceforge.net/p/sbml/libsbml/474/?limit=25 and implements and tests distrib/comp flattening.

Something is still wonky with the flattening converter, because I could not get things to work as expected when 'distrib' was *not* enabled in the libsbml build:  it ends up coming through as an unknown package, but telling the converter to strip unflattenable packages apparently doesn't include unknown packages.  But that aside, everything else is now working and tested.

There were also two flattening tests that were failing that this commit fixes.  This means that travis isn't testing comp flattening, and may not be testing the packages at all?  That should also be fixed, but not here.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have updated all documentation necessary.
- [ ] I have checked spelling in (new) comments.

## Testing
- [X] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested -->

