### PR TITLE
Series of minor improvements to CI (Windows/zipping/C++ Standard)

### DIFF
--- a/.github/workflows/brief.yml
+++ b/.github/workflows/brief.yml
@@ -50,7 +50,7 @@ jobs:
           curl -L https://prdownloads.sourceforge.net/swig/swigwin-3.0.12.zip > swig.zip
           unzip -o swig.zip -d swig
 
-      - name: add SWIG to Path (Windows)
+      - name: setup Windows environment
         # this is separate from the SWIG download itself, because it needs to be added to the path also when SWIG is cached
         if: matrix.platform == 'windows-latest'
         shell: bash

--- a/.github/workflows/brief.yml
+++ b/.github/workflows/brief.yml
@@ -29,18 +29,18 @@ jobs:
         # On Windows, the dependencies live inside the source folder, ie `.`.
         # For the CI, we put SWIG there too, for simplicity.
         if: matrix.platform == 'windows-latest'
-        id: cache-win-dependencies
+        id: cache-win-dependencies-static
         uses: actions/cache@v2
         with:
           path: |
             ./dependencies
             ./swig
-          key: ${{ runner.os }}-dependencies
+          key: ${{ runner.os }}-dependencies-static
 
       - name: Download pre-built Windows dependencies and SWIG
         # Windows dependencies have to be in a subfolder called `dependencies`, directly under the git repository root.
         # also gets SWIG, completing the set of dependencies needed for windows
-        if: matrix.platform == 'windows-latest' && steps.cache-win-dependencies.outputs.cache-hit != 'true'
+        if: matrix.platform == 'windows-latest' && steps.cache-win-dependencies-static.outputs.cache-hit != 'true'
         shell: bash
         run: |
           curl -L https://sourceforge.net/projects/sbml/files/libsbml/win-dependencies/libSBML_dependencies_vs15_release_x64_static.zip/download > dependencies.zip

