### PR TITLE
Fix sonarcloud smells 5

### DIFF
--- a/src/sbml/SBMLDocument.cpp
+++ b/src/sbml/SBMLDocument.cpp
@@ -79,26 +79,6 @@ using namespace std;
 LIBSBML_CPP_NAMESPACE_BEGIN
 #ifdef __cplusplus
 
-/*
- * Function to check whether an error reported by a compatability validation
- * prior to conversion between levels/versions can be ignored.
- * Some conversions will lose information but the model will still be valid
- * when converted.
- */
-//static unsigned int ignorable[] = {
-//  92001,
-//  92003,
-//  92004,
-//  92005,
-//  92006,
-//  93001,
-//  91003,
-//  91005,
-//  91006,
-//  91013
-//};
-
-
 
 /*
  * Get the most recent Level of SBML supported by this release of

--- a/src/sbml/SBMLDocument.h
+++ b/src/sbml/SBMLDocument.h
@@ -1634,8 +1634,6 @@ public:
 
 protected:
   /** @cond doxygenLibsbmlInternal */
-  //typedef std::map<std::string, bool>  PkgRequiredMap;
-  //typedef PkgRequiredMap::iterator     PkgRequiredMapIter;
   typedef std::map<std::string, bool>  PkgUseDefaultNSMap;
   typedef PkgUseDefaultNSMap::iterator PkgUseDefaultNSMapIter;
 
@@ -1705,7 +1703,6 @@ protected:
   std::list<SBMLValidator*> mValidators;
   SBMLInternalValidator *mInternalValidator;
 
-  //PkgRequiredMap           mPkgRequiredMap;
   XMLAttributes            mRequiredAttrOfUnknownPkg;
   XMLAttributes            mRequiredAttrOfUnknownDisabledPkg;
 

--- a/src/sbml/SBMLError.cpp
+++ b/src/sbml/SBMLError.cpp
@@ -235,15 +235,6 @@ SBMLError::SBMLError (  const unsigned int errorId
     {
       // The id is in the range of error numbers that are supposed to be in
       // the SBML layer, but it's NOT in our table. This is an internal error.
-      // Unfortunately, we don't have an error log or anywhere to report it
-      // except the measure of last resort: the standard error output.
-    
-      //cerr << "Internal error: unknown error code '" << mErrorId
-      //     << "' encountered while processing error." << endl;
-      //return;
-      // Changed this behaviour
-
-      // Now we log the error as an UnKnown Error and mark it as invalid
 
       mValidError = false;
     }
@@ -472,9 +463,7 @@ SBMLError::print(ostream& s) const
 void
 SBMLError::adjustErrorId(unsigned int)
 {
-  // actually dont do this since it means a user cannot 
-  // look for the specific error
-  //mErrorId = mErrorId - offset;
+  // TODO deprecate this unused function
 }
 /** @endcond */
 

--- a/src/sbml/SBMLNamespaces.cpp
+++ b/src/sbml/SBMLNamespaces.cpp
@@ -417,8 +417,6 @@ SBMLNamespaces::addPackageNamespace(const std::string &pkgName, unsigned int pkg
   {
     return LIBSBML_INVALID_ATTRIBUTE_VALUE;
   }
-
-//  return LIBSBML_OPERATION_SUCCESS;
 }
 
 

--- a/src/sbml/SBMLReader.cpp
+++ b/src/sbml/SBMLReader.cpp
@@ -280,25 +280,22 @@ SBMLReader::readInternal (const char* content, bool isFile)
 
         d->setInvalidLevel();
 
-	      return d;
+        return d;
       }
     }
     else
     {
-      // here we do not have an xml document at all
-//      d->getErrorLog()->logError(NotSchemaConformant);
-
       if (stream.isError())
       {
         sortReportedErrors(d);    
       }
       d->setInvalidLevel();
-      
+
       return d;
     }
-	
+
     d->read(stream);
