### PR TITLE
Reduce number of jobs via conditionals

### DIFF
--- a/.github/workflows/brief.yml
+++ b/.github/workflows/brief.yml
@@ -7,7 +7,7 @@ env:
 
 jobs:
   build:
-    name: ${{ matrix.platform }}, Parser option ${{ matrix.xml_parser_option }}, with namespaces ${{ matrix.with_namespace}}, strict includes ${{ matrix.with_namespace }}, with examples ${{ matrix.with_examples}}, package option ${{ matrix.package_option}}
+    name: ${{ matrix.platform }}, Parser option ${{ matrix.xml_parser_option }}, with namespaces ${{ matrix.with_namespace}}, strict includes ${{ matrix.strict }}, with examples ${{ matrix.with_examples}}, package option ${{ matrix.package_option}}
     strategy:
       fail-fast: false
       matrix:
@@ -18,9 +18,7 @@ jobs:
         with_examples: ["True"]
         package_option: ["-DWITH_ALL_PACKAGES=ON"]
         language_bindings:
-          [
-            "-DWITH_JAVA=True -DWITH_CSHARP=True -DWITH_PYTHON=True",
-          ]
+          ["-DWITH_JAVA=True -DWITH_CSHARP=True -DWITH_PYTHON=True"]
     runs-on: ${{ matrix.platform }}
 
     steps:

--- a/.github/workflows/brief.yml
+++ b/.github/workflows/brief.yml
@@ -19,7 +19,7 @@ jobs:
         package_option: ["-DWITH_ALL_PACKAGES=ON"]
         language_bindings:
           [
-            "-DWITH_JAVA=True -DWITH_CSHARP=True -DWITH_CPP_NAMESPACE=True -DWITH_PYTHON=True",
+            "-DWITH_JAVA=True -DWITH_CSHARP=True -DWITH_PYTHON=True",
           ]
     runs-on: ${{ matrix.platform }}
 

--- a/.github/workflows/extensive.yml
+++ b/.github/workflows/extensive.yml
@@ -71,6 +71,7 @@ jobs:
         shell: bash
         run: |
           sudo apt-get install -y check libxerces-c-dev expat ccache
+          echo PYTHON_LINKING_OPTION="-DPYTHON_USE_DYNAMIC_LOOKUP=ON" >> "${GITHUB_ENV}"
 
       - name: Install MacOS dependencies
         # MacOS already has libxml2 by default
@@ -78,7 +79,7 @@ jobs:
         shell: bash
         run: |
           brew install check swig xerces-c expat ccache
-          echo PYTHON_EXECUTABLE_OPTION="-DPYTHON_EXECUTABLE=/usr/local/bin/python3" >> "${GITHUB_ENV}"
+          echo PYTHON_LINKING_OPTION="-DPYTHON_USE_DYNAMIC_LOOKUP=ON" >> "${GITHUB_ENV}"
 
       ### setup ccache, not on Windows ###
       - name: Prepare ccache timestamp
@@ -119,7 +120,7 @@ jobs:
         shell: bash
         working-directory: ${{runner.workspace}}/build
         run: |
-          cmake $GITHUB_WORKSPACE ${PYTHON_EXECUTABLE_OPTION} -DCMAKE_C_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} -DCMAKE_CXX_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} ${{ matrix.package_option }}-DCMAKE_BUILD_TYPE=$BUILD_TYPE -DWITH_CHECK=True ${{matrix.language_bindings}} -DWITH_CPP_NAMESPACE=${{matrix.with_namespace}} -DLIBSBML_USE_STRICT_INCLUDES=${{matrix.strict}} -DWITH_EXAMPLES=${{matrix.with_examples}}
+          cmake $GITHUB_WORKSPACE ${PYTHON_LINKING_OPTION} -DCMAKE_C_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} -DCMAKE_CXX_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} ${{ matrix.package_option }}-DCMAKE_BUILD_TYPE=$BUILD_TYPE -DWITH_CHECK=True ${{matrix.language_bindings}} -DWITH_CPP_NAMESPACE=${{matrix.with_namespace}} -DLIBSBML_USE_STRICT_INCLUDES=${{matrix.strict}} -DWITH_EXAMPLES=${{matrix.with_examples}}
 
       - name: Configure CMake for non-default XML_parser
         if: matrix.xml_parser_option != '-DWITH_LIBXML'

