### PR TITLE
reduce number of build configurations on PR

### DIFF
--- a/.github/workflows/extensive.yml
+++ b/.github/workflows/extensive.yml
@@ -22,7 +22,7 @@ jobs:
         strict: ["True", "False"]
         with_examples: ["True", "False"]
         package_option:
-          ["", "-DWITH_STABLE_PACKAGES=ON", "-DWITH_ALL_PACKAGES=ON"]
+          ["-DWITH_STABLE_PACKAGES=ON", "-DWITH_ALL_PACKAGES=ON"]
         language_bindings:
           [
             "-DWITH_JAVA=True -DWITH_CSHARP=True -DWITH_CPP_NAMESPACE=True -DWITH_PYTHON=True",


### PR DESCRIPTION
## Description
Removes unnecessary workflow configurations from the 216 in `extensive.yml`, the "long" CI run that is triggered when a PR is made.
The removed workflow configurations are:
- "without any packages". This is unnecessary because any flaws with this configuration will be caught if we compiled with stable or all packages too.

## Motivation and Context
Currently, when we get to a PR stage, the `extensive.yml` GitHub actions workflow is run, consisting of 216 different jobs that take a total of ~ to run. Many of these runs are superfluous, and this PR is an attempt to remove the superfluous jobs from extensive.yml.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have updated all documentation necessary.
- [x] I have checked spelling in (new) comments.

## Testing
- [ ] Testing is done automatically and codecov shows test coverage
- [x] This cannot be tested automatically. This PR only removes some superfluous workflow runs.