--- a/.github/workflows/brief.yml
+++ b/.github/workflows/brief.yml
@@ -48,7 +48,7 @@ jobs:
           cp -r dependencies/libSBML\ Dependencies-1.0.0-b1-win64/* dependencies
           rm -r dependencies/libSBML*
           curl -L https://prdownloads.sourceforge.net/swig/swigwin-3.0.12.zip > swig.zip
-          unzip swig.zip -d swig
+          unzip -o swig.zip -d swig
 
       - name: add SWIG to Path (Windows)
         # this is separate from the SWIG download itself, because it needs to be added to the path also when SWIG is cached

--- a/.github/workflows/brief.yml
+++ b/.github/workflows/brief.yml
@@ -56,6 +56,7 @@ jobs:
         shell: bash
         run: |
           echo $GITHUB_WORKSPACE"/swig/swigwin-3.0.12/" >> $GITHUB_PATH
+          echo RUNTIME_LINKING_OPTION="-DWITH_STATIC_RUNTIME=ON" >> "${GITHUB_ENV}"
 
       - name: Install Ubuntu dependencies
         # ubuntu already has SWIG and libxml2 by default
@@ -105,7 +106,7 @@ jobs:
         shell: bash
         working-directory: ${{runner.workspace}}/build
         run: |
-          cmake $GITHUB_WORKSPACE ${PYTHON_LINKING_OPTION} -DCMAKE_C_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} -DCMAKE_CXX_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} ${{ matrix.package_option }}-DCMAKE_BUILD_TYPE=$BUILD_TYPE -DWITH_CHECK=True ${{matrix.language_bindings}} -DWITH_CPP_NAMESPACE=${{matrix.with_namespace}} -DLIBSBML_USE_STRICT_INCLUDES=${{matrix.strict}} -DWITH_EXAMPLES=${{matrix.with_examples}}
+          cmake $GITHUB_WORKSPACE ${RUNTIME_LINKING_OPTION} ${PYTHON_LINKING_OPTION} -DCMAKE_C_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} -DCMAKE_CXX_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} ${{ matrix.package_option }}-DCMAKE_BUILD_TYPE=$BUILD_TYPE -DWITH_CHECK=True ${{matrix.language_bindings}} -DWITH_CPP_NAMESPACE=${{matrix.with_namespace}} -DLIBSBML_USE_STRICT_INCLUDES=${{matrix.strict}} -DWITH_EXAMPLES=${{matrix.with_examples}}
 
       - name: Build
         working-directory: ${{runner.workspace}}/build

--- a/.github/workflows/brief.yml
+++ b/.github/workflows/brief.yml
@@ -40,10 +40,10 @@ jobs:
       - name: Download pre-built Windows dependencies and SWIG
         # Windows dependencies have to be in a subfolder called `dependencies`, directly under the git repository root.
         # also gets SWIG, completing the set of dependencies needed for windows
-        if: matrix.platform == 'windows-latest' && steps.cache-win-dependencies.outputs.cache-hit != 'true'
+        if: matrix.platform == 'windows-latest'
         shell: bash
         run: |
-          curl -L https://sourceforge.net/projects/sbml/files/libsbml/win-dependencies/libSBML_dependencies_vs15_release_x64.zip/download > dependencies.zip
+          curl -L https://sourceforge.net/projects/sbml/files/libsbml/win-dependencies/libSBML_dependencies_vs15_release_x64_static.zip/download > dependencies.zip
           unzip dependencies.zip -d dependencies
           cp -r dependencies/libSBML\ Dependencies-1.0.0-b1-win64/* dependencies
           rm -r dependencies/libSBML*

--- a/.github/workflows/brief.yml
+++ b/.github/workflows/brief.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Download pre-built Windows dependencies and SWIG
         # Windows dependencies have to be in a subfolder called `dependencies`, directly under the git repository root.
         # also gets SWIG, completing the set of dependencies needed for windows
-        if: matrix.platform == 'windows-latest'
+        if: matrix.platform == 'windows-latest' && steps.cache-win-dependencies.outputs.cache-hit != 'true'
         shell: bash
         run: |
           curl -L https://sourceforge.net/projects/sbml/files/libsbml/win-dependencies/libSBML_dependencies_vs15_release_x64_static.zip/download > dependencies.zip

--- a/.github/workflows/extensive.yml
+++ b/.github/workflows/extensive.yml
@@ -26,9 +26,9 @@ jobs:
         language_bindings:
           ["-DWITH_JAVA=True -DWITH_CSHARP=True -DWITH_PYTHON=True"]
         include:
-        # to test the other two XML parsers while avoiding a combinatorial explosion in the number of jobs,
-        # we additionally include just two runs / OS : one for Expat, and one for Xerces
-        # extra Windows runs
+          # to test the other two XML parsers while avoiding a combinatorial explosion in the number of jobs,
+          # we additionally include just two runs / OS : one for Expat, and one for Xerces
+          # extra Windows runs
           - xml_parser_option: "-DWITH_EXPAT"
             platform: windows-latest
             with_namespace: "True"
@@ -43,7 +43,7 @@ jobs:
             with_examples: "True"
             package_option: "-DWITH_ALL_PACKAGES=ON"
             language_bindings: ""
-        # extra MacOS runs
+          # extra MacOS runs
           - xml_parser_option: "-DWITH_EXPAT"
             platform: macos-latest
             with_namespace: "True"
@@ -58,7 +58,7 @@ jobs:
             with_examples: "True"
             package_option: "-DWITH_ALL_PACKAGES=ON"
             language_bindings: ""
-        # extra Ubuntu runs
+          # extra Ubuntu runs
           - xml_parser_option: "-DWITH_EXPAT"
             platform: ubuntu-16.04
             with_namespace: "True"
@@ -83,13 +83,13 @@ jobs:
         # On Windows, the dependencies live inside the source folder, ie `.`.
         # For the CI, we put SWIG there too, for simplicity.
         if: matrix.platform == 'windows-latest'
-        id: cache-win-dependencies
+        id: cache-win-dependencies-static
         uses: actions/cache@v2
         with:
           path: |
             ./dependencies
             ./swig
-          key: ${{ runner.os }}-dependencies
+          key: ${{ runner.os }}-dependencies-static
 
       - name: Download pre-built Windows dependencies and SWIG
         # Windows dependencies have to be in a subfolder called `dependencies`, directly under the git repository root.
@@ -97,19 +97,20 @@ jobs:
         if: matrix.platform == 'windows-latest' && steps.cache-win-dependencies.outputs.cache-hit != 'true'
         shell: bash
         run: |
-          curl -L https://sourceforge.net/projects/sbml/files/libsbml/win-dependencies/libSBML_dependencies_vs15_release_x64.zip/download > dependencies.zip
+          curl -L https://sourceforge.net/projects/sbml/files/libsbml/win-dependencies/libSBML_dependencies_vs15_release_x64_static.zip/download > dependencies.zip
           unzip dependencies.zip -d dependencies
           cp -r dependencies/libSBML\ Dependencies-1.0.0-b1-win64/* dependencies
           rm -r dependencies/libSBML*
           curl -L https://prdownloads.sourceforge.net/swig/swigwin-3.0.12.zip > swig.zip
-          unzip swig.zip -d swig
+          unzip -o swig.zip -d swig
 
-      - name: add SWIG to Path (Windows)
+      - name: setup Windows environment
         # this is separate from the SWIG download itself, because it needs to be added to the path also when SWIG is cached
         if: matrix.platform == 'windows-latest'
         shell: bash
         run: |
           echo $GITHUB_WORKSPACE"/swig/swigwin-3.0.12/" >> $GITHUB_PATH
+          echo RUNTIME_LINKING_OPTION="-DWITH_STATIC_RUNTIME=ON" >> "${GITHUB_ENV}"
 
       - name: Install Ubuntu dependencies
         # ubuntu already has SWIG and libxml2 by default
@@ -166,14 +167,14 @@ jobs:
         shell: bash
         working-directory: ${{runner.workspace}}/build
         run: |
-          cmake $GITHUB_WORKSPACE ${PYTHON_LINKING_OPTION} -DCMAKE_C_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} -DCMAKE_CXX_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} ${{ matrix.package_option }}-DCMAKE_BUILD_TYPE=$BUILD_TYPE -DWITH_CHECK=True ${{matrix.language_bindings}} -DWITH_CPP_NAMESPACE=${{matrix.with_namespace}} -DLIBSBML_USE_STRICT_INCLUDES=${{matrix.strict}} -DWITH_EXAMPLES=${{matrix.with_examples}}
+          cmake $GITHUB_WORKSPACE ${RUNTIME_LINKING_OPTION} ${PYTHON_LINKING_OPTION} -DCMAKE_C_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} -DCMAKE_CXX_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} ${{ matrix.package_option }}-DCMAKE_BUILD_TYPE=$BUILD_TYPE -DWITH_CHECK=True ${{matrix.language_bindings}} -DWITH_CPP_NAMESPACE=${{matrix.with_namespace}} -DLIBSBML_USE_STRICT_INCLUDES=${{matrix.strict}} -DWITH_EXAMPLES=${{matrix.with_examples}}
 
       - name: Configure CMake for non-default XML_parser
         if: matrix.xml_parser_option != '-DWITH_LIBXML'
         shell: bash
         working-directory: ${{runner.workspace}}/build
         run: |
-          cmake $GITHUB_WORKSPACE ${PYTHON_LINKING_OPTION} -DCMAKE_C_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} -DCMAKE_CXX_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} ${{ matrix.package_option}} -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DWITH_CHECK=True ${{matrix.language_bindings}} -DWITH_LIBXML=False ${{matrix.xml_parser_option}}=True -DWITH_CPP_NAMESPACE=${{matrix.with_namespace}} -DLIBSBML_USE_STRICT_INCLUDES=${{matrix.strict}} -DWITH_EXAMPLES=${{matrix.with_examples}}
+          cmake $GITHUB_WORKSPACE ${RUNTIME_LINKING_OPTION} ${PYTHON_LINKING_OPTION} -DCMAKE_C_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} -DCMAKE_CXX_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} ${{ matrix.package_option}} -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DWITH_CHECK=True ${{matrix.language_bindings}} -DWITH_LIBXML=False ${{matrix.xml_parser_option}}=True -DWITH_CPP_NAMESPACE=${{matrix.with_namespace}} -DLIBSBML_USE_STRICT_INCLUDES=${{matrix.strict}} -DWITH_EXAMPLES=${{matrix.with_examples}}
 
       - name: Build
         working-directory: ${{runner.workspace}}/build

--- a/.github/workflows/extensive.yml
+++ b/.github/workflows/extensive.yml
@@ -174,7 +174,7 @@ jobs:
         shell: bash
         working-directory: ${{runner.workspace}}/build
         run: |
-          cmake $GITHUB_WORKSPACE ${RUNTIME_LINKING_OPTION} ${PYTHON_LINKING_OPTION} -DCMAKE_C_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} -DCMAKE_CXX_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} ${{ matrix.package_option}} -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DWITH_CHECK=True ${{matrix.language_bindings}} -DWITH_LIBXML=False ${{matrix.xml_parser_option}}=True -DWITH_CPP_NAMESPACE=${{matrix.with_namespace}} -DLIBSBML_USE_STRICT_INCLUDES=${{matrix.strict}} -DWITH_EXAMPLES=${{matrix.with_examples}}
+          cmake $GITHUB_WORKSPACE ${RUNTIME_LINKING_OPTION} ${PYTHON_LINKING_OPTION} -DCMAKE_CXX_STANDARD=98 -DCMAKE_C_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} -DCMAKE_CXX_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} ${{ matrix.package_option}} -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DWITH_CHECK=True ${{matrix.language_bindings}} -DWITH_LIBXML=False ${{matrix.xml_parser_option}}=True -DWITH_CPP_NAMESPACE=${{matrix.with_namespace}} -DLIBSBML_USE_STRICT_INCLUDES=${{matrix.strict}} -DWITH_EXAMPLES=${{matrix.with_examples}}
 
       - name: Build
         working-directory: ${{runner.workspace}}/build

--- a/.github/workflows/store-artefact.yml
+++ b/.github/workflows/store-artefact.yml
@@ -116,15 +116,20 @@ jobs:
         shell: bash
         run: |
           cmake --build . --config $BUILD_TYPE
-          cmake --install . --config $BUILD_TYPE
 
       ### run tests ###
       - name: Test
         working-directory: ${{runner.workspace}}/build
         shell: bash
         run: ctest -C $BUILD_TYPE
+      
+      ### create binaries ###
+      - name: Install
+        working-directory: ${{runner.workspace}}/build
+        shell: bash
+        run: cmake --install . --config $BUILD_TYPE
 
-      ### package artifact ###
+      ### setup artifact environment ###
       - name: Store libSBML version in environment
         shell: bash
         run: echo "LIBSBML_VERSION=$( cat VERSION.txt)"  >> "${GITHUB_ENV}"
@@ -141,15 +146,7 @@ jobs:
         run: |
           echo "ARTIFACT_NAME_SUFFIX=all-packages" >> "${GITHUB_ENV}"
 
-      #### Windows ####
-      - name: Package executable (Windows)
-        if: matrix.platform == 'windows-latest'
-        working-directory: ${{runner.workspace}}/build
-        shell: bash
-        run: |
-          cpack -G ZIP -C $BUILD_TYPE 
-          mv libSBML-${LIBSBML_VERSION}-win64.zip libSBML-${LIBSBML_VERSION}-win64-nightly-${ARTIFACT_NAME_SUFFIX}.zip
-
+      ### Upload installed versions ###
       - name: Upload Windows binary archive
         if: matrix.platform == 'windows-latest'
         uses: actions/upload-artifact@v2

--- a/.github/workflows/store-artefact.yml
+++ b/.github/workflows/store-artefact.yml
@@ -188,41 +188,11 @@ jobs:
           retention-days: 1
           if-no-files-found: error
 
-      #### Ubuntu 16.04 ####
-      - name: Package executable (Ubuntu 16.04)
-        if: matrix.platform == 'ubuntu-16.04'
-        working-directory: ${{runner.workspace}}/build
-        shell: bash
-        run: |
-          cpack -G ZIP -C $BUILD_TYPE
-          mv libSBML-${LIBSBML_VERSION}-Linux.zip libSBML-${LIBSBML_VERSION}-Linux-nightly-${ARTIFACT_NAME_SUFFIX}.zip
-          cpack -G TGZ -C $BUILD_TYPE
-          mv libSBML-${LIBSBML_VERSION}-Linux.tar.gz libSBML-${LIBSBML_VERSION}-Linux-nightly-${ARTIFACT_NAME_SUFFIX}.tar.gz
-          cpack -C $BUILD_TYPE
-
-      - name: Upload Ubuntu binary archive (zip)
-        if: matrix.platform == 'ubuntu-16.04'
-        uses: actions/upload-artifact@v2
-        with:
-          name: Ubuntu nightly (zip, libSBML ${{env.LIBSBML_VERSION}}, ${{env.ARTIFACT_NAME_SUFFIX}})
-          path: ${{runner.workspace}}/build/libSBML-${{env.LIBSBML_VERSION}}-Linux-nightly-${{env.ARTIFACT_NAME_SUFFIX}}.zip
-          retention-days: 1
-          if-no-files-found: error
-
-      - name: Upload Ubuntu binary archive (tar.gz)
-        if: matrix.platform == 'ubuntu-16.04'
-        uses: actions/upload-artifact@v2
-        with:
-          name: Ubuntu nightly (tar.gz, libSBML ${{env.LIBSBML_VERSION}}, ${{env.ARTIFACT_NAME_SUFFIX}})
-          path: ${{runner.workspace}}/build/libSBML-${{env.LIBSBML_VERSION}}-Linux-nightly-${{env.ARTIFACT_NAME_SUFFIX}}.tar.gz
-          retention-days: 1
-          if-no-files-found: error
-
       - name: Upload Ubuntu binary archive (tar.gz)
         if: matrix.platform == 'ubuntu-16.04'
         uses: actions/upload-artifact@v2
         with:
           name: Ubuntu nightly unzipped ( libSBML ${{env.LIBSBML_VERSION}}, ${{env.ARTIFACT_NAME_SUFFIX}})
-          path: ${{runner.workspace}}/build/libSBML-${{env.LIBSBML_VERSION}}-Linux*
+          path: ${{runner.workspace}}/install/*
           retention-days: 1
           if-no-files-found: error

--- a/.github/workflows/store-artefact.yml
+++ b/.github/workflows/store-artefact.yml
@@ -155,40 +155,20 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: Windows nightly (zip, libSBML ${{env.LIBSBML_VERSION}}, ${{env.ARTIFACT_NAME_SUFFIX}})
-          path: ${{runner.workspace}}/build/libSBML-${{env.LIBSBML_VERSION}}-win64-nightly-${{env.ARTIFACT_NAME_SUFFIX}}.zip
+          path: ${{runner.workspace}}/install/*
           retention-days: 1
           if-no-files-found: error
 
-      #### Mac OS ####
-      - name: Package executable (MacOS)
-        if: matrix.platform == 'macos-latest'
-        working-directory: ${{runner.workspace}}/build
-        shell: bash
-        run: |
-          cpack -G ZIP -C $BUILD_TYPE
-          mv libSBML-${LIBSBML_VERSION}-Darwin.zip libSBML-${LIBSBML_VERSION}-Darwin-nightly-${ARTIFACT_NAME_SUFFIX}.zip
-          cpack -G TGZ -C $BUILD_TYPE
-          mv libSBML-${LIBSBML_VERSION}-Darwin.tar.gz libSBML-${LIBSBML_VERSION}-Darwin-nightly-${ARTIFACT_NAME_SUFFIX}.tar.gz
-
-      - name: Upload MacOS binary archive (zip)
-        if: matrix.platform == 'macos-latest'
-        uses: actions/upload-artifact@v2
-        with:
-          name: MacOS nightly (zip, libSBML ${{env.LIBSBML_VERSION}}, ${{env.ARTIFACT_NAME_SUFFIX}})
-          path: ${{runner.workspace}}/build/libSBML-${{env.LIBSBML_VERSION}}-Darwin-nightly-${{env.ARTIFACT_NAME_SUFFIX}}.zip
-          retention-days: 1
-          if-no-files-found: error
-
-      - name: Upload MacOS binary archive (tar.gz)
+      - name: Upload MacOS binary archive
         if: matrix.platform == 'macos-latest'
         uses: actions/upload-artifact@v2
         with:
           name: MacOS nightly (tar.gz, libSBML ${{env.LIBSBML_VERSION}}, ${{env.ARTIFACT_NAME_SUFFIX}})
-          path: ${{runner.workspace}}/build/libSBML-${{env.LIBSBML_VERSION}}-Darwin-nightly-${{env.ARTIFACT_NAME_SUFFIX}}.tar.gz
+          path: ${{runner.workspace}}/install/*
           retention-days: 1
           if-no-files-found: error
 
-      - name: Upload Ubuntu binary archive (tar.gz)
+      - name: Upload Ubuntu binary archive
         if: matrix.platform == 'ubuntu-16.04'
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/store-artefact.yml
+++ b/.github/workflows/store-artefact.yml
@@ -31,33 +31,34 @@ jobs:
         # On Windows, the dependencies live inside the source folder, ie `.`.
         # For the CI, we put SWIG there too, for simplicity.
         if: matrix.platform == 'windows-latest'
-        id: cache-win-dependencies
+        id: cache-win-dependencies-static
         uses: actions/cache@v2
         with:
           path: |
             ./dependencies
             ./swig
-          key: ${{ runner.os }}-dependencies
+          key: ${{ runner.os }}-dependencies-static
 
       - name: Download pre-built Windows dependencies and SWIG
         # Windows dependencies have to be in a subfolder called `dependencies`, directly under the git repository root.
         # also gets SWIG, completing the set of dependencies needed for windows
-        if: matrix.platform == 'windows-latest' && steps.cache-win-dependencies.outputs.cache-hit != 'true'
+        if: matrix.platform == 'windows-latest' && steps.cache-win-dependencies-static.outputs.cache-hit != 'true'
         shell: bash
         run: |
-          curl -L https://sourceforge.net/projects/sbml/files/libsbml/win-dependencies/libSBML_dependencies_vs15_release_x64.zip/download > dependencies.zip
+          curl -L https://sourceforge.net/projects/sbml/files/libsbml/win-dependencies/libSBML_dependencies_vs15_release_x64_static.zip/download > dependencies.zip
           unzip dependencies.zip -d dependencies
           cp -r dependencies/libSBML\ Dependencies-1.0.0-b1-win64/* dependencies
           rm -r dependencies/libSBML*
           curl -L https://prdownloads.sourceforge.net/swig/swigwin-3.0.12.zip > swig.zip
-          unzip swig.zip -d swig
+          unzip -o swig.zip -d swig
 
-      - name: add SWIG to Path (Windows)
+      - name: setup Windows environment
         # this is separate from the SWIG download itself, because it needs to be added to the path also when SWIG is cached
         if: matrix.platform == 'windows-latest'
         shell: bash
         run: |
           echo $GITHUB_WORKSPACE"/swig/swigwin-3.0.12/" >> $GITHUB_PATH
+          echo RUNTIME_LINKING_OPTION="-DWITH_STATIC_RUNTIME=ON" >> "${GITHUB_ENV}"
 
       - name: Install Ubuntu dependencies
         # ubuntu already has SWIG and libxml2 by default
@@ -107,7 +108,7 @@ jobs:
         shell: bash
         working-directory: ${{runner.workspace}}/build
         run: |
-          cmake $GITHUB_WORKSPACE ${PYTHON_LINKING_OPTION} -DCMAKE_C_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} -DCMAKE_CXX_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} ${{ matrix.package_option }}-DCMAKE_BUILD_TYPE=$BUILD_TYPE -DWITH_CHECK=True ${{matrix.language_bindings}} -DWITH_CPP_NAMESPACE=${{matrix.with_namespace}} -DLIBSBML_USE_STRICT_INCLUDES=${{matrix.strict}} -DWITH_EXAMPLES=${{matrix.with_examples}}
+          cmake ${RUNTIME_LINKING_OPTION} $GITHUB_WORKSPACE ${PYTHON_LINKING_OPTION} -DCMAKE_C_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} -DCMAKE_CXX_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} ${{ matrix.package_option }}-DCMAKE_BUILD_TYPE=$BUILD_TYPE -DWITH_CHECK=True ${{matrix.language_bindings}} -DWITH_CPP_NAMESPACE=${{matrix.with_namespace}} -DLIBSBML_USE_STRICT_INCLUDES=${{matrix.strict}} -DWITH_EXAMPLES=${{matrix.with_examples}}
 
       - name: Build
         working-directory: ${{runner.workspace}}/build

--- a/.github/workflows/store-artefact.yml
+++ b/.github/workflows/store-artefact.yml
@@ -151,7 +151,7 @@ jobs:
         if: matrix.platform == 'windows-latest'
         uses: actions/upload-artifact@v2
         with:
-          name: Windows nightly (zip, libSBML ${{env.LIBSBML_VERSION}}, ${{env.ARTIFACT_NAME_SUFFIX}})
+          name: Windows (zip, libSBML ${{env.LIBSBML_VERSION}}, ${{env.ARTIFACT_NAME_SUFFIX}})
           path: ${{runner.workspace}}/install/*
           retention-days: 1
           if-no-files-found: error
@@ -160,7 +160,7 @@ jobs:
         if: matrix.platform == 'macos-latest'
         uses: actions/upload-artifact@v2
         with:
-          name: MacOS nightly (tar.gz, libSBML ${{env.LIBSBML_VERSION}}, ${{env.ARTIFACT_NAME_SUFFIX}})
+          name: MacOS (zip, libSBML ${{env.LIBSBML_VERSION}}, ${{env.ARTIFACT_NAME_SUFFIX}})
           path: ${{runner.workspace}}/install/*
           retention-days: 1
           if-no-files-found: error
@@ -169,7 +169,7 @@ jobs:
         if: matrix.platform == 'ubuntu-16.04'
         uses: actions/upload-artifact@v2
         with:
-          name: Ubuntu nightly unzipped ( libSBML ${{env.LIBSBML_VERSION}}, ${{env.ARTIFACT_NAME_SUFFIX}})
+          name: Ubuntu nightly (zip, libSBML ${{env.LIBSBML_VERSION}}, ${{env.ARTIFACT_NAME_SUFFIX}})
           path: ${{runner.workspace}}/install/*
           retention-days: 1
           if-no-files-found: error

--- a/.github/workflows/store-artefact.yml
+++ b/.github/workflows/store-artefact.yml
@@ -129,6 +129,13 @@ jobs:
         shell: bash
         run: cmake --install . --config $BUILD_TYPE
 
+      - name: Remove large .lib file on Windows
+      ### file temporarily needed for bindings ###
+        if: matrix.platform == 'windows-latest'
+        working-directory: ${{runner.workspace}}/install
+        shell: bash
+        run: rm lib/libsbml-static.lib
+
       ### setup artifact environment ###
       - name: Store libSBML version in environment
         shell: bash

--- a/.github/workflows/store-artefact.yml
+++ b/.github/workflows/store-artefact.yml
@@ -109,7 +109,7 @@ jobs:
         working-directory: ${{runner.workspace}}/build
         run: |
           mkdir ../install
-          cmake ${RUNTIME_LINKING_OPTION} $GITHUB_WORKSPACE ${PYTHON_LINKING_OPTION} -DCMAKE_INSTALL_PREFIX=../install -DCMAKE_C_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} -DCMAKE_CXX_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} ${{ matrix.package_option }}-DCMAKE_BUILD_TYPE=$BUILD_TYPE -DWITH_CHECK=True ${{matrix.language_bindings}} -DWITH_CPP_NAMESPACE=${{matrix.with_namespace}} -DLIBSBML_USE_STRICT_INCLUDES=${{matrix.strict}} -DWITH_EXAMPLES=${{matrix.with_examples}}
+          cmake ${RUNTIME_LINKING_OPTION} $GITHUB_WORKSPACE ${PYTHON_LINKING_OPTION} -DCMAKE_CXX_STANDARD=98 -DCMAKE_INSTALL_PREFIX=../install -DCMAKE_C_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} -DCMAKE_CXX_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} ${{ matrix.package_option }}-DCMAKE_BUILD_TYPE=$BUILD_TYPE -DWITH_CHECK=True ${{matrix.language_bindings}} -DWITH_CPP_NAMESPACE=${{matrix.with_namespace}} -DLIBSBML_USE_STRICT_INCLUDES=${{matrix.strict}} -DWITH_EXAMPLES=${{matrix.with_examples}}
 
       - name: Build
         working-directory: ${{runner.workspace}}/build

--- a/.github/workflows/store-artefact.yml
+++ b/.github/workflows/store-artefact.yml
@@ -196,6 +196,7 @@ jobs:
           mv libSBML-${LIBSBML_VERSION}-Linux.zip libSBML-${LIBSBML_VERSION}-Linux-nightly-${ARTIFACT_NAME_SUFFIX}.zip
           cpack -G TGZ -C $BUILD_TYPE
           mv libSBML-${LIBSBML_VERSION}-Linux.tar.gz libSBML-${LIBSBML_VERSION}-Linux-nightly-${ARTIFACT_NAME_SUFFIX}.tar.gz
+          cpack -C $BUILD_TYPE
 
       - name: Upload Ubuntu binary archive (zip)
         if: matrix.platform == 'ubuntu-16.04'
@@ -212,5 +213,14 @@ jobs:
         with:
           name: Ubuntu nightly (tar.gz, libSBML ${{env.LIBSBML_VERSION}}, ${{env.ARTIFACT_NAME_SUFFIX}})
           path: ${{runner.workspace}}/build/libSBML-${{env.LIBSBML_VERSION}}-Linux-nightly-${{env.ARTIFACT_NAME_SUFFIX}}.tar.gz
+          retention-days: 1
+          if-no-files-found: error
+
+      - name: Upload Ubuntu binary archive (tar.gz)
+        if: matrix.platform == 'ubuntu-16.04'
+        uses: actions/upload-artifact@v2
+        with:
+          name: Ubuntu nightly unzipped ( libSBML ${{env.LIBSBML_VERSION}}, ${{env.ARTIFACT_NAME_SUFFIX}})
+          path: ${{runner.workspace}}/build/libSBML-${{env.LIBSBML_VERSION}}-Linux*
           retention-days: 1
           if-no-files-found: error

--- a/.github/workflows/store-artefact.yml
+++ b/.github/workflows/store-artefact.yml
@@ -108,13 +108,15 @@ jobs:
         shell: bash
         working-directory: ${{runner.workspace}}/build
         run: |
-          cmake ${RUNTIME_LINKING_OPTION} $GITHUB_WORKSPACE ${PYTHON_LINKING_OPTION} -DCMAKE_C_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} -DCMAKE_CXX_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} ${{ matrix.package_option }}-DCMAKE_BUILD_TYPE=$BUILD_TYPE -DWITH_CHECK=True ${{matrix.language_bindings}} -DWITH_CPP_NAMESPACE=${{matrix.with_namespace}} -DLIBSBML_USE_STRICT_INCLUDES=${{matrix.strict}} -DWITH_EXAMPLES=${{matrix.with_examples}}
+          mkdir ../install
+          cmake ${RUNTIME_LINKING_OPTION} $GITHUB_WORKSPACE ${PYTHON_LINKING_OPTION} -DCMAKE_INSTALL_PREFIX=../install -DCMAKE_C_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} -DCMAKE_CXX_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} ${{ matrix.package_option }}-DCMAKE_BUILD_TYPE=$BUILD_TYPE -DWITH_CHECK=True ${{matrix.language_bindings}} -DWITH_CPP_NAMESPACE=${{matrix.with_namespace}} -DLIBSBML_USE_STRICT_INCLUDES=${{matrix.strict}} -DWITH_EXAMPLES=${{matrix.with_examples}}
 
       - name: Build
         working-directory: ${{runner.workspace}}/build
         shell: bash
         run: |
           cmake --build . --config $BUILD_TYPE
+          cmake --install . --config $BUILD_TYPE
 
       ### run tests ###
       - name: Test


### PR DESCRIPTION
## Description
This PR addresses a series of minor flaws to the CI system.
Some of them are only Windows-related
- Windows libraries are built with static runtime, and use the static dependencies.
- A large file that is not needed in the binary is removed from the artifact

Additionally:
- ~~the rapid build tests both C++98 and C++20, spanning the range of current C++ standards~~ This is trickier than expected and will be addressed in a separate PR.
- the extensive build and the artifacts are explicitly built with C++98
- The artifacts are not doubly compressed (once explicitly by us, once implicitly be the `upload-artefact` action) - we leave the compression to the `upload-artefact` action, which creates a zip.

Note that the removal of the double compression creates much larger artifacts. The reviewer may wish to comment if this is a problem.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Minor improvements to CI/CD.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change): The Windows artifacts are now different as they are built with static runtime and static dependencies (the other OS builds are also slightly different as the artifacts are not as compressed, and we specify the C++ standard for some of the builds).

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have updated all documentation necessary. CI docs kept in separate document for now.
- [x] I have checked spelling in (new) comments.

## Testing
- [ ] Testing is done automatically and codecov shows test coverage
- [x] This cannot be tested automatically. Artifacts look reasonable to me, and tests pass. Definitely worth the reviewer checking the artifacts too though.

