### PR TITLE
Bugfix sigaction not available in windows

### DIFF
--- a/examples/c++/translateL3Math.cpp
+++ b/examples/c++/translateL3Math.cpp
@@ -79,7 +79,7 @@ main (int argc, char* argv[])
        << endl;
 
   L3ParserSettings settings;
-  while (1)
+  do
   {
     cout << "Enter infix formula, MathML expression, or change parsing rules with the keywords:\nLOG_AS_LOG10, LOG_AS_LN, LOG_AS_ERROR, EXPAND_UMINUS, COLLAPSE_UMINUS, TARGETL2, TARGETL3, NO_UNITS, UNITS, or FILE:<filename>\n(Ctrl-C to quit):"
          << endl << endl;
@@ -163,7 +163,7 @@ main (int argc, char* argv[])
 
       cin.getline(line, BUFFER_SIZE, '\n');
     }
-  }
+  } while (line != 0);
 
   StringBuffer_free(sb);
   return 0;

--- a/examples/c++/translateL3Math.cpp
+++ b/examples/c++/translateL3Math.cpp
@@ -43,7 +43,6 @@
 
 #include <iostream>
 
-#include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -59,9 +58,6 @@ LIBSBML_CPP_NAMESPACE_USE
 
 char *translateInfix  (const char *formula, const L3ParserSettings& settings);
 char *translateMathML (const char *xml);
-void quitHandler(int s);
-
-volatile sig_atomic_t isRunning = 1;
 
 
 int
@@ -75,10 +71,6 @@ main (int argc, char* argv[])
   SBMLDocument*   doc = NULL;
   StringBuffer_t* sb = StringBuffer_create(1024);
 
-  // Register ctrl-c handler
-  struct sigaction act;
-  act.sa_handler = quitHandler;
-  sigaction(SIGINT, &act, NULL);
 
   cout << endl 
        << "This program translates L3 infix formulas into MathML and" << endl
@@ -87,7 +79,7 @@ main (int argc, char* argv[])
        << endl;
 
   L3ParserSettings settings;
-  while (isRunning)
+  while (1)
   {
     cout << "Enter infix formula, MathML expression, or change parsing rules with the keywords:\nLOG_AS_LOG10, LOG_AS_LN, LOG_AS_ERROR, EXPAND_UMINUS, COLLAPSE_UMINUS, TARGETL2, TARGETL3, NO_UNITS, UNITS, or FILE:<filename>\n(Ctrl-C to quit):"
          << endl << endl;
@@ -173,7 +165,6 @@ main (int argc, char* argv[])
     }
   }
 
-  cout << "Quitting." << endl;
   StringBuffer_free(sb);
   return 0;
 }
@@ -220,13 +211,4 @@ translateMathML (const char* xml)
 
   ASTNode_free(math);
   return result;
-}
-
-/**
-  * Handles ctrl-c signal (aka SIGINT)
-  */
-void
-quitHandler(int s) 
-{
-  isRunning = 0;
 }

--- a/examples/c++/translateMath.cpp
+++ b/examples/c++/translateMath.cpp
@@ -76,7 +76,7 @@ main (int argc, char* argv[])
        << "translation. Ctrl-C quits" << endl
        << endl;
 
-  while (1)
+  do
   {
     cout << "Enter infix formula or MathML expression (Ctrl-C to quit):"
          << endl << endl;
@@ -110,7 +110,7 @@ main (int argc, char* argv[])
 
       cin.getline(line, BUFFER_SIZE, '\n');
     }
-  }
+  } while (line != 0);
 
   StringBuffer_free(sb);
   return 0;

--- a/examples/c++/translateMath.cpp
+++ b/examples/c++/translateMath.cpp
@@ -42,7 +42,6 @@
 
 #include <iostream>
 
-#include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -58,9 +57,6 @@ LIBSBML_CPP_NAMESPACE_USE
 
 char *translateInfix  (const char *formula);
 char *translateMathML (const char *xml);
-void quitHandler(int s);
-
-volatile sig_atomic_t isRunning = 1;
 
 
 int
@@ -73,10 +69,6 @@ main (int argc, char* argv[])
   size_t          len;
   StringBuffer_t* sb = StringBuffer_create(1024);
 
-  // Register ctrl-c handler
-  struct sigaction act;
-  act.sa_handler = quitHandler;
-  sigaction(SIGINT, &act, NULL);
 
   cout << endl 
        << "This program translates infix formulas into MathML and" << endl
@@ -84,7 +76,7 @@ main (int argc, char* argv[])
        << "translation. Ctrl-C quits" << endl
        << endl;
 
-  while (isRunning)
+  while (1)
   {
     cout << "Enter infix formula or MathML expression (Ctrl-C to quit):"
          << endl << endl;
@@ -162,14 +154,4 @@ translateMathML (const char* xml)
 
   ASTNode_free(math);
   return result;
-}
-
-
-/**
-  * Handles ctrl-c signal (aka SIGINT)
-  */
-void
-quitHandler(int s) 
-{
-  isRunning = 0;
 }


### PR DESCRIPTION
## Description
`sigaction` was introduced to stop sonarcloud complaining about an infinite loop however this is not portable to windows. This PR introduces a simpler solution suggested by @fbergmann which is portable.

## Motivation and Context
`sigaction` was introduced to stop sonarcloud complaining about an infinite loop however this is not portable to windows.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have updated all documentation necessary.
- [x] I have checked spelling in (new) comments.

## Testing
- [X] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested -->

