### PR TITLE
need a return when zlib is used

### DIFF
--- a/src/sbml/packages/spatial/common/CompressionUtil.cpp
+++ b/src/sbml/packages/spatial/common/CompressionUtil.cpp
@@ -167,10 +167,10 @@ int compress_data(void* data, size_t length, int level, unsigned char*& result, 
   outLength = buffer.size();
   result = (unsigned char*)malloc(sizeof(int) * outLength);
   if (result == NULL)
-    return;
+    return LIBSBML_OPERATION_FAILED;
   for (int i = 0; i < outLength; i++)
     result[i] = (unsigned char)buffer[i];
-  return LIBSBML_OPERATION_SUCCESS
+  return LIBSBML_OPERATION_SUCCESS;
 #endif
 }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
compress data must retun alue when zlib *is* used

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here, using the 'fixes #<issue>' syntax. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have updated all documentation necessary.
- [ ] I have checked spelling in (new) comments.

## Testing
- [X] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested -->

