### PR TITLE
Add basic nightly builds

### DIFF
--- a/.github/workflows/store-artefact.yml
+++ b/.github/workflows/store-artefact.yml
@@ -1,6 +1,8 @@
 name: CMake (create and store Windows artefact)
 
-on: [push]
+on:
+  schedule:
+    - cron:  '0 5 * * *'
 
 env:
   BUILD_TYPE: Release

--- a/.github/workflows/store-artefact.yml
+++ b/.github/workflows/store-artefact.yml
@@ -108,7 +108,6 @@ jobs:
       - name: Build
         working-directory: ${{runner.workspace}}/build
         shell: bash
-        # TODO make the below version-independed and OS-independent!
         run: |
           cmake --build . --config $BUILD_TYPE --parallel 4
 
@@ -119,6 +118,10 @@ jobs:
         run: ctest -C $BUILD_TYPE
 
       ### package artifact ###
+      - name: Store libSBML version in environment
+        shell: bash
+        run: echo "LIBSBML_VERSION=$( cat VERSION.txt)"  >> "${GITHUB_ENV}"
+
       - name: Set artifact name suffix to stable packages
         if: matrix.package_option=='-DWITH_STABLE_PACKAGES=ON'
         shell: bash
@@ -138,14 +141,14 @@ jobs:
         shell: bash
         run: |
           cpack -G ZIP -C $BUILD_TYPE 
-          mv libSBML-5.19.1-win64.zip libSBML-5.19.1-win64-nightly-${ARTIFACT_NAME_SUFFIX}.zip
+          mv libSBML-${LIBSBML_VERSION}-win64.zip libSBML-${LIBSBML_VERSION}-win64-nightly-${ARTIFACT_NAME_SUFFIX}.zip
 
       - name: Upload Windows binary archive
         if: matrix.platform == 'windows-latest'
         uses: actions/upload-artifact@v2
         with:
-          name: Windows nightly (zip, ${{env.ARTIFACT_NAME_SUFFIX}})
-          path: ${{runner.workspace}}/build/libSBML-5.19.1-win64-nightly-${{env.ARTIFACT_NAME_SUFFIX}}.zip
+          name: Windows nightly (zip, libSBML ${{env.LIBSBML_VERSION}}, ${{env.ARTIFACT_NAME_SUFFIX}})
+          path: ${{runner.workspace}}/build/libSBML-${{env.LIBSBML_VERSION}}-win64-nightly-${{env.ARTIFACT_NAME_SUFFIX}}.zip
           retention-days: 1
           if-no-files-found: error
 
@@ -156,16 +159,16 @@ jobs:
         shell: bash
         run: |
           cpack -G ZIP -C $BUILD_TYPE
-          mv libSBML-5.19.1-Darwin.zip libSBML-5.19.1-Darwin-nightly-${ARTIFACT_NAME_SUFFIX}.zip
+          mv libSBML-${LIBSBML_VERSION}-Darwin.zip libSBML-${LIBSBML_VERSION}-Darwin-nightly-${ARTIFACT_NAME_SUFFIX}.zip
           cpack -G TGZ -C $BUILD_TYPE
-          mv libSBML-5.19.1-Darwin.tar.gz libSBML-5.19.1-Darwin-nightly-${ARTIFACT_NAME_SUFFIX}.tar.gz
-      
+          mv libSBML-${LIBSBML_VERSION}-Darwin.tar.gz libSBML-${LIBSBML_VERSION}-Darwin-nightly-${ARTIFACT_NAME_SUFFIX}.tar.gz
+
       - name: Upload MacOS binary archive (zip)
         if: matrix.platform == 'macos-latest'
         uses: actions/upload-artifact@v2
         with:
-          name: MacOS nightly (zip, ${{env.ARTIFACT_NAME_SUFFIX}})
-          path: ${{runner.workspace}}/build/libSBML-5.19.1-Darwin-nightly-${{env.ARTIFACT_NAME_SUFFIX}}.zip
+          name: MacOS nightly (zip, libSBML ${{env.LIBSBML_VERSION}}, ${{env.ARTIFACT_NAME_SUFFIX}})
+          path: ${{runner.workspace}}/build/libSBML-${{env.LIBSBML_VERSION}}-Darwin-nightly-${{env.ARTIFACT_NAME_SUFFIX}}.zip
           retention-days: 1
           if-no-files-found: error
 
