### PR TITLE
Make the package buildable in CMake subdirectory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ endif()
 
 
 
-set(LIBSBML_ROOT_SOURCE_DIR "${CMAKE_SOURCE_DIR}" CACHE PATH
+set(LIBSBML_ROOT_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}" CACHE PATH
     "Path to the libSBML root source directory")
 set(LIBSBML_ROOT_BINARY_DIR "${CMAKE_BINARY_DIR}" CACHE PATH
     "Path to the libSBML root build directory")


### PR DESCRIPTION
## Description
This allows to bundle libsbml in larger projects using `add_subdirectory` or CMake "ExternalProject" tools.

## Motivation and Context
Build of l3v2 math (and possibly other things) depended on the fact that libSBML is built from the "top" CMake directory. This fixes it (at least for the default build I tested).

Review is certainly needed though -- mainly, I am not sure about the rest of the build system, which occasionally contains raw `CMAKE_SOURCE_DIR` variable. Some additional changes might be needed to build e.g. the examples and some SWIG wrappers cleanly in a subdirectory (although there aren't many good reasons to do that).

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have updated all documentation necessary.   (Note: basically no documentation updated)
- [x] I have checked spelling in (new) comments.   (Note: no, there are none)

## Testing
- [X] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically

