### PR TITLE
Add continuous integration

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -22,10 +22,10 @@ jobs:
         with_examples: ['True', 'False']
         package_option: ['', '-DWITH_STABLE_PACKAGES=ON', '-DWITH_ALL_PACKAGES=ON']
     runs-on: ${{ matrix.platform }}
-    
+
     steps:
     - uses: actions/checkout@v2
-    
+
     ### configure the operating system ###
     - name: Cache Windows dependencies and SWIG
       # On Windows, the dependencies live inside the source folder, ie `.`.
@@ -38,10 +38,10 @@ jobs:
               ./dependencies
               ./swig
         key: ${{ runner.os }}-dependencies
-    
+
     - name: Download pre-built Windows dependencies and SWIG
       # Windows dependencies have to be in a subfolder called `dependencies`, directly under the git repository root.
-      # also gets SWIG, completing the set of dependencies needed for windows      
+      # also gets SWIG, completing the set of dependencies needed for windows
       if: matrix.platform == 'windows-latest' && steps.cache-win-dependencies.outputs.cache-hit != 'true'
       shell: bash
       run: |
@@ -58,26 +58,51 @@ jobs:
       shell: bash
       run: |
            echo $GITHUB_WORKSPACE"/swig/swigwin-3.0.12/" >> $GITHUB_PATH
-    
+
     - name: Install Ubuntu dependencies
       # ubuntu already has SWIG and libxml2 by default
       if: matrix.platform == 'ubuntu-16.04'
       shell: bash
       run: |
-            sudo apt-get install check
-            sudo apt-get install libxerces-c-dev
-            sudo apt-get install expat
+            sudo apt-get install -y check libxerces-c-dev expat ccache
 
     - name: Install MacOS dependencies
       # MacOS already has libxml2 by default
       if: matrix.platform == 'macos-latest'
       shell: bash
       run: |
-            brew install check    
-            brew install swig
-            brew install xerces-c
-            brew install expat
-    
+            brew install check swig xerces-c expat ccache
+
+    ### setup ccache, not on Windows ###
+    - name: Prepare ccache timestamp
+      if: matrix.platform != 'windows-latest'
+      id: ccache_cache_timestamp
+      shell: cmake -P {0}
+      run: |
+        string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
+        message("::set-output name=timestamp::${current_date}")
+    - name: Set ccache cache directory
+      if: matrix.platform != 'windows-latest'
+      shell: bash
+      run: |
+        echo "CCACHE_DIR=${{runner.workspace}}/.ccache" >> "${GITHUB_ENV}"
+        echo "COMPILER_LAUNCHER=ccache" >> "${GITHUB_ENV}"
+    - name: cache ccache files
+      if: matrix.platform != 'windows-latest'
+      uses: actions/cache@v1.1.0
+      with:
+        path: ${{runner.workspace}}/.ccache
+        key: ${{ runner.os }}-test-${{ matrix.xml_parser_option }}-${{ matrix.with_namespace }}-${{ matrix.strict }}-${{ steps.ccache_cache_timestamp.outputs.timestamp }}
+        restore-keys: |
+          ${{ runner.os }}-test-${{ matrix.xml_parser_option }}-${{ matrix.with_namespace }}-${{ matrix.strict }}-${{ steps.ccache_cache_timestamp.outputs.timestamp }}
+          ${{ runner.os }}-test-${{ matrix.xml_parser_option }}-${{ matrix.with_namespace }}-${{ matrix.strict }}-
+          ${{ runner.os }}-test-${{ matrix.xml_parser_option }}-${{ matrix.with_namespace }}-${{ matrix.strict }}-
+          ${{ runner.os }}-test-${{ matrix.xml_parser_option }}-${{ matrix.with_namespace }}-${{ matrix.strict }}-
+          ${{ runner.os }}-test-${{ matrix.xml_parser_option }}-${{ matrix.with_namespace }}-
+          ${{ runner.os }}-test-${{ matrix.xml_parser_option }}-
+          ${{ runner.os }}-test-
+          ${{ runner.os }}-
+
     ### build the project ###
     - name: Create Build Environment
       run: cmake -E make_directory ${{runner.workspace}}/build