@@ -173,8 +176,8 @@ jobs:
         if: matrix.platform == 'macos-latest'
         uses: actions/upload-artifact@v2
         with:
-          name: MacOS nightly (tar.gz, ${{env.ARTIFACT_NAME_SUFFIX}})
-          path: ${{runner.workspace}}/build/libSBML-5.19.1-Darwin-nightly-${{env.ARTIFACT_NAME_SUFFIX}}.tar.gz
+          name: MacOS nightly (tar.gz, libSBML ${{env.LIBSBML_VERSION}}, ${{env.ARTIFACT_NAME_SUFFIX}})
+          path: ${{runner.workspace}}/build/libSBML-${{env.LIBSBML_VERSION}}-Darwin-nightly-${{env.ARTIFACT_NAME_SUFFIX}}.tar.gz
           retention-days: 1
           if-no-files-found: error
 
@@ -185,16 +188,16 @@ jobs:
         shell: bash
         run: |
           cpack -G ZIP -C $BUILD_TYPE
-          mv libSBML-5.19.1-Linux.zip libSBML-5.19.1-Linux-nightly-${ARTIFACT_NAME_SUFFIX}.zip
+          mv libSBML-${LIBSBML_VERSION}-Linux.zip libSBML-${LIBSBML_VERSION}-Linux-nightly-${ARTIFACT_NAME_SUFFIX}.zip
           cpack -G TGZ -C $BUILD_TYPE
-          mv libSBML-5.19.1-Linux.tar.gz libSBML-5.19.1-Linux-nightly-${ARTIFACT_NAME_SUFFIX}.tar.gz
+          mv libSBML-${LIBSBML_VERSION}-Linux.tar.gz libSBML-${LIBSBML_VERSION}-Linux-nightly-${ARTIFACT_NAME_SUFFIX}.tar.gz
 
       - name: Upload Ubuntu binary archive (zip)
         if: matrix.platform == 'ubuntu-16.04'
         uses: actions/upload-artifact@v2
         with:
-          name: Ubuntu nightly (zip, ${{env.ARTIFACT_NAME_SUFFIX}})
-          path: ${{runner.workspace}}/build/libSBML-5.19.1-Linux-nightly-${{env.ARTIFACT_NAME_SUFFIX}}.zip
+          name: Ubuntu nightly (zip, libSBML ${{env.LIBSBML_VERSION}}, ${{env.ARTIFACT_NAME_SUFFIX}})
+          path: ${{runner.workspace}}/build/libSBML-${{env.LIBSBML_VERSION}}-Linux-nightly-${{env.ARTIFACT_NAME_SUFFIX}}.zip
           retention-days: 1
           if-no-files-found: error
 
@@ -202,9 +205,7 @@ jobs:
         if: matrix.platform == 'ubuntu-16.04'
         uses: actions/upload-artifact@v2
         with:
-          name: Ubuntu nightly (tar.gz, ${{env.ARTIFACT_NAME_SUFFIX}}) 
-          path: ${{runner.workspace}}/build/libSBML-5.19.1-Linux-nightly-${{env.ARTIFACT_NAME_SUFFIX}}.tar.gz
+          name: Ubuntu nightly (tar.gz, libSBML ${{env.LIBSBML_VERSION}}, ${{env.ARTIFACT_NAME_SUFFIX}})
+          path: ${{runner.workspace}}/build/libSBML-${{env.LIBSBML_VERSION}}-Linux-nightly-${{env.ARTIFACT_NAME_SUFFIX}}.tar.gz
           retention-days: 1
           if-no-files-found: error
-
- 

--- a/.github/workflows/store-artefact.yml
+++ b/.github/workflows/store-artefact.yml
@@ -1,8 +1,8 @@
-name: CMake (create and store Windows artefact)
+name: Nightly build (binaries)
 
 on:
   schedule:
-    - cron:  '0 5 * * *'
+    - cron: "0 5 * * *"
 
 env:
   BUILD_TYPE: Release
@@ -13,12 +13,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [windows-latest]
+        platform: [windows-latest, macos-latest, ubuntu-16.04]
         xml_parser_option: ["-DWITH_LIBXML"]
         with_namespace: ["True"]
         strict: ["True"]
         with_examples: ["True"]
