### PR TITLE
Fix spatial tests so they pass when libsbml is compiled without zlib.

### DIFF
--- a/src/sbml/packages/spatial/common/CompressionUtil.cpp
+++ b/src/sbml/packages/spatial/common/CompressionUtil.cpp
@@ -41,6 +41,7 @@
 #include <sstream>
 #include <iomanip>
 #include <sbml/compress/CompressCommon.h>
+#include <sbml/common/operationReturnValues.h>
 
 #ifdef USE_ZLIB
 #include <zlib.h>
@@ -102,13 +103,14 @@ std::string charIntsToString(const int * array, size_t length)
   return ret;
 }
 
-void compress_data(void* data, size_t length, int level, unsigned char*& result, int& outLength)
+int compress_data(void* data, size_t length, int level, unsigned char*& result, int& outLength)
 {
 #ifndef USE_ZLIB
   // throwing an exception won't help our users, better set the result array and length to NULL. 
   // throw ZlibNotLinked();
   outLength = 0;
   result = NULL;
+  return LIBSBML_OPERATION_FAILED;
 #else
   std::vector<char> buffer;
 
@@ -168,6 +170,7 @@ void compress_data(void* data, size_t length, int level, unsigned char*& result,
     return;
   for (int i = 0; i < outLength; i++)
     result[i] = (unsigned char)buffer[i];
+  return LIBSBML_OPERATION_SUCCESS
 #endif
 }
 

--- a/src/sbml/packages/spatial/common/CompressionUtil.h
+++ b/src/sbml/packages/spatial/common/CompressionUtil.h
@@ -119,7 +119,7 @@ extern std::string vectorToString(const std::vector<double>& vec);
 extern std::string arrayToString(const unsigned char* array, size_t length);
 extern std::string arrayToString(const double* array, size_t length);
 extern std::string charIntsToString(const int* array, size_t length);
-extern void compress_data(void* data, size_t length, int level, unsigned char*& result, int& outLength);
+extern int compress_data(void* data, size_t length, int level, unsigned char*& result, int& outLength);
 extern void uncompress_data(void* data, size_t length, double*& result, size_t& outLength);
 extern void uncompress_data(void* data, size_t length, int*& result, size_t& outLength);
 extern void copySampleArrays(double* &target, size_t& targetLength, double* source, size_t sourceLength);

--- a/src/sbml/packages/spatial/sbml/ParametricObject.cpp
+++ b/src/sbml/packages/spatial/sbml/ParametricObject.cpp
@@ -1748,17 +1748,19 @@ int ParametricObject::compress(int level)
 {
   freeCompressed();
   unsigned char* result; int length;
-  compress_data(const_cast<char*>(mPointIndex.c_str()), mPointIndex.length(), level, result, length);
+  int ret = compress_data(const_cast<char*>(mPointIndex.c_str()), mPointIndex.length(), level, result, length);
 
-  mPointIndex = arrayToString(result, length);
-  copySampleArrays(mPointIndexCompressed, mPointIndexCompressedLength, result, length);
+  if (ret == LIBSBML_OPERATION_SUCCESS)
+  {
+      mPointIndex = arrayToString(result, length);
+      copySampleArrays(mPointIndexCompressed, mPointIndexCompressedLength, result, length);
 
-  free(result);
+      free(result);
 
-  mCompression = SPATIAL_COMPRESSIONKIND_DEFLATED;
-  mPointIndexLength = mPointIndexCompressedLength;
-
-  return LIBSBML_OPERATION_SUCCESS;
+      mCompression = SPATIAL_COMPRESSIONKIND_DEFLATED;
+      mPointIndexLength = mPointIndexCompressedLength;
+  }
+  return ret;
 }
 
 unsigned int

--- a/src/sbml/packages/spatial/sbml/ParametricObject.h
+++ b/src/sbml/packages/spatial/sbml/ParametricObject.h
@@ -1259,8 +1259,13 @@ public:
    * compresses the samples stored, if the flag is set to UNCOMPRESSED, then 
    * changes the flag to compressed. 
    * 
+   * Returns failure if libsbml was built without zlib linked.
+   *
    * @param compression level 0 (store) ... 9 (max compression)
    * 
+   * @copydetails doc_returns_success_code
+   * @li @sbmlconstant{LIBSBML_OPERATION_SUCCESS, OperationReturnValues_t}
+   * @li @sbmlconstant{LIBSBML_OPERATION_FAILED, OperationReturnValues_t}
    */
   int compress(int level);
 

--- a/src/sbml/packages/spatial/sbml/SampledField.cpp
+++ b/src/sbml/packages/spatial/sbml/SampledField.cpp
@@ -2155,15 +2155,19 @@ int SampledField::compress(int level)
 {
   freeCompressed();
   unsigned char* result; int length;
-  compress_data(const_cast<char*>(mSamples.c_str()), mSamples.length(), level, result, length);
+  int ret = compress_data(const_cast<char*>(mSamples.c_str()), mSamples.length(), level, result, length);
 
-  mSamples = arrayToString(result, length);
-  copySampleArrays(mSamplesCompressed, mSamplesCompressedLength, result, length);
+  if (ret == LIBSBML_OPERATION_SUCCESS)
+  {
+      mSamples = arrayToString(result, length);
+      copySampleArrays(mSamplesCompressed, mSamplesCompressedLength, result, length);
 
-  free(result);
+      free(result);
 
-  setSamplesLength(mSamplesCompressedLength);
-  return setCompression(SPATIAL_COMPRESSIONKIND_DEFLATED);
+      setSamplesLength(mSamplesCompressedLength);
+      return setCompression(SPATIAL_COMPRESSIONKIND_DEFLATED);
+  }
+  return ret;
 }
 
 unsigned int

--- a/src/sbml/packages/spatial/sbml/SampledField.h
+++ b/src/sbml/packages/spatial/sbml/SampledField.h
@@ -1467,8 +1467,13 @@ public:
    * compresses the samples stored, if the flag is set to UNCOMPRESSED, then 
    * changes the flag to compressed. 
    * 
+   * Returns failure if libsbml was built without zlib linked.
+   *
    * @param compression level 0 (store) ... 9 (max compression)
    * 
+   * @copydetails doc_returns_success_code
+   * @li @sbmlconstant{LIBSBML_OPERATION_SUCCESS, OperationReturnValues_t}
+   * @li @sbmlconstant{LIBSBML_OPERATION_FAILED, OperationReturnValues_t}
    */
   int compress(int level);
 

--- a/src/sbml/packages/spatial/sbml/SpatialPoints.cpp
+++ b/src/sbml/packages/spatial/sbml/SpatialPoints.cpp
@@ -1642,17 +1642,19 @@ int SpatialPoints::compress(int level)
 {
   freeCompressed();
   unsigned char* result; int length;
-  compress_data(const_cast<char*>(mArrayData.c_str()), mArrayData.length(), level, result, length);
+  int ret = compress_data(const_cast<char*>(mArrayData.c_str()), mArrayData.length(), level, result, length);
 
-  mArrayData = arrayToString(result, length);
-  copySampleArrays(mArrayDataCompressed, mArrayDataCompressedLength, result, length);
+  if (ret == LIBSBML_OPERATION_SUCCESS)
+  {
+      mArrayData = arrayToString(result, length);
+      copySampleArrays(mArrayDataCompressed, mArrayDataCompressedLength, result, length);
 
-  free(result);
+      free(result);
 
-  mCompression = SPATIAL_COMPRESSIONKIND_DEFLATED;
-  mArrayDataLength = mArrayDataCompressedLength;
-
-  return LIBSBML_OPERATION_SUCCESS;
+      mCompression = SPATIAL_COMPRESSIONKIND_DEFLATED;
+      mArrayDataLength = mArrayDataCompressedLength;
+  }
+  return ret;
 }
 
 unsigned int

--- a/src/sbml/packages/spatial/sbml/SpatialPoints.h
+++ b/src/sbml/packages/spatial/sbml/SpatialPoints.h
@@ -1224,8 +1224,13 @@ public:
     * compresses the samples stored, if the flag is set to UNCOMPRESSED, then 
     * changes the flag to compressed. 
     * 
+    * Returns failure if libsbml was built without zlib linked.
+    * 
     * @param compression level 0 (store) ... 9 (max compression)
     * 
+    * @copydetails doc_returns_success_code
+    * @li @sbmlconstant{LIBSBML_OPERATION_SUCCESS, OperationReturnValues_t}
+    * @li @sbmlconstant{LIBSBML_OPERATION_FAILED, OperationReturnValues_t}
     */
   int compress(int level);
 

--- a/src/sbml/packages/spatial/sbml/test/TestParametricObject.cpp
+++ b/src/sbml/packages/spatial/sbml/test/TestParametricObject.cpp
@@ -185,18 +185,22 @@ START_TEST (test_ParametricObject_compress)
   G->setId("i");
   G->setPolygonType("triangle");
   G->setDomainType("p");
+  G->setCompression("uncompressed");
 
   G->setPointIndex(points, 9);  
 
   fail_unless(G->getPointIndexLength() == 9);
   fail_unless(G->getPointIndex() == "1 2 3 2 3 1 5 2 3 ");
 
-  G->compress(9);
-
+  int ret = G->compress(9);
   S = G->toSBML();
-
+#ifdef USE_ZLIB
+  fail_unless(ret == LIBSBML_OPERATION_SUCCESS);
   fail_unless( expectedCompressed == S );
-
+#else
+  fail_unless(ret == LIBSBML_OPERATION_FAILED);
+  fail_unless(expectedUncompressed == S);
+#endif
   free(S);
   G->uncompress();
   S = G->toSBML();

--- a/src/sbml/packages/spatial/sbml/test/TestSpatialPoints.cpp
+++ b/src/sbml/packages/spatial/sbml/test/TestSpatialPoints.cpp
@@ -193,12 +193,17 @@ START_TEST (test_SpatialPoints_compress)
   fail_unless(G->getArrayDataLength() == 9);
   fail_unless(G->getArrayData() == "1 2 3 0.5 7 5.2000000000000002 -4.0099999999999998 5.5 7.7000000000000002 ");
 
-  G->compress(9);
+  int ret = G->compress(9);
 
   S = G->toSBML();
 
-  fail_unless( expectedCompressed == S );
-
+#ifdef USE_ZLIB
+  fail_unless(ret == LIBSBML_OPERATION_SUCCESS);
+  fail_unless(expectedCompressed == S);
+#else
+  fail_unless(ret == LIBSBML_OPERATION_FAILED);
+  fail_unless(expectedUncompressed == S);
+#endif
   free(S);
   G->uncompress();
   S = G->toSBML();


### PR DESCRIPTION
Utility functions for spatial uses zlib to perform compression.  However, libsbml might have been compiled without compression enabled, meaning that the 'compress' function won't do anything.  This change changes the return value of compress_data so that it can return failure, which in turn can be returned by the 'compress' functions that call it.  The tests then can check whether failure was properly returned, and whether the resulting models indeed remain uncompressed.

Addresses https://github.com/sbmlteam/libsbml/issues/67

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have updated all documentation necessary.
- [X] I have checked spelling in (new) comments.

## Testing
- [X] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested -->