@@ -87,19 +112,19 @@ jobs:
       shell: bash
       working-directory: ${{runner.workspace}}/build
       run: |
-            cmake $GITHUB_WORKSPACE ${{ matrix.package_option }}-DCMAKE_BUILD_TYPE=$BUILD_TYPE -DWITH_CHECK=True -DWITH_JAVA=True -DWITH_CPP_NAMESPACE=${{matrix.with_namespace}} -DLIBSBML_USE_STRICT_INCLUDES=${{matrix.strict}} -DWITH_EXAMPLES=${{matrix.with_examples}}
-    
+            cmake $GITHUB_WORKSPACE -DCMAKE_C_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} -DCMAKE_CXX_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} ${{ matrix.package_option }}-DCMAKE_BUILD_TYPE=$BUILD_TYPE -DWITH_CHECK=True -DWITH_JAVA=True -DWITH_CPP_NAMESPACE=${{matrix.with_namespace}} -DLIBSBML_USE_STRICT_INCLUDES=${{matrix.strict}} -DWITH_EXAMPLES=${{matrix.with_examples}}
+
     - name: Configure CMake for non-default XML_parser
       if: matrix.xml_parser_option != '-DWITH_LIBXML'
       shell: bash
       working-directory: ${{runner.workspace}}/build
       run: |
-            cmake $GITHUB_WORKSPACE ${{ matrix.package_option}} -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DWITH_CHECK=True -DWITH_JAVA=True -DWITH_LIBXML=False ${{matrix.xml_parser_option}}=True -DWITH_CPP_NAMESPACE=${{matrix.with_namespace}} -DLIBSBML_USE_STRICT_INCLUDES=${{matrix.strict}} -DWITH_EXAMPLES=${{matrix.with_examples}}
+            cmake $GITHUB_WORKSPACE -DCMAKE_C_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} -DCMAKE_CXX_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} ${{ matrix.package_option}} -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DWITH_CHECK=True -DWITH_JAVA=True -DWITH_LIBXML=False ${{matrix.xml_parser_option}}=True -DWITH_CPP_NAMESPACE=${{matrix.with_namespace}} -DLIBSBML_USE_STRICT_INCLUDES=${{matrix.strict}} -DWITH_EXAMPLES=${{matrix.with_examples}}
 
     - name: Build
       working-directory: ${{runner.workspace}}/build
       shell: bash