-        package_option: ["-DWITH_ALL_PACKAGES=ON"]
+        package_option: ["-DWITH_ALL_PACKAGES=ON", "-DWITH_STABLE_PACKAGES=ON"]
     runs-on: ${{ matrix.platform }}
 
     steps:
@@ -110,8 +110,7 @@ jobs:
         shell: bash
         # TODO make the below version-independed and OS-independent!
         run: |
-          cmake --build . --config $BUILD_TYPE --parallel 4 --target PACKAGE
-          mv libSBML-5.19.1-win64.exe libSBML-5.19.1-win64-nightly.exe
+          cmake --build . --config $BUILD_TYPE --parallel 4
 
       ### run tests ###
       - name: Test
@@ -119,9 +118,93 @@ jobs:
         shell: bash
         run: ctest -C $BUILD_TYPE
 
-      - name: Upload Windows64 installer artifact
+      ### package artifact ###
+      - name: Set artifact name suffix to stable packages
+        if: matrix.package_option=='-DWITH_STABLE_PACKAGES=ON'
+        shell: bash
+        run: |
+          echo "ARTIFACT_NAME_SUFFIX=stable-packages" >> "${GITHUB_ENV}"
+
+      - name: Set artifact name suffix to all packages
+        if: matrix.package_option=='-DWITH_ALL_PACKAGES=ON'
+        shell: bash
+        run: |
+          echo "ARTIFACT_NAME_SUFFIX=all-packages" >> "${GITHUB_ENV}"
+
+      #### Windows ####
+      - name: Package executable (Windows)
+        if: matrix.platform == 'windows-latest'
+        working-directory: ${{runner.workspace}}/build
+        shell: bash
+        run: |
+          cpack -G ZIP -C $BUILD_TYPE 
+          mv libSBML-5.19.1-win64.zip libSBML-5.19.1-win64-nightly-${ARTIFACT_NAME_SUFFIX}.zip
+
+      - name: Upload Windows binary archive
+        if: matrix.platform == 'windows-latest'
         uses: actions/upload-artifact@v2
         with:
-          name: Win64 installer
-          path: ${{runner.workspace}}/build/libSBML-5.19.1-win64-nightly.exe
+          name: Windows nightly (zip, ${{env.ARTIFACT_NAME_SUFFIX}})
+          path: ${{runner.workspace}}/build/libSBML-5.19.1-win64-nightly-${{env.ARTIFACT_NAME_SUFFIX}}.zip
           retention-days: 1
+          if-no-files-found: error
+
+      #### Mac OS ####
+      - name: Package executable (MacOS)
+        if: matrix.platform == 'macos-latest'
+        working-directory: ${{runner.workspace}}/build
+        shell: bash
+        run: |
+          cpack -G ZIP -C $BUILD_TYPE
+          mv libSBML-5.19.1-Darwin.zip libSBML-5.19.1-Darwin-nightly-${ARTIFACT_NAME_SUFFIX}.zip
+          cpack -G TGZ -C $BUILD_TYPE
+          mv libSBML-5.19.1-Darwin.tar.gz libSBML-5.19.1-Darwin-nightly-${ARTIFACT_NAME_SUFFIX}.tar.gz
+      
+      - name: Upload MacOS binary archive (zip)
+        if: matrix.platform == 'macos-latest'
+        uses: actions/upload-artifact@v2
+        with:
+          name: MacOS nightly (zip, ${{env.ARTIFACT_NAME_SUFFIX}})
+          path: ${{runner.workspace}}/build/libSBML-5.19.1-Darwin-nightly-${{env.ARTIFACT_NAME_SUFFIX}}.zip
+          retention-days: 1
+          if-no-files-found: error
+
+      - name: Upload MacOS binary archive (tar.gz)
+        if: matrix.platform == 'macos-latest'
+        uses: actions/upload-artifact@v2
+        with:
+          name: MacOS nightly (tar.gz, ${{env.ARTIFACT_NAME_SUFFIX}})
+          path: ${{runner.workspace}}/build/libSBML-5.19.1-Darwin-nightly-${{env.ARTIFACT_NAME_SUFFIX}}.tar.gz
+          retention-days: 1
+          if-no-files-found: error
+
+      #### Ubuntu 16.04 ####
+      - name: Package executable (Ubuntu 16.04)
+        if: matrix.platform == 'ubuntu-16.04'
+        working-directory: ${{runner.workspace}}/build
+        shell: bash
+        run: |
+          cpack -G ZIP -C $BUILD_TYPE
+          mv libSBML-5.19.1-Linux.zip libSBML-5.19.1-Linux-nightly-${ARTIFACT_NAME_SUFFIX}.zip
+          cpack -G TGZ -C $BUILD_TYPE
+          mv libSBML-5.19.1-Linux.tar.gz libSBML-5.19.1-Linux-nightly-${ARTIFACT_NAME_SUFFIX}.tar.gz
+
+      - name: Upload Ubuntu binary archive (zip)
+        if: matrix.platform == 'ubuntu-16.04'
+        uses: actions/upload-artifact@v2
+        with:
+          name: Ubuntu nightly (zip, ${{env.ARTIFACT_NAME_SUFFIX}})
+          path: ${{runner.workspace}}/build/libSBML-5.19.1-Linux-nightly-${{env.ARTIFACT_NAME_SUFFIX}}.zip
+          retention-days: 1
+          if-no-files-found: error
+
+      - name: Upload Ubuntu binary archive (tar.gz)
+        if: matrix.platform == 'ubuntu-16.04'
+        uses: actions/upload-artifact@v2
+        with:
+          name: Ubuntu nightly (tar.gz, ${{env.ARTIFACT_NAME_SUFFIX}}) 
+          path: ${{runner.workspace}}/build/libSBML-5.19.1-Linux-nightly-${{env.ARTIFACT_NAME_SUFFIX}}.tar.gz
+          retention-days: 1
+          if-no-files-found: error
+
+ 

