### PR TITLE
Fix cmake root dirs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,9 +44,9 @@ endif()
 
 
 
-set(LIBSBML_ROOT_SOURCE_DIR "${CMAKE_SOURCE_DIR}" CACHE PATH
+set(LIBSBML_ROOT_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}" CACHE PATH
     "Path to the libSBML root source directory")
-set(LIBSBML_ROOT_BINARY_DIR "${CMAKE_BINARY_DIR}" CACHE PATH
+set(LIBSBML_ROOT_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}" CACHE PATH
     "Path to the libSBML root build directory")
 
 include (CMakeTestCCompiler)


### PR DESCRIPTION
When compiling libsbml as a submodule, cmake's root dir is not the same as libsbml' root dir.  This change allows it to compile in both situations.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Testing
- [] Testing is done automatically and codecov shows test coverage
- [X] This cannot be tested automatically <!-- describe how it has been tested -->