-      run: cmake --build . --config $BUILD_TYPE
+      run: cmake --build . --config $BUILD_TYPE --parallel 4
 
     ### run tests ###
     - name: Test

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,0 +1,100 @@
+name: CMake
+
+on: [push]
+
+env:
+  BUILD_TYPE: Release
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        platform: [windows-latest, macos-latest, ubuntu-16.04]
+        xml_parser_option: ['-DWITH_LIBXML','-DWITH_XERCES','-DWITH_EXPAT']
+        with_namespace: ['True', 'False']
+        strict: ['True', 'False']
+        with_examples: ['True', 'False']
+    runs-on: ${{ matrix.platform }}
+    
+    steps:
+    - uses: actions/checkout@v2
+    
+    ### configure the operating system ###
+    - name: Cache Windows dependencies and SWIG
+      # On Windows, the dependencies live inside the source folder, ie `.`.
+      # For the CI, we put SWIG there too, for simplicity.
+      if: matrix.platform == 'windows-latest'
+      id: cache-win-dependencies
+      uses: actions/cache@v2
+      with:
+        path: |
+              ./dependencies
+              ./swig
+        key: ${{ runner.os }}-dependencies
+    
+    - name: Download pre-built Windows dependencies and SWIG
+      # Windows dependencies have to be in a subfolder called `dependencies`, directly under the git repository root.
+      # also gets SWIG, completing the set of dependencies needed for windows      
+      if: matrix.platform == 'windows-latest' && steps.cache-win-dependencies.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        curl -L https://sourceforge.net/projects/sbml/files/libsbml/win-dependencies/libSBML_dependencies_vs15_release_x64.zip/download > dependencies.zip
+        unzip dependencies.zip -d dependencies
+        cp -r dependencies/libSBML\ Dependencies-1.0.0-b1-win64/* dependencies
+        rm -r dependencies/libSBML*
+        curl -L https://prdownloads.sourceforge.net/swig/swigwin-3.0.12.zip > swig.zip
+        unzip swig.zip -d swig
+
+    - name: add SWIG to Path (Windows)
+      # this is separate from the SWIG download itself, because it needs to be added to the path also when SWIG is cached
+      if: matrix.platform == 'windows-latest'
+      shell: bash
+      run: echo "./swig/swigwin-3.0.12" >> $GITHUB_PATH
+      
+    - name: Install Ubuntu dependencies
+      # ubuntu already has SWIG and libxml2 by default
+      if: matrix.platform == 'ubuntu-16.04'
+      shell: bash
+      run: |
+            sudo apt-get install check
+            sudo apt-get install libxerces-c-dev
+            sudo apt-get install expat
+
+    - name: Install MacOS dependencies
+      # MacOS already has libxml2 by default
+      if: matrix.platform == 'macos-latest'
+      shell: bash
+      run: |
+            brew install check    
+            brew install swig
+            brew install xerces-c
+            brew install expat
+    
+    ### build the project ###
+    - name: Create Build Environment
+      run: cmake -E make_directory ${{runner.workspace}}/build
+
+    - name: Configure CMake for default XML_parser (LIBXML2)
+      if: matrix.xml_parser_option == '-DWITH_LIBXML' # default option, no need to specify -DWITH_LIBXML=...
+      shell: bash
+      working-directory: ${{runner.workspace}}/build
+      run: |
+            cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DWITH_CHECK=True -DWITH_JAVA=True -DWITH_CPP_NAMESPACE=${{matrix.with_namespace}} -DLIBSBML_USE_STRICT_INCLUDES=${{matrix.strict}} -DWITH_EXAMPLE=${{matrix.with_examples}}
+    
+    - name: Configure CMake for non-default XML_parser
+      if: matrix.xml_parser_option != '-DWITH_LIBXML'
+      shell: bash
+      working-directory: ${{runner.workspace}}/build
+      run: |
+            cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DWITH_CHECK=True -DWITH_JAVA=True -DWITH_LIBXML=False ${{matrix.xml_parser_option}}=True -DWITH_CPP_NAMESPACE=${{matrix.with_namespace}} -DLIBSBML_USE_STRICT_INCLUDES=${{matrix.strict}} -DWITH_EXAMPLE=${{matrix.with_examples}}
+
+    - name: Build
+      working-directory: ${{runner.workspace}}/build
+      shell: bash
+      run: cmake --build . --config $BUILD_TYPE
+
+    ### run tests ###
+    - name: Test
+      working-directory: ${{runner.workspace}}/build
+      shell: bash
+      run: ctest -C $BUILD_TYPE

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -82,14 +82,14 @@ jobs:
       shell: bash
       working-directory: ${{runner.workspace}}/build
       run: |
-            cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DWITH_CHECK=True -DWITH_JAVA=True -DWITH_CPP_NAMESPACE=${{matrix.with_namespace}} -DLIBSBML_USE_STRICT_INCLUDES=${{matrix.strict}} -DWITH_EXAMPLE=${{matrix.with_examples}}
+            cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DWITH_CHECK=True -DWITH_JAVA=True -DWITH_CPP_NAMESPACE=${{matrix.with_namespace}} -DLIBSBML_USE_STRICT_INCLUDES=${{matrix.strict}} -DWITH_EXAMPLES=${{matrix.with_examples}}
     
     - name: Configure CMake for non-default XML_parser
       if: matrix.xml_parser_option != '-DWITH_LIBXML'
       shell: bash
       working-directory: ${{runner.workspace}}/build
       run: |
-            cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DWITH_CHECK=True -DWITH_JAVA=True -DWITH_LIBXML=False ${{matrix.xml_parser_option}}=True -DWITH_CPP_NAMESPACE=${{matrix.with_namespace}} -DLIBSBML_USE_STRICT_INCLUDES=${{matrix.strict}} -DWITH_EXAMPLE=${{matrix.with_examples}}
+            cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DWITH_CHECK=True -DWITH_JAVA=True -DWITH_LIBXML=False ${{matrix.xml_parser_option}}=True -DWITH_CPP_NAMESPACE=${{matrix.with_namespace}} -DLIBSBML_USE_STRICT_INCLUDES=${{matrix.strict}} -DWITH_EXAMPLES=${{matrix.with_examples}}
 
     - name: Build
       working-directory: ${{runner.workspace}}/build

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,6 +1,10 @@
 name: CMake
 
-on: [push]
+on:
+  pull_request:
+    branches:
+      - development
+      - stable
 
 env:
   BUILD_TYPE: Release

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -7,6 +7,7 @@ env:
 
 jobs:
   build:
+    name: ${{ matrix.platform }}, Parser option ${{ matrix.xml_parser_option }}, with namespaces ${{ matrix.with_namespace}}, strict includes ${{ matrix.with_namespace }}, with examples ${{ matrix.with_examples}}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -49,8 +49,9 @@ jobs:
       # this is separate from the SWIG download itself, because it needs to be added to the path also when SWIG is cached
       if: matrix.platform == 'windows-latest'
       shell: bash
-      run: echo "./swig/swigwin-3.0.12" >> $GITHUB_PATH
-      
+      run: |
+           echo $GITHUB_WORKSPACE"/swig/swigwin-3.0.12/" >> $GITHUB_PATH
+    
     - name: Install Ubuntu dependencies
       # ubuntu already has SWIG and libxml2 by default
       if: matrix.platform == 'ubuntu-16.04'

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -7,7 +7,7 @@ env:
 
 jobs:
   build:
-    name: ${{ matrix.platform }}, Parser option ${{ matrix.xml_parser_option }}, with namespaces ${{ matrix.with_namespace}}, strict includes ${{ matrix.with_namespace }}, with examples ${{ matrix.with_examples}}
+    name: ${{ matrix.platform }}, Parser option ${{ matrix.xml_parser_option }}, with namespaces ${{ matrix.with_namespace}}, strict includes ${{ matrix.with_namespace }}, with examples ${{ matrix.with_examples}}, package option ${{ matrix.package_option}}
     strategy:
       fail-fast: false
       matrix:
@@ -16,6 +16,7 @@ jobs:
         with_namespace: ['True', 'False']
         strict: ['True', 'False']
         with_examples: ['True', 'False']
+        package_option: ['', '-DWITH_STABLE_PACKAGES=ON', '-DWITH_ALL_PACKAGES=ON']
     runs-on: ${{ matrix.platform }}
     
     steps:
@@ -82,14 +83,14 @@ jobs:
       shell: bash
       working-directory: ${{runner.workspace}}/build
       run: |
-            cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DWITH_CHECK=True -DWITH_JAVA=True -DWITH_CPP_NAMESPACE=${{matrix.with_namespace}} -DLIBSBML_USE_STRICT_INCLUDES=${{matrix.strict}} -DWITH_EXAMPLES=${{matrix.with_examples}}
+            cmake $GITHUB_WORKSPACE ${{ matrix.package_option }}-DCMAKE_BUILD_TYPE=$BUILD_TYPE -DWITH_CHECK=True -DWITH_JAVA=True -DWITH_CPP_NAMESPACE=${{matrix.with_namespace}} -DLIBSBML_USE_STRICT_INCLUDES=${{matrix.strict}} -DWITH_EXAMPLES=${{matrix.with_examples}}
     
     - name: Configure CMake for non-default XML_parser
       if: matrix.xml_parser_option != '-DWITH_LIBXML'
       shell: bash
       working-directory: ${{runner.workspace}}/build
       run: |
-            cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DWITH_CHECK=True -DWITH_JAVA=True -DWITH_LIBXML=False ${{matrix.xml_parser_option}}=True -DWITH_CPP_NAMESPACE=${{matrix.with_namespace}} -DLIBSBML_USE_STRICT_INCLUDES=${{matrix.strict}} -DWITH_EXAMPLES=${{matrix.with_examples}}
+            cmake $GITHUB_WORKSPACE ${{ matrix.package_option}} -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DWITH_CHECK=True -DWITH_JAVA=True -DWITH_LIBXML=False ${{matrix.xml_parser_option}}=True -DWITH_CPP_NAMESPACE=${{matrix.with_namespace}} -DLIBSBML_USE_STRICT_INCLUDES=${{matrix.strict}} -DWITH_EXAMPLES=${{matrix.with_examples}}
 
     - name: Build
       working-directory: ${{runner.workspace}}/build

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -8,6 +8,7 @@ env:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         platform: [windows-latest, macos-latest, ubuntu-16.04]
         xml_parser_option: ['-DWITH_LIBXML','-DWITH_XERCES','-DWITH_EXPAT']

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -365,6 +365,7 @@ if(WITH_SWIG)
     find_program(SWIG_EXECUTABLE
         NAMES swig
         PATHS
+	      ./swig/swigwin-3.0.12
               c:/swigwin-3.0.10
               c:/swigwin-3.0.9
               c:/swigwin-3.0.8

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -365,7 +365,6 @@ if(WITH_SWIG)
     find_program(SWIG_EXECUTABLE
         NAMES swig
         PATHS
-	      ./swig/swigwin-3.0.12
               c:/swigwin-3.0.10
               c:/swigwin-3.0.9
               c:/swigwin-3.0.8


### PR DESCRIPTION
## Description

This PR adds CI to LibSBML. CI is implemented using GitHub actions, as GitHub Actions provides a higher number (20) of parallel jobs on more powerful machines than Travis, for free for open-source projects like ours. The file driving this is `cmake.yml` located in `.github/workflows` (There can be more such "workflow" YAML files there in the future if we want).

The implementation installs dependencies for, builds, and tests all combinations of 
- {MacOS, Ubuntu 16.04, Windows 10} operating systems 
- {LibXML2, expat, Xerces} xml parsers 
- with and without namespaces
- with and without examples
- with and without strict includes
which means that `3^2 * 2^3 = 9 * 8 = 72` independent jobs (which take ~1:30 h to complete in total) are run at every `push`. The implementation is pretty naive for now, but will cover a large part of the use cases at least. The only clever thing that happens is that the windows dependencies and SWIG download are cached. ~~I added an alternative SWIG path to a CMake file for convenience, as the structure of the underbelly of the Github Actions machine is still a bit murky for me.~~ 

I would be grateful for suggestions about
- how, if it all, can/should we test the CI itself (beyond looking at the output and saying that yes, `ctest` has passed some reasonable-looking tests).
- where/how to document the CI functionality (I will create a file on the shared drive for now, as Sarah suggested)
- anything else you think is important.
- routes for future improvement (I am currently trying a few :) )

## Motivation and Context
The context is described above. The change is required to start addressing the lack of CI/CD in LibSBML. It partially solves the problem that there is currently only minimal, if any, CI/CD for LibSBML.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have updated all documentation necessary.
- [x] I have checked spelling in (new) comments.

## Testing
- [ ] Testing is done automatically and codecov shows test coverage
- [x] This cannot be tested automatically. I've done some manual reading of the GitHub Actions logs for the various combinations, and the output seems reasonable to me. I expected `Cmake` to catch any missing dependencies or settings, and the `ctest` runs at the end displayed reasonably named tests passing. The GitHub Actions logs can be viewed [here](https://github.com/alessandrofelder/libsbml/actions/runs/406153877)
