### PR TITLE
 - #116: do compile & install math sources

### DIFF
--- a/src/sbml/math/Makefile.in
+++ b/src/sbml/math/Makefile.in
@@ -116,15 +116,14 @@ distfiles = $(sources) $(headers) Makefile.in
 # The default action is to remake everything.  Those rules which are not
 # defined below are defined in makefile-common-actions.mk.
 
-all: Makefile 
-# default
+all: Makefile default
 
 
 # -----------------------------------------------------------------------------
 # Checking.
 # -----------------------------------------------------------------------------
 
-#check: check-recursive
+check: check-recursive
 
 
 # -----------------------------------------------------------------------------
@@ -143,39 +142,24 @@ tags: etags ctags
 # in 'all' as a default to make sure files get compiled if someone does
 # 'make install' from the top level without first doing a 'make'.
 
-install:
+install: all install-headers
 
-uninstall:
+installcheck: all installcheck-headers
 
-installcheck:
-
-#install: all install-headers
-
-#installcheck: all installcheck-headers
-
-#uninstall: uninstall-headers
+uninstall: uninstall-headers
 
 
 # -----------------------------------------------------------------------------
 # Cleaning.
 # -----------------------------------------------------------------------------
 
-clean: clean-normal
+clean: clean-normal clean-recursive
 
-distclean: distclean-normal
+distclean: distclean-normal distclean-recursive
 
-mostlyclean: mostlyclean-normal
+mostlyclean: mostlyclean-normal mostlyclean-recursive
 
-maintainer-clean: maintainer-clean-normal
-
-
-#clean: clean-normal clean-recursive
-
-#distclean: distclean-normal distclean-recursive
-
-#mostlyclean: mostlyclean-normal mostlyclean-recursive
-
-#maintainer-clean: maintainer-clean-normal maintainer-clean-recursive
+maintainer-clean: maintainer-clean-normal maintainer-clean-recursive
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Description
modified gnumakefile to again compile and install math sources

## Motivation and Context
change was needed, as users had problems using gnumake compiled library.
fixes #116

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have updated all documentation necessary.
- [ ] I have checked spelling in (new) comments.

## Testing
- [ ] Testing is done automatically and codecov shows test coverage
- [x] This cannot be tested automatically <!-- describe how it has been tested -->

since our builds do not use gnumake anymore, and ci is testing only cmake, this will have to be tested manuall: 

- checkout ... ./configure && make && make install ... then compile one of the math examples (used printMath with a sample file). 