--- a/.github/workflows/store-artefact.yml
+++ b/.github/workflows/store-artefact.yml
@@ -1,0 +1,125 @@
+name: CMake (create and store Windows artefact)
+
+on: [push]
+
+env:
+  BUILD_TYPE: Release
+
+jobs:
+  build:
+    name: ${{ matrix.platform }}, Parser option ${{ matrix.xml_parser_option }}, with namespaces ${{ matrix.with_namespace}}, strict includes ${{ matrix.with_namespace }}, with examples ${{ matrix.with_examples}}, package option ${{ matrix.package_option}}
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: [windows-latest]
+        xml_parser_option: ["-DWITH_LIBXML"]
+        with_namespace: ["True"]
+        strict: ["True"]
+        with_examples: ["True"]
+        package_option: ["-DWITH_ALL_PACKAGES=ON"]
+    runs-on: ${{ matrix.platform }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      ### configure the operating system ###
+      - name: Cache Windows dependencies and SWIG
+        # On Windows, the dependencies live inside the source folder, ie `.`.
+        # For the CI, we put SWIG there too, for simplicity.
+        if: matrix.platform == 'windows-latest'
+        id: cache-win-dependencies
+        uses: actions/cache@v2
+        with:
+          path: |
+            ./dependencies
+            ./swig
+          key: ${{ runner.os }}-dependencies
+
+      - name: Download pre-built Windows dependencies and SWIG
+        # Windows dependencies have to be in a subfolder called `dependencies`, directly under the git repository root.
+        # also gets SWIG, completing the set of dependencies needed for windows
+        if: matrix.platform == 'windows-latest' && steps.cache-win-dependencies.outputs.cache-hit != 'true'
+        shell: bash
+        run: |
+          curl -L https://sourceforge.net/projects/sbml/files/libsbml/win-dependencies/libSBML_dependencies_vs15_release_x64.zip/download > dependencies.zip
+          unzip dependencies.zip -d dependencies
+          cp -r dependencies/libSBML\ Dependencies-1.0.0-b1-win64/* dependencies
+          rm -r dependencies/libSBML*
+          curl -L https://prdownloads.sourceforge.net/swig/swigwin-3.0.12.zip > swig.zip
+          unzip swig.zip -d swig
+
+      - name: add SWIG to Path (Windows)
+        # this is separate from the SWIG download itself, because it needs to be added to the path also when SWIG is cached
+        if: matrix.platform == 'windows-latest'
+        shell: bash
+        run: |
+          echo $GITHUB_WORKSPACE"/swig/swigwin-3.0.12/" >> $GITHUB_PATH
+
+      - name: Install Ubuntu dependencies
+        # ubuntu already has SWIG and libxml2 by default
+        if: matrix.platform == 'ubuntu-16.04'
+        shell: bash
+        run: |
+          sudo apt-get install -y check ccache
+
+      - name: Install MacOS dependencies
+        # MacOS already has libxml2 by default
+        if: matrix.platform == 'macos-latest'
+        shell: bash
+        run: |
+          brew install check swig ccache
+
+      ### setup ccache, not on Windows ###
+      - name: Prepare ccache timestamp
+        if: matrix.platform != 'windows-latest'
+        id: ccache_cache_timestamp
+        shell: cmake -P {0}
+        run: |
+          string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
+          message("::set-output name=timestamp::${current_date}")
+      - name: Set ccache cache directory
+        if: matrix.platform != 'windows-latest'
+        shell: bash
+        run: |
+          echo "CCACHE_DIR=${{runner.workspace}}/.ccache" >> "${GITHUB_ENV}"
+          echo "COMPILER_LAUNCHER=ccache" >> "${GITHUB_ENV}"
+      - name: cache ccache files
+        if: matrix.platform != 'windows-latest'
+        uses: actions/cache@v2
+        with:
+          path: ${{runner.workspace}}/.ccache
+          key: ${{ runner.os }}-${{ steps.ccache_cache_timestamp.outputs.timestamp }}
+          restore-keys: |
+            ${{ runner.os }}-${{ steps.ccache_cache_timestamp.outputs.timestamp }}
+            ${{ runner.os }}-
+
+      ### build the project ###
+      - name: Create Build Environment
+        run: cmake -E make_directory ${{runner.workspace}}/build
+
+      - name: Configure CMake for default XML_parser (LIBXML2)
+        shell: bash
+        working-directory: ${{runner.workspace}}/build
+        run: |
+          cmake $GITHUB_WORKSPACE -DCMAKE_C_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} -DCMAKE_CXX_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} ${{ matrix.package_option }}-DCMAKE_BUILD_TYPE=$BUILD_TYPE -DWITH_CHECK=True -DWITH_JAVA=True -DWITH_CPP_NAMESPACE=${{matrix.with_namespace}} -DLIBSBML_USE_STRICT_INCLUDES=${{matrix.strict}} -DWITH_EXAMPLES=${{matrix.with_examples}}
+
+      - name: Build
+        working-directory: ${{runner.workspace}}/build
+        shell: bash
+        # TODO make the below version-independed and OS-independent!
+        run: |
+          cmake --build . --config $BUILD_TYPE --parallel 4 --target PACKAGE
+          mv libSBML-5.19.1-win64.exe libSBML-5.19.1-win64-nightly.exe
+
+      ### run tests ###
+      - name: Test
+        working-directory: ${{runner.workspace}}/build
+        shell: bash
+        run: ctest -C $BUILD_TYPE
+
+      - name: Upload Windows64 installer artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: Win64 installer
+          path: ${{runner.workspace}}/build/libSBML-5.19.1-win64-nightly.exe
+          retention-days: 1


### PR DESCRIPTION
## Description

This PR adds a completely new GitHub actions workflow file, that is aimed at taking care of nightly builds.
The workflow is scheduled to run at 5 AM UTC (but actually seems to start around 15 minutes later) every day.
For each of Windows, Mac and Ubuntu, it builds and run the tests, with stable packages, and with all packages.
It then packages the builds into binaries and provides them as compressed files (zip for Windows, zip and tar.gz for unix-based OSs) with appropriate names. An example of the binaries provided can be seen [here](https://github.com/alessandrofelder/libsbml/actions/runs/570612644).

All CI currently only has Java bindings. Providing users with bindings to other languages will be done in a separate PR, which will also add those bindings to the two other workflows we have.

I am not sure what the best way to test the artifacts is? I would appreciate reviewer comments on this.

## Motivation and Context

This is a step towards a simpler and more frequent provision of the latest builds of libsbml.
More language bindings should be provided soon.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have updated all documentation necessary (CI/CD docs currently held in a separate document on google drive).
- [x] I have checked spelling in (new) comments.

## Testing
- [ ] Testing is done automatically and codecov shows test coverage
- [x] This cannot be tested automatically. Not sure how to best test this. Could manually download artefacts and check that they work well in conjunction with software they are supposed to integrate well with?