--- a/.github/workflows/extensive.yml
+++ b/.github/workflows/extensive.yml
@@ -119,14 +119,14 @@ jobs:
         shell: bash
         working-directory: ${{runner.workspace}}/build
         run: |
-          cmake $GITHUB_WORKSPACE ${PYTHON_EXECUTABLE_OPTION} -DCMAKE_C_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} -DCMAKE_CXX_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} ${{ matrix.package_option }}-DCMAKE_BUILD_TYPE=$BUILD_TYPE -DWITH_CHECK=True -DWITH_JAVA=True -DWITH_CPP_NAMESPACE=${{matrix.with_namespace}} -DLIBSBML_USE_STRICT_INCLUDES=${{matrix.strict}} -DWITH_EXAMPLES=${{matrix.with_examples}}
+          cmake $GITHUB_WORKSPACE ${PYTHON_EXECUTABLE_OPTION} -DCMAKE_C_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} -DCMAKE_CXX_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} ${{ matrix.package_option }}-DCMAKE_BUILD_TYPE=$BUILD_TYPE -DWITH_CHECK=True ${{matrix.language_bindings}} -DWITH_CPP_NAMESPACE=${{matrix.with_namespace}} -DLIBSBML_USE_STRICT_INCLUDES=${{matrix.strict}} -DWITH_EXAMPLES=${{matrix.with_examples}}
 
       - name: Configure CMake for non-default XML_parser
         if: matrix.xml_parser_option != '-DWITH_LIBXML'
         shell: bash
         working-directory: ${{runner.workspace}}/build
         run: |
-          cmake $GITHUB_WORKSPACE -DCMAKE_C_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} -DCMAKE_CXX_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} ${{ matrix.package_option}} -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DWITH_CHECK=True -DWITH_JAVA=True -DWITH_LIBXML=False ${{matrix.xml_parser_option}}=True -DWITH_CPP_NAMESPACE=${{matrix.with_namespace}} -DLIBSBML_USE_STRICT_INCLUDES=${{matrix.strict}} -DWITH_EXAMPLES=${{matrix.with_examples}}
+          cmake $GITHUB_WORKSPACE -DCMAKE_C_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} -DCMAKE_CXX_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} ${{ matrix.package_option}} -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DWITH_CHECK=True ${{matrix.language_bindings}} -DWITH_LIBXML=False ${{matrix.xml_parser_option}}=True -DWITH_CPP_NAMESPACE=${{matrix.with_namespace}} -DLIBSBML_USE_STRICT_INCLUDES=${{matrix.strict}} -DWITH_EXAMPLES=${{matrix.with_examples}}
 
       - name: Build
         working-directory: ${{runner.workspace}}/build

--- a/.github/workflows/extensive.yml
+++ b/.github/workflows/extensive.yml
@@ -25,7 +25,7 @@ jobs:
           ["", "-DWITH_STABLE_PACKAGES=ON", "-DWITH_ALL_PACKAGES=ON"]
         language_bindings:
           [
-            "-DWITH_JAVA=True -DWITH_CSHARP=True -DWITH_CPP_NAMESPACE=True -DWITH_PYTHON=True",
+            "-DWITH_JAVA=True -DWITH_CSHARP=True -DWITH_PYTHON=True",
           ]
     runs-on: ${{ matrix.platform }}
 

--- a/.github/workflows/extensive.yml
+++ b/.github/workflows/extensive.yml
@@ -127,7 +127,7 @@ jobs:
         shell: bash
         working-directory: ${{runner.workspace}}/build
         run: |
