### PR TITLE
Changed to use time.time() instead of time.clock()

### DIFF
--- a/examples/python/readSBML.py
+++ b/examples/python/readSBML.py
@@ -48,13 +48,13 @@ from libsbml import *
 def main (args):
   """Usage: readSBML filename
   """
-  
+
   if len(args) != 2:
       print("Usage: readSBML filename")
       return 1
 
   filename = args[1]
-  current = time.clock()
+  current = time.time()
   document = readSBML(filename)
 
   errors = document.getNumErrors()
@@ -62,7 +62,7 @@ def main (args):
   print()
   print("            filename: " + filename)
   print("           file size: " + str(os.stat(filename).st_size))
-  print("      read time (ms): " + str(time.clock() - current))
+  print("      read time (ms): " + str((time.time() - current)*1000))
   print(" validation error(s): " + str(errors))
   print()
   document.printErrors()
@@ -71,4 +71,4 @@ def main (args):
 
 
 if __name__ == '__main__':
-  main(sys.argv)  
+  main(sys.argv)


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Changed to use time.time() instead of time.clock() in readSBML.py

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here, using the 'fixes #<issue>' syntax. -->
Since the time.clock() function has been removed in python 3.8, changed to use time.time() instead.
See https://docs.python.org/3.7/library/time.html?highlight=time%20clock#time.clock

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have updated all documentation necessary.
- [ ] I have checked spelling in (new) comments.

## Testing
- [X] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested -->