-    
+
     if (stream.isError())
     {
       // If we encountered an error, some parsers will report it sooner

--- a/src/sbml/SBMLTransforms.cpp
+++ b/src/sbml/SBMLTransforms.cpp
@@ -344,8 +344,6 @@ SBMLTransforms::getComponentValuesForModel(const Model * m, IdValueMap& values)
         {
           ValueSet v = make_pair(s->getInitialAmount(), true);
           values.insert(pair<const std::string, ValueSet>(s->getId(), v));
-          //values.insert(pair<const std::string, double>(s->getId(), 
-          //                                            s->getInitialAmount()));
         }
         else if (s->isSetInitialAmount())
         {

--- a/src/sbml/SBase.h
+++ b/src/sbml/SBase.h
@@ -2389,8 +2389,7 @@ s.setNotes("<body xmlns='http://www.w3.org/1999/xhtml'><p>here is my note</p></b
 
   /** @endcond */
 
-//   virtual int getAttribute(const std::string& attributeName, const char * value) const;
-
+  /** @cond doxygenLibsbmlInternal */
 
    virtual bool isSetAttribute(const std::string& attributeName) const;
 
@@ -2423,12 +2422,6 @@ s.setNotes("<body xmlns='http://www.w3.org/1999/xhtml'><p>here is my note</p></b
   /** @cond doxygenLibsbmlInternal */
 
    virtual int setAttribute(const std::string& attributeName, const std::string& value);
-
-  /** @endcond */
-
-  /** @cond doxygenLibsbmlInternal */
-
-//   virtual int setAttribute(const std::string& attributeName, const char* value);
 
   /** @endcond */
 
@@ -3756,8 +3749,6 @@ SBase.readExtensionAttributes(attributes, expectedAttributes);
   //
   std::string mURI;
 
-  // boolean to keep track of whether the user has touched an annotation
-  //bool            mAnnotationChanged;
   bool            mHistoryChanged;
   bool            mCVTermsChanged;
 

--- a/src/sbml/SimpleSpeciesReference.cpp
+++ b/src/sbml/SimpleSpeciesReference.cpp
@@ -78,8 +78,7 @@ SimpleSpeciesReference::SimpleSpeciesReference (SBMLNamespaces *sbmlns) :
    SBase   (sbmlns  )
  , mSpecies( "" )
 {
-  // does not need to load here as this is an inbetween class
-  //loadPlugins(sbmlns);
+  // TODO deprecate this function
 }
 /** @endcond */
 
@@ -503,36 +502,6 @@ SimpleSpeciesReference::getAttribute(const std::string& attributeName,
 /** @cond doxygenLibsbmlInternal */
 
 /*
- * Returns the value of the "attributeName" attribute of this
- * SimpleSpeciesReference.
- */
-//int
-//SimpleSpeciesReference::getAttribute(const std::string& attributeName,
-//                                     const char* value) const
-//{
-//  int return_value = SBase::getAttribute(attributeName, value);
-//
-//  if (return_value == LIBSBML_OPERATION_SUCCESS)
-//  {
-//    return return_value;
-//  }
-//
-//  if (attributeName == "species")
-//  {
-//    value = getSpecies().c_str();
-//    return_value = LIBSBML_OPERATION_SUCCESS;
-//  }
-//
-//  return return_value;
-//}
-//
-/** @endcond */
-
-
-
-/** @cond doxygenLibsbmlInternal */
-
-/*
  * Predicate returning @c true if this SimpleSpeciesReference's attribute
  * "attributeName" is set.
  */
@@ -648,30 +617,6 @@ SimpleSpeciesReference::setAttribute(const std::string& attributeName,
 
   return return_value;
 }
-
-/** @endcond */
-
-
-
-/** @cond doxygenLibsbmlInternal */
-
-/*
- * Sets the value of the "attributeName" attribute of this
- * SimpleSpeciesReference.
- */
-//int
-//SimpleSpeciesReference::setAttribute(const std::string& attributeName,
-//                                     const char* value)
-//{
-//  int return_value = SBase::setAttribute(attributeName, value);
-//
-//  if (attributeName == "species")
-//  {
-//    return_value = setSpecies(value);
-//  }
-//
-//  return return_value;
-//}
 
 /** @endcond */
 

--- a/src/sbml/SimpleSpeciesReference.h
+++ b/src/sbml/SimpleSpeciesReference.h
@@ -403,27 +403,6 @@ public:
   /** @cond doxygenLibsbmlInternal */
 
   /**
-   * Returns the value of the "attributeName" attribute of this
-   * SimpleSpeciesReference.
-   *
-   * @param attributeName, the name of the attribute to retrieve.
-   *
-   * @param value, the address of the value to record.
-   *
-   * @copydetails doc_returns_success_code
-   * @li @sbmlconstant{LIBSBML_OPERATION_SUCCESS, OperationReturnValues_t}
-   * @li @sbmlconstant{LIBSBML_OPERATION_FAILED, OperationReturnValues_t}
-   */
-  //virtual int getAttribute(const std::string& attributeName,
-  //                         const char* value) const;
-
-  /** @endcond */
-
-
-
-  /** @cond doxygenLibsbmlInternal */
-
-  /**
    * Predicate returning @c true if this SimpleSpeciesReference's attribute
    * "attributeName" is set.
    *
@@ -543,27 +522,6 @@ public:
   /** @cond doxygenLibsbmlInternal */
 
   /**
-   * Sets the value of the "attributeName" attribute of this
-   * SimpleSpeciesReference.
-   *
-   * @param attributeName, the name of the attribute to set.
-   *
-   * @param value, the value of the attribute to set.
-   *
-   * @copydetails doc_returns_success_code
-   * @li @sbmlconstant{LIBSBML_OPERATION_SUCCESS, OperationReturnValues_t}
-   * @li @sbmlconstant{LIBSBML_OPERATION_FAILED, OperationReturnValues_t}
-   */
-  //virtual int setAttribute(const std::string& attributeName, const char*
-  //  value);
-
-  /** @endcond */
-
-
-
-  /** @cond doxygenLibsbmlInternal */
-
-  /**
    * Unsets the value of the "attributeName" attribute of this
    * SimpleSpeciesReference.
    *
@@ -640,8 +598,6 @@ protected:
    */
   virtual void writeAttributes (XMLOutputStream& stream) const;
 
-  //std::string  mId;
-  //std::string  mName;
   std::string  mSpecies;
 
   /** @endcond */

--- a/src/sbml/Species.cpp
+++ b/src/sbml/Species.cpp
@@ -590,15 +590,6 @@ Species::isSetConstant () const
 int
 Species::setId (const std::string& sid)
 {
-  /* since the setId function has been used as an
-   * alias for setName we cant require it to only
-   * be used on a L2 model
-   */
-/*  if (getLevel() == 1)
-  {
-    return LIBSBML_UNEXPECTED_ATTRIBUTE;
-  }
-*/
   if (!(SyntaxChecker::isValidInternalSId(sid)))
   {
     return LIBSBML_INVALID_ATTRIBUTE_VALUE;
@@ -1445,60 +1436,6 @@ Species::getAttribute(const std::string& attributeName,
 /** @cond doxygenLibsbmlInternal */
 
 /*
- * Returns the value of the "attributeName" attribute of this Species.
- */
-//int
-//Species::getAttribute(const std::string& attributeName,
-//                      const char* value) const
-//{
-//  int return_value = SBase::getAttribute(attributeName, value);
-//
-//  if (return_value == LIBSBML_OPERATION_SUCCESS)
-//  {
-//    return return_value;
-//  }
-//
-//  if (attributeName == "compartment")
-//  {
-//    value = getCompartment().c_str();
-//    return_value = LIBSBML_OPERATION_SUCCESS;
-//  }
-//  else if (attributeName == "substanceUnits")
-//  {
-//    value = getSubstanceUnits().c_str();
-//    return_value = LIBSBML_OPERATION_SUCCESS;
-//  }
-//  else if (attributeName == "conversionFactor")
-//  {
-//    value = getConversionFactor().c_str();
-//    return_value = LIBSBML_OPERATION_SUCCESS;
-//  }
-//  else if (attributeName == "speciesType")
-//  {
-//    value = getSpeciesType().c_str();
-//    return_value = LIBSBML_OPERATION_SUCCESS;
-//  }
-//  else if (attributeName == "spatialSizeUnits")
-//  {
-//    value = getSpatialSizeUnits().c_str();
-//    return_value = LIBSBML_OPERATION_SUCCESS;
-//  }
-//  else if (attributeName == "units")
-//  {
-//    value = getUnits().c_str();
-//    return_value = LIBSBML_OPERATION_SUCCESS;
-//  }
-//
-//  return return_value;
-//}
-//
-/** @endcond */
-
-
-
-/** @cond doxygenLibsbmlInternal */
-
-/*
  * Predicate returning @c true if this Species's attribute "attributeName" is
  * set.
  */
@@ -1697,48 +1634,6 @@ Species::setAttribute(const std::string& attributeName,
   return return_value;
 }
 
-/** @endcond */
-
-
-
-/** @cond doxygenLibsbmlInternal */
-
-/*
- * Sets the value of the "attributeName" attribute of this Species.
- */
-//int
-//Species::setAttribute(const std::string& attributeName, const char* value)
-//{
-//  int return_value = SBase::setAttribute(attributeName, value);
-//
-//  if (attributeName == "compartment")
-//  {
-//    return_value = setCompartment(value);
-//  }
-//  else if (attributeName == "substanceUnits")
-//  {
-//    return_value = setSubstanceUnits(value);
-//  }
-//  else if (attributeName == "conversionFactor")
-//  {
-//    return_value = setConversionFactor(value);
-//  }
-//  else if (attributeName == "speciesType")
-//  {
-//    return_value = setSpeciesType(value);
-//  }
-//  else if (attributeName == "spatialSizeUnits")
-//  {
-//    return_value = setSpatialSizeUnits(value);
-//  }
-//  else if (attributeName == "units")
-//  {
-//    return_value = setUnits(value);
-//  }
-//
-//  return return_value;
-//}
-//
 /** @endcond */
 
 

--- a/src/sbml/Species.h
+++ b/src/sbml/Species.h
@@ -1458,26 +1458,6 @@ public:
   /** @cond doxygenLibsbmlInternal */
 
   /**
-   * Returns the value of the "attributeName" attribute of this Species.
-   *
-   * @param attributeName, the name of the attribute to retrieve.
-   *
-   * @param value, the address of the value to record.
-   *
-   * @copydetails doc_returns_success_code
-   * @li @sbmlconstant{LIBSBML_OPERATION_SUCCESS, OperationReturnValues_t}
-   * @li @sbmlconstant{LIBSBML_OPERATION_FAILED, OperationReturnValues_t}
-   */
-  //virtual int getAttribute(const std::string& attributeName,
-  //                         const char* value) const;
-
-  /** @endcond */
-
-
-
-  /** @cond doxygenLibsbmlInternal */
-
-  /**
    * Predicate returning @c true if this Species's attribute "attributeName" is
    * set.
    *
@@ -1592,26 +1572,6 @@ public:
   /** @cond doxygenLibsbmlInternal */
 
   /**
-   * Sets the value of the "attributeName" attribute of this Species.
-   *
-   * @param attributeName, the name of the attribute to set.
-   *
-   * @param value, the value of the attribute to set.
-   *
-   * @copydetails doc_returns_success_code
-   * @li @sbmlconstant{LIBSBML_OPERATION_SUCCESS, OperationReturnValues_t}
-   * @li @sbmlconstant{LIBSBML_OPERATION_FAILED, OperationReturnValues_t}
-   */
-  //virtual int setAttribute(const std::string& attributeName, const char*
-  //  value);
-
-  /** @endcond */
-
-
-
-  /** @cond doxygenLibsbmlInternal */
-
-  /**
    * Unsets the value of the "attributeName" attribute of this Species.
    *
    * @param attributeName, the name of the attribute to query.
@@ -1671,8 +1631,6 @@ protected:
    */
   virtual void writeAttributes (XMLOutputStream& stream) const;
 
-  //std::string  mId;
-  //std::string  mName;
   std::string  mSpeciesType;
   std::string  mCompartment;
 

--- a/src/sbml/SpeciesReference.h
+++ b/src/sbml/SpeciesReference.h
@@ -995,26 +995,6 @@ public:
   /** @cond doxygenLibsbmlInternal */
 
   /**
-   * Returns the value of the "attributeName" attribute of this SpeciesReference.
-   *
-   * @param attributeName, the name of the attribute to retrieve.
-   *
-   * @param value, the address of the value to record.
-   *
-   * @copydetails doc_returns_success_code
-   * @li @sbmlconstant{LIBSBML_OPERATION_SUCCESS, OperationReturnValues_t}
-   * @li @sbmlconstant{LIBSBML_OPERATION_FAILED, OperationReturnValues_t}
-   */
-  //virtual int getAttribute(const std::string& attributeName,
-  //                         const char* value) const;
-
-  /** @endcond */
-
-
-
-  /** @cond doxygenLibsbmlInternal */
-
-  /**
    * Predicate returning @c true if this SpeciesReference's attribute
    * "attributeName" is set.
    *
@@ -1121,26 +1101,6 @@ public:
    */
   virtual int setAttribute(const std::string& attributeName,
                            const std::string& value);
-
-  /** @endcond */
-
-
-
-  /** @cond doxygenLibsbmlInternal */
-
-  /**
-   * Sets the value of the "attributeName" attribute of this SpeciesReference.
-   *
-   * @param attributeName, the name of the attribute to set.
-   *
-   * @param value, the value of the attribute to set.
-   *
-   * @copydetails doc_returns_success_code
-   * @li @sbmlconstant{LIBSBML_OPERATION_SUCCESS, OperationReturnValues_t}
-   * @li @sbmlconstant{LIBSBML_OPERATION_FAILED, OperationReturnValues_t}
-   */
-  //virtual int setAttribute(const std::string& attributeName, const char*
-  //  value);
 
   /** @endcond */
 

--- a/src/sbml/SpeciesType.cpp
+++ b/src/sbml/SpeciesType.cpp
@@ -177,15 +177,6 @@ SpeciesType::isSetName () const
 int
 SpeciesType::setId (const std::string& sid)
 {
-  /* since the setId function has been used as an
-   * alias for setName we cant require it to only
-   * be used on a L2 model
-   */
-/*  if (getLevel() == 1)
-  {
-    return LIBSBML_UNEXPECTED_ATTRIBUTE;
-  }
-*/
   if (!(SyntaxChecker::isValidInternalSId(sid)))
   {
     return LIBSBML_INVALID_ATTRIBUTE_VALUE;
@@ -405,24 +396,6 @@ SpeciesType::getAttribute(const std::string& attributeName,
 /** @cond doxygenLibsbmlInternal */
 
 /*
- * Returns the value of the "attributeName" attribute of this SpeciesType.
- */
-//int
-//SpeciesType::getAttribute(const std::string& attributeName,
-//                          const char* value) const
-//{
-//  int return_value = SBase::getAttribute(attributeName, value);
-//
-//  return return_value;
-//}
-
-/** @endcond */
-
-
-
-/** @cond doxygenLibsbmlInternal */
-
-/*
  * Predicate returning @c true if this SpeciesType's attribute "attributeName"
  * is set.
  */
@@ -520,23 +493,6 @@ SpeciesType::setAttribute(const std::string& attributeName,
 
   return return_value;
 }
-
-/** @endcond */
-
-
-
-/** @cond doxygenLibsbmlInternal */
-
-/*
- * Sets the value of the "attributeName" attribute of this SpeciesType.
- */
-//int
-//SpeciesType::setAttribute(const std::string& attributeName, const char* value)
-//{
-//  int return_value = SBase::setAttribute(attributeName, value);
-//
-//  return return_value;
-//}
 
 /** @endcond */
 

--- a/src/sbml/SpeciesType.h
+++ b/src/sbml/SpeciesType.h
@@ -419,26 +419,6 @@ public:
   /** @cond doxygenLibsbmlInternal */
 
   /**
-   * Returns the value of the "attributeName" attribute of this SpeciesType.
-   *
-   * @param attributeName, the name of the attribute to retrieve.
-   *
-   * @param value, the address of the value to record.
-   *
-   * @copydetails doc_returns_success_code
-   * @li @sbmlconstant{LIBSBML_OPERATION_SUCCESS, OperationReturnValues_t}
-   * @li @sbmlconstant{LIBSBML_OPERATION_FAILED, OperationReturnValues_t}
-   */
-  //virtual int getAttribute(const std::string& attributeName,
-  //                         const char* value) const;
-
-  /** @endcond */
-
-
-
-  /** @cond doxygenLibsbmlInternal */
-
-  /**
    * Predicate returning @c true if this SpeciesType's attribute
    * "attributeName" is set.
    *
@@ -553,26 +533,6 @@ public:
   /** @cond doxygenLibsbmlInternal */
 
   /**
-   * Sets the value of the "attributeName" attribute of this SpeciesType.
-   *
-   * @param attributeName, the name of the attribute to set.
-   *
-   * @param value, the value of the attribute to set.
-   *
-   * @copydetails doc_returns_success_code
-   * @li @sbmlconstant{LIBSBML_OPERATION_SUCCESS, OperationReturnValues_t}
-   * @li @sbmlconstant{LIBSBML_OPERATION_FAILED, OperationReturnValues_t}
-   */
-  //virtual int setAttribute(const std::string& attributeName, const char*
-  //  value);
-
-  /** @endcond */
-
-
-
-  /** @cond doxygenLibsbmlInternal */
-
-  /**
    * Unsets the value of the "attributeName" attribute of this SpeciesType.
    *
    * @param attributeName, the name of the attribute to query.
@@ -623,9 +583,6 @@ protected:
    * @param stream the XMLOutputStream to use.
    */
   virtual void writeAttributes (XMLOutputStream& stream) const;
-
-  //std::string  mId;
-  //std::string  mName;
 
   /* the validator classes need to be friends to access the 
    * protected constructor that takes no arguments

--- a/src/sbml/StoichiometryMath.h
+++ b/src/sbml/StoichiometryMath.h
@@ -572,14 +572,6 @@ protected:
    */
   virtual bool readOtherXML (XMLInputStream& stream);
 
-  /**
-   * Create and return an SBML object of this class, if present.
-   *
-   * @return the SBML object corresponding to next XMLToken in the
-   * XMLInputStream or @c NULL if the token was not recognized.
-   */
-//  virtual SBase* createObject (XMLInputStream& stream);
-
 
   /**
    * Subclasses should override this method to get the list of

--- a/src/sbml/SyntaxChecker.cpp
+++ b/src/sbml/SyntaxChecker.cpp
@@ -651,8 +651,8 @@ SyntaxChecker::isUnicodeLetter(std::string::iterator it, unsigned int numBytes)
 
 
   unsigned char c1 = (unsigned char)*it;
-  unsigned char c2 ;/* = *(it+1); */
-  unsigned char c3 ;/* = *(it+2); */
+  unsigned char c2;
+  unsigned char c3;
   
   switch (numBytes)
   {
@@ -1344,8 +1344,8 @@ SyntaxChecker::isUnicodeDigit(std::string::iterator it, unsigned int numBytes)
 
 
   unsigned char c1 = (unsigned char)*it;
-  unsigned char c2 ;/* = *(it+1); */
-  unsigned char c3 ;/* = *(it+2); */
+  unsigned char c2;
+  unsigned char c3;
   
   switch (numBytes)
   {
@@ -1585,8 +1585,8 @@ SyntaxChecker::isCombiningChar(std::string::iterator it, unsigned int numBytes)
   */
 
   unsigned char c1 = (unsigned char)*it;
-  unsigned char c2 ;/* = *(it+1); */
-  unsigned char c3 ;/* = *(it+2); */
+  unsigned char c2;
+  unsigned char c3;
   
   switch (numBytes)
   {
@@ -1987,8 +1987,8 @@ SyntaxChecker::isExtender(std::string::iterator it, unsigned int numBytes)
   */
 
   unsigned char c1 = (unsigned char)*it;
-  unsigned char c2 ;/* = *(it+1); */
-  unsigned char c3 ;/* = *(it+2); */
+  unsigned char c2;
+  unsigned char c3;
   
   switch (numBytes)
   {

--- a/src/sbml/Trigger.cpp
+++ b/src/sbml/Trigger.cpp
@@ -521,24 +521,6 @@ Trigger::getAttribute(const std::string& attributeName,
 /** @cond doxygenLibsbmlInternal */
 
 /*
- * Returns the value of the "attributeName" attribute of this Trigger.
- */
-//int
-//Trigger::getAttribute(const std::string& attributeName,
-//                      const char* value) const
-//{
-//  int return_value = SBase::getAttribute(attributeName, value);
-//
-//  return return_value;
-//}
-
-/** @endcond */
-
-
-
-/** @cond doxygenLibsbmlInternal */
-
-/*
  * Predicate returning @c true if this Trigger's attribute "attributeName" is
  * set.
  */
@@ -653,23 +635,6 @@ Trigger::setAttribute(const std::string& attributeName,
 
   return return_value;
 }
-
-/** @endcond */
-
-
-
-/** @cond doxygenLibsbmlInternal */
-
-/*
- * Sets the value of the "attributeName" attribute of this Trigger.
- */
-//int
-//Trigger::setAttribute(const std::string& attributeName, const char* value)
-//{
-//  int return_value = SBase::setAttribute(attributeName, value);
-//
-//  return return_value;
-//}
 
 /** @endcond */
 

--- a/src/sbml/Trigger.h
+++ b/src/sbml/Trigger.h
@@ -633,26 +633,6 @@ public:
   /** @cond doxygenLibsbmlInternal */
 
   /**
-   * Returns the value of the "attributeName" attribute of this Trigger.
-   *
-   * @param attributeName, the name of the attribute to retrieve.
-   *
-   * @param value, the address of the value to record.
-   *
-   * @copydetails doc_returns_success_code
-   * @li @sbmlconstant{LIBSBML_OPERATION_SUCCESS, OperationReturnValues_t}
-   * @li @sbmlconstant{LIBSBML_OPERATION_FAILED, OperationReturnValues_t}
-   */
-  //virtual int getAttribute(const std::string& attributeName,
-  //                         const char* value) const;
-
-  /** @endcond */
-
-
-
-  /** @cond doxygenLibsbmlInternal */
-
-  /**
    * Predicate returning @c true if this Trigger's attribute "attributeName" is
    * set.
    *
@@ -767,26 +747,6 @@ public:
   /** @cond doxygenLibsbmlInternal */
 
   /**
-   * Sets the value of the "attributeName" attribute of this Trigger.
-   *
-   * @param attributeName, the name of the attribute to set.
-   *
-   * @param value, the value of the attribute to set.
-   *
-   * @copydetails doc_returns_success_code
-   * @li @sbmlconstant{LIBSBML_OPERATION_SUCCESS, OperationReturnValues_t}
-   * @li @sbmlconstant{LIBSBML_OPERATION_FAILED, OperationReturnValues_t}
-   */
-  //virtual int setAttribute(const std::string& attributeName, const char*
-  //  value);
-
-  /** @endcond */
-
-
-
-  /** @cond doxygenLibsbmlInternal */
-
-  /**
    * Unsets the value of the "attributeName" attribute of this Trigger.
    *
    * @param attributeName, the name of the attribute to query.
@@ -825,14 +785,6 @@ protected:
    * @return @c true if the subclass read from the stream, @c false otherwise.
    */
   virtual bool readOtherXML (XMLInputStream& stream);
-
-  /**
-   * Create and return an SBML object of this class, if present.
-   *
-   * @return the SBML object corresponding to next XMLToken in the
-   * XMLInputStream or @c NULL if the token was not recognized.
-   */
-//  virtual SBase* createObject (XMLInputStream& stream);
 
 
   /**

--- a/src/sbml/Unit.cpp
+++ b/src/sbml/Unit.cpp
@@ -86,7 +86,7 @@ Unit::Unit (unsigned int level, unsigned int version) :
   if (level == 3)
   {
     mExponentDouble = numeric_limits<double>::quiet_NaN();
-    mScale = SBML_INT_MAX;//numeric_limits<int>::max();
+    mScale = SBML_INT_MAX;
     mMultiplier = numeric_limits<double>::quiet_NaN();
   }
   // before level 3 exponent, scale and multiplier were set by default
@@ -280,7 +280,7 @@ Unit::getExponent () const
       }
       else
       {
-        return 0;// numeric_limits<int>::quiet_NaN();
+        return 0;
       }
     }
     else
@@ -1156,27 +1156,6 @@ Unit::getAttribute(const std::string& attributeName, std::string& value) const
 /** @cond doxygenLibsbmlInternal */
 
 /*
- * Returns the value of the "attributeName" attribute of this Unit.
- */
-//int
-//Unit::getAttribute(const std::string& attributeName, const char* value) const
-//{
-//  int return_value = SBase::getAttribute(attributeName, value);
-//
-//  if (attributeName == "kind")
-//  {
-//    value = UnitKind_toString(getKind());
-//  }
-//  return return_value;
-//}
-
-/** @endcond */
-
-
-
-/** @cond doxygenLibsbmlInternal */
-
-/*
  * Predicate returning @c true if this Unit's attribute "attributeName" is set.
  */
 bool
@@ -1322,23 +1301,6 @@ Unit::setAttribute(const std::string& attributeName, const std::string& value)
   }
   return return_value;
 }
-
-/** @endcond */
-
-
-
-/** @cond doxygenLibsbmlInternal */
-
-/*
- * Sets the value of the "attributeName" attribute of this Unit.
- */
-//int
-//Unit::setAttribute(const std::string& attributeName, const char* value)
-//{
-//  int return_value = SBase::setAttribute(attributeName, value);
-//
-//  return return_value;
-//}
 
 /** @endcond */
 
@@ -1613,11 +1575,6 @@ Unit::merge(Unit * unit1, Unit * unit2)
 
   if (newExponent == 0)
   {
-    // actually we do not want the new multiplier to be 1
-    // there may be a scaling factor in the now dimensionless unit that
-    // needs to propogate thru a units calculation
-    // newMultiplier = 1;
-
     newMultiplier = unit1Multi * unit2Multi;
   }
   else
@@ -1703,7 +1660,6 @@ Unit::convertToSI(const Unit * unit)
       /* 1 coulomb = 1 Ampere second */
       newUnit->setKind(UNIT_KIND_AMPERE);
       ud->addUnit(newUnit);
- //     newUnit = new Unit(uKind, unit->getExponent(), unit->getScale(), unit->getMultiplier());
       newUnit->setKind(UNIT_KIND_SECOND);
       newUnit->setExponentUnitChecking(unit->getExponentUnitChecking());
       newUnit->setMultiplier(1);
@@ -1726,17 +1682,14 @@ Unit::convertToSI(const Unit * unit)
       newUnit->setMultiplier(truncateDoublePrecision(newMultiplier));
       newUnit->setExponentUnitChecking(2*newUnit->getExponentUnitChecking());  
       ud->addUnit(newUnit);
-//      newUnit = new Unit(uKind, unit->getExponent(), unit->getScale(), unit->getMultiplier());
       newUnit->setKind(UNIT_KIND_KILOGRAM);
       newUnit->setMultiplier(1.0);
       newUnit->setExponentUnitChecking(-1*unit->getExponentUnitChecking());  
       ud->addUnit(newUnit);
-//      newUnit = new Unit(uKind, unit->getExponent(), unit->getScale(), unit->getMultiplier());
       newUnit->setKind(UNIT_KIND_METRE);
       newUnit->setMultiplier(1.0);
       newUnit->setExponentUnitChecking(-2*unit->getExponentUnitChecking());  
       ud->addUnit(newUnit);
-//      newUnit = new Unit(uKind, unit->getExponent(), unit->getScale(), unit->getMultiplier());
       newUnit->setKind(UNIT_KIND_SECOND);
       newUnit->setMultiplier(1.0);
       newUnit->setExponentUnitChecking(4*unit->getExponentUnitChecking());  
@@ -1760,7 +1713,6 @@ Unit::convertToSI(const Unit * unit)
       newUnit->setMultiplier(truncateDoublePrecision(newMultiplier));
       newUnit->setExponentUnitChecking(2*newUnit->getExponentUnitChecking());  
       ud->addUnit(newUnit);
- //     newUnit = new Unit(uKind, unit->getExponent(), unit->getScale(), unit->getMultiplier());
       newUnit->setKind(UNIT_KIND_SECOND);
       newUnit->setMultiplier(1.0);
       newUnit->setExponentUnitChecking(-2*unit->getExponentUnitChecking());  
@@ -1775,17 +1727,14 @@ Unit::convertToSI(const Unit * unit)
       newUnit->setMultiplier(truncateDoublePrecision(newMultiplier));
       newUnit->setExponentUnitChecking(-2*newUnit->getExponentUnitChecking());  
       ud->addUnit(newUnit);
-//      newUnit = new Unit(uKind, unit->getExponent(), unit->getScale(), unit->getMultiplier());
       newUnit->setKind(UNIT_KIND_KILOGRAM);
       newUnit->setMultiplier(1.0);
       newUnit->setExponentUnitChecking(unit->getExponentUnitChecking());
       ud->addUnit(newUnit);
-//      newUnit = new Unit(uKind, unit->getExponent(), unit->getScale(), unit->getMultiplier());
       newUnit->setKind(UNIT_KIND_METRE);
       newUnit->setMultiplier(1.0);
       newUnit->setExponentUnitChecking(2*unit->getExponentUnitChecking());  
       ud->addUnit(newUnit);
- //     newUnit = new Unit(uKind, unit->getExponent(), unit->getScale(), unit->getMultiplier());
       newUnit->setKind(UNIT_KIND_SECOND);
       newUnit->setMultiplier(1.0);
       newUnit->setExponentUnitChecking(-2*unit->getExponentUnitChecking());  
@@ -1801,12 +1750,10 @@ Unit::convertToSI(const Unit * unit)
       /* 1 joule = 1 m^2 kg s^-2 */
       newUnit->setKind(UNIT_KIND_KILOGRAM);
       ud->addUnit(newUnit);
-//      newUnit = new Unit(uKind, unit->getExponent(), unit->getScale(), unit->getMultiplier());
       newUnit->setKind(UNIT_KIND_METRE);
       newUnit->setMultiplier(1.0);
       newUnit->setExponentUnitChecking(2*unit->getExponentUnitChecking());  
       ud->addUnit(newUnit);
-//      newUnit = new Unit(uKind, unit->getExponent(), unit->getScale(), unit->getMultiplier());
       newUnit->setKind(UNIT_KIND_SECOND);
       newUnit->setMultiplier(1.0);
       newUnit->setExponentUnitChecking(-2*unit->getExponentUnitChecking());  
@@ -1817,7 +1764,6 @@ Unit::convertToSI(const Unit * unit)
       /* 1 katal = 1 mol s^-1 */
       newUnit->setKind(UNIT_KIND_MOLE);
       ud->addUnit(newUnit);
-//      newUnit = new Unit(uKind, unit->getExponent(), unit->getScale(), unit->getMultiplier());
       newUnit->setKind(UNIT_KIND_SECOND);
       newUnit->setMultiplier(1.0);
       newUnit->setExponentUnitChecking(-1*unit->getExponentUnitChecking());  
@@ -1855,7 +1801,6 @@ Unit::convertToSI(const Unit * unit)
       /* 1 lux = 1 candela m^-2*/ 
       newUnit->setKind(UNIT_KIND_CANDELA);
       ud->addUnit(newUnit);
-//      newUnit = new Unit(uKind, unit->getExponent(), unit->getScale(), unit->getMultiplier());
       newUnit->setKind(UNIT_KIND_METRE);
       newUnit->setMultiplier(1.0);
       newUnit->setExponentUnitChecking(-2*unit->getExponentUnitChecking());  
@@ -1878,12 +1823,10 @@ Unit::convertToSI(const Unit * unit)
       /* 1 newton = 1 m kg s^-2 */
       newUnit->setKind(UNIT_KIND_KILOGRAM);
       ud->addUnit(newUnit);
-//      newUnit = new Unit(uKind, unit->getExponent(), unit->getScale(), unit->getMultiplier());
       newUnit->setKind(UNIT_KIND_METRE);
       newUnit->setMultiplier(1.0);
       newUnit->setExponentUnitChecking(unit->getExponentUnitChecking());
       ud->addUnit(newUnit);
-//      newUnit = new Unit(uKind, unit->getExponent(), unit->getScale(), unit->getMultiplier());
       newUnit->setKind(UNIT_KIND_SECOND);
       newUnit->setMultiplier(1.0);
       newUnit->setExponentUnitChecking(-2*unit->getExponentUnitChecking());  
@@ -1898,17 +1841,14 @@ Unit::convertToSI(const Unit * unit)
       newUnit->setMultiplier(truncateDoublePrecision(newMultiplier));
       newUnit->setExponentUnitChecking(-2*newUnit->getExponentUnitChecking());  
       ud->addUnit(newUnit);
-//      newUnit = new Unit(uKind, unit->getExponent(), unit->getScale(), unit->getMultiplier());
       newUnit->setKind(UNIT_KIND_KILOGRAM);
       newUnit->setMultiplier(1.0);
       newUnit->setExponentUnitChecking(unit->getExponentUnitChecking());
       ud->addUnit(newUnit);
-//      newUnit = new Unit(uKind, unit->getExponent(), unit->getScale(), unit->getMultiplier());
       newUnit->setKind(UNIT_KIND_METRE);
       newUnit->setMultiplier(1.0);
       newUnit->setExponentUnitChecking(2*unit->getExponentUnitChecking());  
       ud->addUnit(newUnit);
-//      newUnit = new Unit(uKind, unit->getExponent(), unit->getScale(), unit->getMultiplier());
       newUnit->setKind(UNIT_KIND_SECOND);
       newUnit->setMultiplier(1.0);
       newUnit->setExponentUnitChecking(-3*unit->getExponentUnitChecking());  
@@ -1919,12 +1859,10 @@ Unit::convertToSI(const Unit * unit)
       /* 1 pascal = 1 m^-1 kg s^-2 */
       newUnit->setKind(UNIT_KIND_KILOGRAM);
       ud->addUnit(newUnit);
-//      newUnit = new Unit(uKind, unit->getExponent(), unit->getScale(), unit->getMultiplier());
       newUnit->setKind(UNIT_KIND_METRE);
       newUnit->setMultiplier(1.0);
       newUnit->setExponentUnitChecking(-1*unit->getExponentUnitChecking());  
       ud->addUnit(newUnit);
-//      newUnit = new Unit(uKind, unit->getExponent(), unit->getScale(), unit->getMultiplier());
       newUnit->setKind(UNIT_KIND_SECOND);
       newUnit->setMultiplier(1.0);
       newUnit->setExponentUnitChecking(-2*unit->getExponentUnitChecking());  
@@ -1944,17 +1882,14 @@ Unit::convertToSI(const Unit * unit)
       newUnit->setMultiplier(truncateDoublePrecision(newMultiplier));
       newUnit->setExponentUnitChecking(2*newUnit->getExponentUnitChecking());  
       ud->addUnit(newUnit);
-//      newUnit = new Unit(uKind, unit->getExponent(), unit->getScale(), unit->getMultiplier());
       newUnit->setKind(UNIT_KIND_KILOGRAM);
       newUnit->setMultiplier(1.0);
       newUnit->setExponentUnitChecking(-1*unit->getExponentUnitChecking());  
       ud->addUnit(newUnit);
-//      newUnit = new Unit(uKind, unit->getExponent(), unit->getScale(), unit->getMultiplier());
       newUnit->setKind(UNIT_KIND_METRE);
       newUnit->setMultiplier(1.0);
       newUnit->setExponentUnitChecking(-2*unit->getExponentUnitChecking());  
       ud->addUnit(newUnit);
-//      newUnit = new Unit(uKind, unit->getExponent(), unit->getScale(), unit->getMultiplier());
       newUnit->setKind(UNIT_KIND_SECOND);
       newUnit->setMultiplier(1.0);
       newUnit->setExponentUnitChecking(3*unit->getExponentUnitChecking());  
@@ -1969,12 +1904,10 @@ Unit::convertToSI(const Unit * unit)
       newUnit->setMultiplier(truncateDoublePrecision(newMultiplier));
       newUnit->setExponentUnitChecking(-1*newUnit->getExponentUnitChecking());  
       ud->addUnit(newUnit);
-//      newUnit = new Unit(uKind, unit->getExponent(), unit->getScale(), unit->getMultiplier());
       newUnit->setKind(UNIT_KIND_KILOGRAM);
       newUnit->setMultiplier(1.0);
       newUnit->setExponentUnitChecking(unit->getExponentUnitChecking());
       ud->addUnit(newUnit);
-//      newUnit = new Unit(uKind, unit->getExponent(), unit->getScale(), unit->getMultiplier());
       newUnit->setKind(UNIT_KIND_SECOND);
       newUnit->setMultiplier(1.0);
       newUnit->setExponentUnitChecking(-2*unit->getExponentUnitChecking());  
@@ -1989,17 +1922,14 @@ Unit::convertToSI(const Unit * unit)
       newUnit->setMultiplier(truncateDoublePrecision(newMultiplier));
       newUnit->setExponentUnitChecking(-1*newUnit->getExponentUnitChecking());  
       ud->addUnit(newUnit);
-//      newUnit = new Unit(uKind, unit->getExponent(), unit->getScale(), unit->getMultiplier());
       newUnit->setKind(UNIT_KIND_KILOGRAM);
       newUnit->setMultiplier(1.0);
       newUnit->setExponentUnitChecking(unit->getExponentUnitChecking());
       ud->addUnit(newUnit);
-//      newUnit = new Unit(uKind, unit->getExponent(), unit->getScale(), unit->getMultiplier());
       newUnit->setKind(UNIT_KIND_METRE);
       newUnit->setMultiplier(1.0);
       newUnit->setExponentUnitChecking(2*unit->getExponentUnitChecking());  
       ud->addUnit(newUnit);
-//      newUnit = new Unit(uKind, unit->getExponent(), unit->getScale(), unit->getMultiplier());
       newUnit->setKind(UNIT_KIND_SECOND);
       newUnit->setMultiplier(1.0);
       newUnit->setExponentUnitChecking(-3*unit->getExponentUnitChecking());  
@@ -2010,12 +1940,10 @@ Unit::convertToSI(const Unit * unit)
       /* 1 watt = 1 m^2 kg s^-3 */
       newUnit->setKind(UNIT_KIND_KILOGRAM);
       ud->addUnit(newUnit);
-//      newUnit = new Unit(uKind, unit->getExponent(), unit->getScale(), unit->getMultiplier());
       newUnit->setKind(UNIT_KIND_METRE);
       newUnit->setMultiplier(1.0);
       newUnit->setExponentUnitChecking(2*unit->getExponentUnitChecking());  
       ud->addUnit(newUnit);
-//      newUnit = new Unit(uKind, unit->getExponent(), unit->getScale(), unit->getMultiplier());
       newUnit->setKind(UNIT_KIND_SECOND);
       newUnit->setMultiplier(1.0);
       newUnit->setExponentUnitChecking(-3*unit->getExponentUnitChecking());  
@@ -2030,17 +1958,14 @@ Unit::convertToSI(const Unit * unit)
       newUnit->setMultiplier(truncateDoublePrecision(newMultiplier));
       newUnit->setExponentUnitChecking(-1*newUnit->getExponentUnitChecking());  
       ud->addUnit(newUnit);
-//      newUnit = new Unit(uKind, unit->getExponent(), unit->getScale(), unit->getMultiplier());
       newUnit->setKind(UNIT_KIND_KILOGRAM);
       newUnit->setMultiplier(1.0);
       newUnit->setExponentUnitChecking(unit->getExponentUnitChecking());
       ud->addUnit(newUnit);
-//      newUnit = new Unit(uKind, unit->getExponent(), unit->getScale(), unit->getMultiplier());
       newUnit->setKind(UNIT_KIND_METRE);
       newUnit->setMultiplier(1.0);
       newUnit->setExponentUnitChecking(2*unit->getExponentUnitChecking());  
       ud->addUnit(newUnit);
-//      newUnit = new Unit(uKind, unit->getExponent(), unit->getScale(), unit->getMultiplier());
       newUnit->setKind(UNIT_KIND_SECOND);
       newUnit->setMultiplier(1.0);
       newUnit->setExponentUnitChecking(-2*unit->getExponentUnitChecking());  
@@ -2497,7 +2422,6 @@ Unit::setExponentUnitChecking (double value)
   /* cannot use setExponent becuase want a double exponent 
    * - even if we are dealing with L2/L1
    */
-  //setExponent(value);
   mExponentDouble = value;
   mExponent = (int)(value);
   mIsSetExponent = true;

--- a/src/sbml/Unit.h
+++ b/src/sbml/Unit.h
@@ -1227,26 +1227,6 @@ public:
   /** @cond doxygenLibsbmlInternal */
 
   /**
-   * Returns the value of the "attributeName" attribute of this Unit.
-   *
-   * @param attributeName, the name of the attribute to retrieve.
-   *
-   * @param value, the address of the value to record.
-   *
-   * @copydetails doc_returns_success_code
-   * @li @sbmlconstant{LIBSBML_OPERATION_SUCCESS, OperationReturnValues_t}
-   * @li @sbmlconstant{LIBSBML_OPERATION_FAILED, OperationReturnValues_t}
-   */
-  //virtual int getAttribute(const std::string& attributeName,
-  //                         const char* value) const;
-
-  /** @endcond */
-
-
-
-  /** @cond doxygenLibsbmlInternal */
-
-  /**
    * Predicate returning @c true if this Unit's attribute "attributeName" is
    * set.
    *
@@ -1353,26 +1333,6 @@ public:
    */
   virtual int setAttribute(const std::string& attributeName,
                            const std::string& value);
-
-  /** @endcond */
-
-
-
-  /** @cond doxygenLibsbmlInternal */
-
-  /**
-   * Sets the value of the "attributeName" attribute of this Unit.
-   *
-   * @param attributeName, the name of the attribute to set.
-   *
-   * @param value, the value of the attribute to set.
-   *
-   * @copydetails doc_returns_success_code
-   * @li @sbmlconstant{LIBSBML_OPERATION_SUCCESS, OperationReturnValues_t}
-   * @li @sbmlconstant{LIBSBML_OPERATION_FAILED, OperationReturnValues_t}
-   */
-  //virtual int setAttribute(const std::string& attributeName, const char*
-  //  value);
 
   /** @endcond */
 

--- a/src/sbml/UnitDefinition.cpp
+++ b/src/sbml/UnitDefinition.cpp
@@ -236,15 +236,6 @@ UnitDefinition::isSetName () const
 int
 UnitDefinition::setId (const std::string& sid)
 {
-  /* since the setId function has been used as an
-   * alias for setName we can't require it to only
-   * be used on a L2 model
-   */
-/*  if (getLevel() == 1)
-  {
-    return LIBSBML_UNEXPECTED_ATTRIBUTE;
-  }
-*/
   if (!(SyntaxChecker::isValidInternalSId(sid)))
   {
     return LIBSBML_INVALID_ATTRIBUTE_VALUE;
@@ -629,7 +620,6 @@ UnitDefinition::isVariantOfSubstancePerTime (bool relaxed) const
   // this unitDefinition times second^1 should be a variant
   // of substance
   UnitDefinition *ud = static_cast<UnitDefinition*>(this->clone());
-  //Unit *u = new Unit(UNIT_KIND_SECOND);
   Unit *u = new Unit(ud->getSBMLNamespaces());
   u->setKind(UNIT_KIND_SECOND);
   u->initDefaults();

--- a/src/sbml/UnitDefinition.h
+++ b/src/sbml/UnitDefinition.h
@@ -1058,26 +1058,6 @@ public:
   /** @cond doxygenLibsbmlInternal */
 
   /**
-   * Returns the value of the "attributeName" attribute of this UnitDefinition.
-   *
-   * @param attributeName, the name of the attribute to retrieve.
-   *
-   * @param value, the address of the value to record.
-   *
-   * @copydetails doc_returns_success_code
-   * @li @sbmlconstant{LIBSBML_OPERATION_SUCCESS, OperationReturnValues_t}
-   * @li @sbmlconstant{LIBSBML_OPERATION_FAILED, OperationReturnValues_t}
-   */
-  //virtual int getAttribute(const std::string& attributeName,
-  //                         const char* value) const;
-
-  /** @endcond */
-
-
-
-  /** @cond doxygenLibsbmlInternal */
-
-  /**
    * Predicate returning @c true if this UnitDefinition's attribute
    * "attributeName" is set.
    *
@@ -1184,26 +1164,6 @@ public:
    */
   virtual int setAttribute(const std::string& attributeName,
                            const std::string& value);
-
-  /** @endcond */
-
-
-
-  /** @cond doxygenLibsbmlInternal */
-
-  /**
-   * Sets the value of the "attributeName" attribute of this UnitDefinition.
-   *
-   * @param attributeName, the name of the attribute to set.
-   *
-   * @param value, the value of the attribute to set.
-   *
-   * @copydetails doc_returns_success_code
-   * @li @sbmlconstant{LIBSBML_OPERATION_SUCCESS, OperationReturnValues_t}
-   * @li @sbmlconstant{LIBSBML_OPERATION_FAILED, OperationReturnValues_t}
-   */
-  //virtual int setAttribute(const std::string& attributeName, const char*
-  //  value);
 
   /** @endcond */
 
@@ -1353,8 +1313,6 @@ protected:
   virtual void writeAttributes (XMLOutputStream& stream) const;
 
 
-  //std::string mId;
-  //std::string mName;
   ListOfUnits mUnits;
 
   /* the validator classes need to be friends to access the 


### PR DESCRIPTION
## Description
This PR removes commented out code.

## Motivation and Context
A large number of code smells flagged by the code analysis tool sonarcloud are caused by commented out code. This PR removes around 200 of these type of smells.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have updated all documentation necessary.
- [x] I have checked spelling in (new) comments.

## Testing
- [X] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested -->