-          cmake $GITHUB_WORKSPACE -DCMAKE_C_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} -DCMAKE_CXX_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} ${{ matrix.package_option}} -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DWITH_CHECK=True ${{matrix.language_bindings}} -DWITH_LIBXML=False ${{matrix.xml_parser_option}}=True -DWITH_CPP_NAMESPACE=${{matrix.with_namespace}} -DLIBSBML_USE_STRICT_INCLUDES=${{matrix.strict}} -DWITH_EXAMPLES=${{matrix.with_examples}}
+          cmake $GITHUB_WORKSPACE ${PYTHON_LINKING_OPTION} -DCMAKE_C_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} -DCMAKE_CXX_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} ${{ matrix.package_option}} -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DWITH_CHECK=True ${{matrix.language_bindings}} -DWITH_LIBXML=False ${{matrix.xml_parser_option}}=True -DWITH_CPP_NAMESPACE=${{matrix.with_namespace}} -DLIBSBML_USE_STRICT_INCLUDES=${{matrix.strict}} -DWITH_EXAMPLES=${{matrix.with_examples}}
 
       - name: Build
         working-directory: ${{runner.workspace}}/build

--- a/.github/workflows/extensive.yml
+++ b/.github/workflows/extensive.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   build:
     if: github.event.pull_request.draft == false # avoid triggering on draft
-    name: ${{ matrix.platform }}, Parser option ${{ matrix.xml_parser_option }}, with namespaces ${{ matrix.with_namespace}}, strict includes ${{ matrix.with_namespace }}, with examples ${{ matrix.with_examples}}, package option ${{ matrix.package_option}}
+    name: ${{ matrix.platform }}, Parser option ${{ matrix.xml_parser_option }}, with namespaces ${{ matrix.with_namespace}}, strict includes ${{ matrix.strict }}, with examples ${{ matrix.with_examples}}, package option ${{ matrix.package_option}}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/extensive.yml
+++ b/.github/workflows/extensive.yml
@@ -16,17 +16,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        xml_parser_option: ["-DWITH_LIBXML"]
         platform: [windows-latest, macos-latest, ubuntu-16.04]
-        xml_parser_option: ["-DWITH_LIBXML", "-DWITH_XERCES", "-DWITH_EXPAT"]
         with_namespace: ["True", "False"]
-        strict: ["True", "False"]
-        with_examples: ["True", "False"]
+        strict: ["True"]
+        with_examples: ["True"]
         package_option:
           ["", "-DWITH_STABLE_PACKAGES=ON", "-DWITH_ALL_PACKAGES=ON"]
         language_bindings:
-          [
-            "-DWITH_JAVA=True -DWITH_CSHARP=True -DWITH_PYTHON=True",
-          ]
+          ["-DWITH_JAVA=True -DWITH_CSHARP=True -DWITH_PYTHON=True"]
     runs-on: ${{ matrix.platform }}
 
     steps:

--- a/.github/workflows/extensive.yml
+++ b/.github/workflows/extensive.yml
@@ -25,6 +25,54 @@ jobs:
           ["", "-DWITH_STABLE_PACKAGES=ON", "-DWITH_ALL_PACKAGES=ON"]
         language_bindings:
           ["-DWITH_JAVA=True -DWITH_CSHARP=True -DWITH_PYTHON=True"]
