### PR TITLE
 #70 : ensure we have a newer compiler before compiling the compressi…

### DIFF
--- a/src/sbml/packages/spatial/sbml/test/TestCompression.cpp
+++ b/src/sbml/packages/spatial/sbml/test/TestCompression.cpp
@@ -53,6 +53,7 @@ LIBSBML_CPP_NAMESPACE_USE
 
 CK_CPPSTART
 
+#if ( __cplusplus > 201103L  ) 
 
 START_TEST(test_Compression_SampledField_1)
 {
@@ -791,6 +792,7 @@ START_TEST(test_Compression_ParametricObject_2)
 }
 END_TEST
 
+#endif
 
 Suite *
 create_suite_Compression(void)
@@ -798,6 +800,7 @@ create_suite_Compression(void)
   Suite *suite = suite_create("Compression");
   TCase *tcase = tcase_create("Compression");
 
+#if ( __cplusplus > 201103L  ) 
 #ifdef USE_ZLIB
   tcase_add_test( tcase, test_Compression_SampledField_1);
   tcase_add_test( tcase, test_Compression_SampledField_2);
@@ -811,6 +814,7 @@ create_suite_Compression(void)
   tcase_add_test( tcase, test_Compression_SpatialPoints_5);
   tcase_add_test( tcase, test_Compression_ParametricObject_1);
   tcase_add_test( tcase, test_Compression_ParametricObject_2);
+#endif
 #endif
 
   suite_add_tcase(suite, tcase);


### PR DESCRIPTION
…on tests

## Description
added #ifdef detecting the supported c++ standard, and not compiling them for compilers before c++14

## Motivation and Context
fixes #70 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have updated all documentation necessary.
- [ ] I have checked spelling in (new) comments.

## Testing
- [X] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested -->

(testing was done on raterule)