### PR TITLE
 - allow compilation without c++11

### DIFF
--- a/src/sbml/xml/XMLOutputStream.cpp
+++ b/src/sbml/xml/XMLOutputStream.cpp
@@ -993,9 +993,15 @@ XMLOutputStream::writeComment (const std::string& programName,
     time_t tim=time(NULL);
     tm *now=localtime(&tim);
 
+#if ( __cplusplus > 201103L  ) 
     snprintf(formattedDateAndTime, 17, "%d-%02d-%02d %02d:%02d",
             now->tm_year+1900, now->tm_mon+1, now->tm_mday,
             now->tm_hour, now->tm_min);
+#else
+    sprintf(formattedDateAndTime, "%d-%02d-%02d %02d:%02d",
+            now->tm_year+1900, now->tm_mon+1, now->tm_mday,
+            now->tm_hour, now->tm_min);
+#endif
     mStream << " on " << formattedDateAndTime;
   }
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context
libsbml would not compile without c++11 enabled

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have updated all documentation necessary.
- [ ] I have checked spelling in (new) comments.

## Testing
- [X] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested -->

this compiles now on raterule