+        include:
+        # to test the other two XML parsers while avoiding a combinatorial explosion in the number of jobs,
+        # we additionally include just two runs / OS : one for Expat, and one for Xerces
+        # extra Windows runs
+          - xml_parser_option: "-DWITH_EXPAT"
+            platform: windows-latest
+            with_namespace: "True"
+            strict: "True"
+            with_examples: "True"
+            package_option: "-DWITH_ALL_PACKAGES=ON"
+            language_bindings: ""
+          - xml_parser_option: "-DWITH_XERCES"
+            platform: windows-latest
+            with_namespace: "True"
+            strict: "True"
+            with_examples: "True"
+            package_option: "-DWITH_ALL_PACKAGES=ON"
+            language_bindings: ""
+        # extra MacOS runs
+          - xml_parser_option: "-DWITH_EXPAT"
+            platform: macos-latest
+            with_namespace: "True"
+            strict: "True"
+            with_examples: "True"
+            package_option: "-DWITH_ALL_PACKAGES=ON"
+            language_bindings: ""
+          - xml_parser_option: "-DWITH_XERCES"
+            platform: macos-latest
+            with_namespace: "True"
+            strict: "True"
+            with_examples: "True"
+            package_option: "-DWITH_ALL_PACKAGES=ON"
+            language_bindings: ""
+        # extra Ubuntu runs
+          - xml_parser_option: "-DWITH_EXPAT"
+            platform: ubuntu-16.04
+            with_namespace: "True"
+            strict: "True"
+            with_examples: "True"
+            package_option: "-DWITH_ALL_PACKAGES=ON"
+            language_bindings: ""
+          - xml_parser_option: "-DWITH_XERCES"
+            platform: ubuntu-16.04
+            with_namespace: "True"
+            strict: "True"
+            with_examples: "True"
+            package_option: "-DWITH_ALL_PACKAGES=ON"
+            language_bindings: ""
     runs-on: ${{ matrix.platform }}
 
     steps:

--- a/.github/workflows/store-artefact.yml
+++ b/.github/workflows/store-artefact.yml
@@ -108,7 +108,7 @@ jobs:
         shell: bash
         working-directory: ${{runner.workspace}}/build
         run: |
-          cmake $GITHUB_WORKSPACE ${PYTHON_EXECUTABLE_OPTION} -DCMAKE_C_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} -DCMAKE_CXX_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} ${{ matrix.package_option }}-DCMAKE_BUILD_TYPE=$BUILD_TYPE -DWITH_CHECK=True -DWITH_JAVA=True -DWITH_CPP_NAMESPACE=${{matrix.with_namespace}} -DLIBSBML_USE_STRICT_INCLUDES=${{matrix.strict}} -DWITH_EXAMPLES=${{matrix.with_examples}}
+          cmake $GITHUB_WORKSPACE ${PYTHON_EXECUTABLE_OPTION} -DCMAKE_C_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} -DCMAKE_CXX_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} ${{ matrix.package_option }}-DCMAKE_BUILD_TYPE=$BUILD_TYPE -DWITH_CHECK=True ${{matrix.language_bindings}} -DWITH_CPP_NAMESPACE=${{matrix.with_namespace}} -DLIBSBML_USE_STRICT_INCLUDES=${{matrix.strict}} -DWITH_EXAMPLES=${{matrix.with_examples}}
 
       - name: Build
         working-directory: ${{runner.workspace}}/build

--- a/.github/workflows/store-artefact.yml
+++ b/.github/workflows/store-artefact.yml
@@ -21,7 +21,7 @@ jobs:
         package_option: ["-DWITH_ALL_PACKAGES=ON", "-DWITH_STABLE_PACKAGES=ON"]
         language_bindings:
           [
-            "-DWITH_JAVA=True -DWITH_CSHARP=True -DWITH_CPP_NAMESPACE=True -DWITH_PYTHON=True",
+            "-DWITH_JAVA=True -DWITH_CSHARP=True -DWITH_PYTHON=True",
           ]
     runs-on: ${{ matrix.platform }}
 

--- a/.github/workflows/store-artefact.yml
+++ b/.github/workflows/store-artefact.yml
@@ -67,6 +67,7 @@ jobs:
         shell: bash
         run: |
           sudo apt-get install -y check ccache
+          echo PYTHON_LINKING_OPTION="-DPYTHON_USE_DYNAMIC_LOOKUP=ON" >> "${GITHUB_ENV}"
 
       - name: Install MacOS dependencies
         # MacOS already has libxml2 by default
@@ -74,7 +75,7 @@ jobs:
         shell: bash
         run: |
           brew install check swig ccache
-          echo PYTHON_EXECUTABLE_OPTION="-DPYTHON_EXECUTABLE=/usr/local/bin/python3" >> "${GITHUB_ENV}"
+          echo PYTHON_LINKING_OPTION="-DPYTHON_USE_DYNAMIC_LOOKUP=ON" >> "${GITHUB_ENV}"
 
       ### setup ccache, not on Windows ###
       - name: Prepare ccache timestamp
@@ -108,7 +109,7 @@ jobs:
         shell: bash
         working-directory: ${{runner.workspace}}/build
         run: |
-          cmake $GITHUB_WORKSPACE ${PYTHON_EXECUTABLE_OPTION} -DCMAKE_C_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} -DCMAKE_CXX_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} ${{ matrix.package_option }}-DCMAKE_BUILD_TYPE=$BUILD_TYPE -DWITH_CHECK=True ${{matrix.language_bindings}} -DWITH_CPP_NAMESPACE=${{matrix.with_namespace}} -DLIBSBML_USE_STRICT_INCLUDES=${{matrix.strict}} -DWITH_EXAMPLES=${{matrix.with_examples}}
+          cmake $GITHUB_WORKSPACE ${PYTHON_LINKING_OPTION} -DCMAKE_C_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} -DCMAKE_CXX_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} ${{ matrix.package_option }}-DCMAKE_BUILD_TYPE=$BUILD_TYPE -DWITH_CHECK=True ${{matrix.language_bindings}} -DWITH_CPP_NAMESPACE=${{matrix.with_namespace}} -DLIBSBML_USE_STRICT_INCLUDES=${{matrix.strict}} -DWITH_EXAMPLES=${{matrix.with_examples}}
 
       - name: Build
         working-directory: ${{runner.workspace}}/build

--- a/.github/workflows/store-artefact.yml
+++ b/.github/workflows/store-artefact.yml
@@ -9,7 +9,7 @@ env:
 
 jobs:
   build:
-    name: ${{ matrix.platform }}, Parser option ${{ matrix.xml_parser_option }}, with namespaces ${{ matrix.with_namespace}}, strict includes ${{ matrix.with_namespace }}, with examples ${{ matrix.with_examples}}, package option ${{ matrix.package_option}}
+    name: ${{ matrix.platform }}, Parser option ${{ matrix.xml_parser_option }}, with namespaces ${{ matrix.with_namespace}}, strict includes ${{ matrix.strict }}, with examples ${{ matrix.with_examples}}, package option ${{ matrix.package_option}}
     strategy:
       fail-fast: false
       matrix:
@@ -20,9 +20,7 @@ jobs:
         with_examples: ["True"]
         package_option: ["-DWITH_ALL_PACKAGES=ON", "-DWITH_STABLE_PACKAGES=ON"]
         language_bindings:
-          [
-            "-DWITH_JAVA=True -DWITH_CSHARP=True -DWITH_PYTHON=True",
-          ]
+          ["-DWITH_JAVA=True -DWITH_CSHARP=True -DWITH_PYTHON=True"]
     runs-on: ${{ matrix.platform }}
 
     steps:


### PR DESCRIPTION
## Description
Removes unnecessary workflow configurations from the 216 in extensive.yml, the "long" CI run that is triggered when a PR is made.

This is done using the following strategy (for each OS):
* All runs are done with examples, and using strict includes, with no exceptions.
* The XML parsers Expat and Xerces are only tested for one run each,  with C++ namespaces, with all packages, and with no language bindings.
* There are 6 runs using LibXML2 as the XML parser, all with C#, Java and Python language bindings, based on all combinations of
   * no packages, stable packages, all packages
   * with and without C++ namespaces

This results in 24 jobs in total, 8 jobs per OS -  a reduction of almost an order of magnitude in the number of jobs, and reduces the runtime of the extensive build from ~4.5 hours to about 1 hour.

## Motivation and Context
Currently, when we get to a PR stage, the extensive.yml GitHub actions workflow is run, consisting of 216 different jobs that take a total of ~4.5 to run. Many of these runs are superfluous, and this PR is an attempt to remove the superfluous jobs from extensive.yml.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] I have updated all documentation necessary. CI docs kept in a word doc for now.
- [x] I have checked spelling in (new) comments.

## Testing
- [ ] Testing is done automatically and codecov shows test coverage
- [x] This cannot be tested automatically. This PR only removes some superfluous workflow runs.

