### PR TITLE
Automatically test both C++98 and C++20 on push

### DIFF
--- a/.github/workflows/brief.yml
+++ b/.github/workflows/brief.yml
@@ -7,7 +7,7 @@ env:
 
 jobs:
   build:
-    name: ${{ matrix.platform }}, Parser option ${{ matrix.xml_parser_option }}, with namespaces ${{ matrix.with_namespace}}, strict includes ${{ matrix.strict }}, with examples ${{ matrix.with_examples}}, package option ${{ matrix.package_option}}
+    name: ${{ matrix.platform }}, Parser option ${{ matrix.xml_parser_option }}, with namespaces ${{ matrix.with_namespace}}, strict includes ${{ matrix.strict }}, with examples ${{ matrix.with_examples}}, package option ${{ matrix.package_option}}, c++  standard ${{matrix.cpp_standard}}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/brief.yml
+++ b/.github/workflows/brief.yml
@@ -19,6 +19,7 @@ jobs:
         package_option: ["-DWITH_ALL_PACKAGES=ON"]
         language_bindings:
           ["-DWITH_JAVA=True -DWITH_CSHARP=True -DWITH_PYTHON=True"]
+        cpp_standard: [98, 20]
     runs-on: ${{ matrix.platform }}
 
     steps:
@@ -106,7 +107,7 @@ jobs:
         shell: bash
         working-directory: ${{runner.workspace}}/build
         run: |
-          cmake $GITHUB_WORKSPACE ${RUNTIME_LINKING_OPTION} ${PYTHON_LINKING_OPTION} -DCMAKE_C_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} -DCMAKE_CXX_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} ${{ matrix.package_option }}-DCMAKE_BUILD_TYPE=$BUILD_TYPE -DWITH_CHECK=True ${{matrix.language_bindings}} -DWITH_CPP_NAMESPACE=${{matrix.with_namespace}} -DLIBSBML_USE_STRICT_INCLUDES=${{matrix.strict}} -DWITH_EXAMPLES=${{matrix.with_examples}}
+          cmake $GITHUB_WORKSPACE ${RUNTIME_LINKING_OPTION} ${PYTHON_LINKING_OPTION} -DCMAKE_CXX_STANDARD=${{matrix.cpp_standard}} -DCMAKE_C_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} -DCMAKE_CXX_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} ${{ matrix.package_option }}-DCMAKE_BUILD_TYPE=$BUILD_TYPE -DWITH_CHECK=True ${{matrix.language_bindings}} -DWITH_CPP_NAMESPACE=${{matrix.with_namespace}} -DLIBSBML_USE_STRICT_INCLUDES=${{matrix.strict}} -DWITH_EXAMPLES=${{matrix.with_examples}}
 
       - name: Build
         working-directory: ${{runner.workspace}}/build

--- a/.github/workflows/brief.yml
+++ b/.github/workflows/brief.yml
@@ -35,7 +35,6 @@ jobs:
         with:
           path: |
             ./dependencies
-            ./swig
           key: ${{ runner.os }}-dependencies-static
 
       - name: Download pre-built Windows dependencies and SWIG
@@ -48,15 +47,20 @@ jobs:
           unzip dependencies.zip -d dependencies
           cp -r dependencies/libSBML\ Dependencies-1.0.0-b1-win64/* dependencies
           rm -r dependencies/libSBML*
-          curl -L https://prdownloads.sourceforge.net/swig/swigwin-3.0.12.zip > swig.zip
+
+      - name: Download SWIG on Windows
+        if: matrix.platform == 'windows-latest'
+        shell: bash
+        run: |
+          curl -L https://sourceforge.net/projects/swig/files/swigwin/swigwin-4.0.2/swigwin-4.0.2.zip/download > swig.zip
           unzip -o swig.zip -d swig
+          echo $GITHUB_WORKSPACE"/swig/swigwin-4.0.2/" >> $GITHUB_PATH
 
       - name: setup Windows environment
         # this is separate from the SWIG download itself, because it needs to be added to the path also when SWIG is cached
         if: matrix.platform == 'windows-latest'
         shell: bash
         run: |
-          echo $GITHUB_WORKSPACE"/swig/swigwin-3.0.12/" >> $GITHUB_PATH
           echo RUNTIME_LINKING_OPTION="-DWITH_STATIC_RUNTIME=ON" >> "${GITHUB_ENV}"
 
       - name: Install Ubuntu dependencies

--- a/dev/utilities/sboTree/SBO.cpp.cmake
+++ b/dev/utilities/sboTree/SBO.cpp.cmake
@@ -187,7 +187,7 @@ SBO::intToString (int sboTerm)
   * functions for checking the SBO term is from correct part of SBO
   * Unary Functor returns the parent portion of a ParentMap pair.
   */
-struct GetSecond : public unary_function<const pair<const int, int>, int>
+struct GetSecond
 {
   int operator() (const pair<const int, int>& pair) { return pair.second; }
 };

--- a/src/sbml/packages/comp/validator/test/TestValidator.cpp
+++ b/src/sbml/packages/comp/validator/test/TestValidator.cpp
@@ -72,7 +72,7 @@ TestValidator::~TestValidator ()
  * Function Object: Return true if the given SBMLError has the given
  * id, false otherwise.
  */
-struct HasId : public unary_function<SBMLError, bool>
+struct HasId
 {
   unsigned int id;
 
@@ -84,7 +84,7 @@ struct HasId : public unary_function<SBMLError, bool>
 /**
  * Function Object: Takes a SBMLError and returns its integer id.
  */
-struct ToId : public unary_function<SBMLError, unsigned int>
+struct ToId
 {
   unsigned int operator() (const SBMLError& msg) { return msg.getErrorId(); }
 };

--- a/src/sbml/packages/distrib/validator/test/TestValidator.cpp
+++ b/src/sbml/packages/distrib/validator/test/TestValidator.cpp
@@ -72,7 +72,7 @@ TestValidator::~TestValidator ()
  * Function Object: Return true if the given SBMLError has the given
  * id, false otherwise.
  */
-struct HasId : public unary_function<SBMLError, bool>
+struct HasId
 {
   unsigned int id;
 
@@ -84,7 +84,7 @@ struct HasId : public unary_function<SBMLError, bool>
 /**
  * Function Object: Takes a SBMLError and returns its integer id.
  */
-struct ToId : public unary_function<SBMLError, unsigned int>
+struct ToId
 {
   unsigned int operator() (const SBMLError& msg) { return msg.getErrorId(); }
 };

--- a/src/sbml/packages/fbc/validator/test/TestValidator.cpp
+++ b/src/sbml/packages/fbc/validator/test/TestValidator.cpp
@@ -72,7 +72,7 @@ TestValidator::~TestValidator ()
  * Function Object: Return true if the given SBMLError has the given
  * id, false otherwise.
  */
-struct HasId : public unary_function<SBMLError, bool>
+struct HasId
 {
   unsigned int id;
 
@@ -84,7 +84,7 @@ struct HasId : public unary_function<SBMLError, bool>
 /**
  * Function Object: Takes a SBMLError and returns its integer id.
  */
-struct ToId : public unary_function<SBMLError, unsigned int>
+struct ToId
 {
   unsigned int operator() (const SBMLError& msg) { return msg.getErrorId(); }
 };

--- a/src/sbml/packages/groups/validator/test/TestValidator.cpp
+++ b/src/sbml/packages/groups/validator/test/TestValidator.cpp
@@ -72,7 +72,7 @@ TestValidator::~TestValidator ()
  * Function Object: Return true if the given SBMLError has the given
  * id, false otherwise.
  */
-struct HasId : public unary_function<SBMLError, bool>
+struct HasId
 {
   unsigned int id;
 
@@ -84,7 +84,7 @@ struct HasId : public unary_function<SBMLError, bool>
 /**
  * Function Object: Takes a SBMLError and returns its integer id.
  */
-struct ToId : public unary_function<SBMLError, unsigned int>
+struct ToId
 {
   unsigned int operator() (const SBMLError& msg) { return msg.getErrorId(); }
 };

--- a/src/sbml/packages/l3v2extendedmath/validator/test/TestValidator.cpp
+++ b/src/sbml/packages/l3v2extendedmath/validator/test/TestValidator.cpp
@@ -72,7 +72,7 @@ TestValidator::~TestValidator ()
  * Function Object: Return true if the given SBMLError has the given
  * id, false otherwise.
  */
-struct HasId : public unary_function<SBMLError, bool>
+struct HasId
 {
   unsigned int id;
 
@@ -84,7 +84,7 @@ struct HasId : public unary_function<SBMLError, bool>
 /**
  * Function Object: Takes a SBMLError and returns its integer id.
  */
-struct ToId : public unary_function<SBMLError, unsigned int>
+struct ToId
 {
   unsigned int operator() (const SBMLError& msg) { return msg.getErrorId(); }
 };

--- a/src/sbml/packages/layout/validator/test/TestValidator.cpp
+++ b/src/sbml/packages/layout/validator/test/TestValidator.cpp
@@ -79,7 +79,7 @@ TestValidator::~TestValidator ()
  * Function Object: Return true if the given SBMLError has the given
  * id, false otherwise.
  */
-struct HasId : public unary_function<SBMLError, bool>
+struct HasId
 {
   unsigned int id;
 
@@ -91,7 +91,7 @@ struct HasId : public unary_function<SBMLError, bool>
 /**
  * Function Object: Takes a SBMLError and returns its integer id.
  */
-struct ToId : public unary_function<SBMLError, unsigned int>
+struct ToId
 {
   unsigned int operator() (const SBMLError& msg) { return msg.getErrorId(); }
 };

--- a/src/sbml/packages/multi/validator/test/TestValidator.cpp
+++ b/src/sbml/packages/multi/validator/test/TestValidator.cpp
@@ -72,7 +72,7 @@ TestValidator::~TestValidator ()
  * Function Object: Return true if the given SBMLError has the given
  * id, false otherwise.
  */
-struct HasId : public unary_function<SBMLError, bool>
+struct HasId
 {
   unsigned int id;
 
@@ -84,7 +84,7 @@ struct HasId : public unary_function<SBMLError, bool>
 /**
  * Function Object: Takes a SBMLError and returns its integer id.
  */
-struct ToId : public unary_function<SBMLError, unsigned int>
+struct ToId
 {
   unsigned int operator() (const SBMLError& msg) { return msg.getErrorId(); }
 };

--- a/src/sbml/packages/qual/validator/test/TestValidator.cpp
+++ b/src/sbml/packages/qual/validator/test/TestValidator.cpp
@@ -79,7 +79,7 @@ TestValidator::~TestValidator ()
  * Function Object: Return true if the given SBMLError has the given
  * id, false otherwise.
  */
-struct HasId : public unary_function<SBMLError, bool>
+struct HasId
 {
   unsigned int id;
 
@@ -91,7 +91,7 @@ struct HasId : public unary_function<SBMLError, bool>
 /**
  * Function Object: Takes a SBMLError and returns its integer id.
  */
-struct ToId : public unary_function<SBMLError, unsigned int>
+struct ToId
 {
   unsigned int operator() (const SBMLError& msg) { return msg.getErrorId(); }
 };

--- a/src/sbml/packages/render/validator/test/TestValidator.cpp
+++ b/src/sbml/packages/render/validator/test/TestValidator.cpp
@@ -79,7 +79,7 @@ TestValidator::~TestValidator ()
  * Function Object: Return true if the given SBMLError has the given
  * id, false otherwise.
  */
-struct HasId : public unary_function<SBMLError, bool>
+struct HasId
 {
   unsigned int id;
 
@@ -91,7 +91,7 @@ struct HasId : public unary_function<SBMLError, bool>
 /**
  * Function Object: Takes a SBMLError and returns its integer id.
  */
-struct ToId : public unary_function<SBMLError, unsigned int>
+struct ToId
 {
   unsigned int operator() (const SBMLError& msg) { return msg.getErrorId(); }
 };

--- a/src/sbml/packages/spatial/validator/test/TestValidator.cpp
+++ b/src/sbml/packages/spatial/validator/test/TestValidator.cpp
@@ -72,7 +72,7 @@ TestValidator::~TestValidator ()
  * Function Object: Return true if the given SBMLError has the given
  * id, false otherwise.
  */
-struct HasId : public unary_function<SBMLError, bool>
+struct HasId
 {
   unsigned int id;
 
@@ -84,7 +84,7 @@ struct HasId : public unary_function<SBMLError, bool>
 /**
  * Function Object: Takes a SBMLError and returns its integer id.
  */
-struct ToId : public unary_function<SBMLError, unsigned int>
+struct ToId
 {
   unsigned int operator() (const SBMLError& msg) { return msg.getErrorId(); }
 };

--- a/src/sbml/test/TestSBase.cpp
+++ b/src/sbml/test/TestSBase.cpp
@@ -429,8 +429,8 @@ END_TEST
 START_TEST (test_SBase_setNotesString)
 {
   Model_t *c = new(std::nothrow) Model(1,2);
-  char * notes = "This is a test note";
-  char * taggednotes = "<notes>This is a test note</notes>";
+  const char * notes = "This is a test note";
+  const char * taggednotes = "<notes>This is a test note</notes>";
 
   SBase_setNotesString(c, notes);
 
@@ -505,8 +505,8 @@ END_TEST
 START_TEST (test_SBase_setNotesString_l3_addMarkup)
 {
   Model_t *c = new(std::nothrow) Model(3, 1);
-  char * notes = "This is a test note";
-  char * taggednotes = "<notes>\n  <p xmlns=\"http://www.w3.org/1999/xhtml\">This is a test note</p>\n</notes>";
+  const char * notes = "This is a test note";
+  const char * taggednotes = "<notes>\n  <p xmlns=\"http://www.w3.org/1999/xhtml\">This is a test note</p>\n</notes>";
 
   SBase_setNotesStringAddMarkup(c, notes);
 
@@ -554,8 +554,8 @@ END_TEST
 
 START_TEST (test_SBase_setAnnotationString)
 {
-  char * annotation = "This is a test note";
-  char * taggedannotation = "<annotation>This is a test note</annotation>";
+  const char * annotation = "This is a test note";
+  const char * taggedannotation = "<annotation>This is a test note</annotation>";
 
   SBase_setAnnotationString(S, annotation);
 
@@ -1447,23 +1447,23 @@ END_TEST
 START_TEST (test_SBase_appendNotesString)
 {
   // add p to p 
-  char * notes = "<p xmlns=\"http://www.w3.org/1999/xhtml\">This is a test note </p>";
-  char * taggednewnotes = "<notes>\n"
+  const char * notes = "<p xmlns=\"http://www.w3.org/1999/xhtml\">This is a test note </p>";
+  const char * taggednewnotes = "<notes>\n"
                        "  <p xmlns=\"http://www.w3.org/1999/xhtml\">This is a test note </p>\n"
                        "  <p xmlns=\"http://www.w3.org/1999/xhtml\">This is more test notes </p>\n"
                        "</notes>";
-  char * taggednewnotes2 = "<notes>\n"
+  const char * taggednewnotes2 = "<notes>\n"
                        "  <p xmlns=\"http://www.w3.org/1999/xhtml\">This is a test note </p>\n"
                        "  <p xmlns=\"http://www.w3.org/1999/xhtml\">This is more test notes 1</p>\n"
                        "  <p xmlns=\"http://www.w3.org/1999/xhtml\">This is more test notes 2</p>\n"
                        "</notes>";
-  char * newnotes = "<p xmlns=\"http://www.w3.org/1999/xhtml\">This is more test notes </p>";
-  char * newnotes2 = "<p xmlns=\"http://www.w3.org/1999/xhtml\">This is more test notes 1</p>"
+  const char * newnotes = "<p xmlns=\"http://www.w3.org/1999/xhtml\">This is more test notes </p>";
+  const char * newnotes2 = "<p xmlns=\"http://www.w3.org/1999/xhtml\">This is more test notes 1</p>"
                      "<p xmlns=\"http://www.w3.org/1999/xhtml\">This is more test notes 2</p>";
-  char * newnotes3= "<notes>\n"
+  const char * newnotes3= "<notes>\n"
                     "  <p xmlns=\"http://www.w3.org/1999/xhtml\">This is more test notes </p>\n"
                     "</notes>";
-  char * newnotes4 = "<notes>\n"
+  const char * newnotes4 = "<notes>\n"
                      "  <p xmlns=\"http://www.w3.org/1999/xhtml\">This is more test notes 1</p>\n"
                      "  <p xmlns=\"http://www.w3.org/1999/xhtml\">This is more test notes 2</p>\n"
                      "</notes>";
@@ -1525,7 +1525,7 @@ END_TEST
 
 START_TEST (test_SBase_appendNotesString1)
 { // add html to html
-  char * notes = "<html xmlns=\"http://www.w3.org/1999/xhtml\">\n"
+  const char * notes = "<html xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "  <head>\n"
                  "    <title/>\n"
                  "  </head>\n"
@@ -1533,7 +1533,7 @@ START_TEST (test_SBase_appendNotesString1)
                  "    <p>This is a test note </p>\n"
                  "  </body>\n"
                  "</html>";
-  char * taggednewnotes = 
+  const char * taggednewnotes = 
                  "<notes>\n"
                  "  <html xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "    <head>\n"
@@ -1545,7 +1545,7 @@ START_TEST (test_SBase_appendNotesString1)
                  "    </body>\n"
                  "  </html>\n"
                  "</notes>";
-  char * addnotes = "<html xmlns=\"http://www.w3.org/1999/xhtml\">\n"
+  const char * addnotes = "<html xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "  <head>\n"
                  "    <title/>\n"
                  "  </head>\n"
@@ -1553,7 +1553,7 @@ START_TEST (test_SBase_appendNotesString1)
                  "    <p>This is more test notes </p>\n"
                  "  </body>\n"
                  "</html>";
-  char * addnotes2 =
+  const char * addnotes2 =
                  "<notes>\n"
                  "  <html xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "    <head>\n"
@@ -1593,7 +1593,7 @@ END_TEST
 
 START_TEST (test_SBase_appendNotesString2)
 { // add body to html
-  char * notes = "<html xmlns=\"http://www.w3.org/1999/xhtml\">\n"
+  const char * notes = "<html xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "  <head>\n"
                  "    <title/>\n"
                  "  </head>\n"
@@ -1601,7 +1601,7 @@ START_TEST (test_SBase_appendNotesString2)
                  "    <p>This is a test note </p>\n"
                  "  </body>\n"
                  "</html>";
-  char * taggednewnotes = 
+  const char * taggednewnotes = 
                  "<notes>\n"
                  "  <html xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "    <head>\n"
@@ -1651,7 +1651,7 @@ END_TEST
 
 START_TEST (test_SBase_appendNotesString3)
 { // add p to html
-  char * notes = "<html xmlns=\"http://www.w3.org/1999/xhtml\">\n"
+  const char * notes = "<html xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "  <head>\n"
                  "    <title/>\n"
                  "  </head>\n"
@@ -1659,7 +1659,7 @@ START_TEST (test_SBase_appendNotesString3)
                  "    <p>This is a test note </p>\n"
                  "  </body>\n"
                  "</html>";
-  char * taggednewnotes = 
+  const char * taggednewnotes = 
                  "<notes>\n"
                  "  <html xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "    <head>\n"
@@ -1671,7 +1671,7 @@ START_TEST (test_SBase_appendNotesString3)
                  "    </body>\n"
                  "  </html>\n"
                  "</notes>";
-  char * taggednewnotes2 =
+  const char * taggednewnotes2 =
                  "<notes>\n"
                  "  <html xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "    <head>\n"
@@ -1684,13 +1684,13 @@ START_TEST (test_SBase_appendNotesString3)
                  "    </body>\n"
                  "  </html>\n"
                  "</notes>";
-  char * addnotes = "<p xmlns=\"http://www.w3.org/1999/xhtml\">This is more test notes </p>\n";
-  char * addnotes2 = "<p xmlns=\"http://www.w3.org/1999/xhtml\">This is more test notes 1</p>\n"
+  const char * addnotes = "<p xmlns=\"http://www.w3.org/1999/xhtml\">This is more test notes </p>\n";
+  const char * addnotes2 = "<p xmlns=\"http://www.w3.org/1999/xhtml\">This is more test notes 1</p>\n"
                      "<p xmlns=\"http://www.w3.org/1999/xhtml\">This is more test notes 2</p>";
-  char * addnotes3 = "<notes>\n"
+  const char * addnotes3 = "<notes>\n"
                      "  <p xmlns=\"http://www.w3.org/1999/xhtml\">This is more test notes </p>\n"
                      "</notes>";
-  char * addnotes4 = "<notes>\n"
+  const char * addnotes4 = "<notes>\n"
                      "  <p xmlns=\"http://www.w3.org/1999/xhtml\">This is more test notes 1</p>\n"
                      "  <p xmlns=\"http://www.w3.org/1999/xhtml\">This is more test notes 2</p>\n"
                      "</notes>";
@@ -1745,10 +1745,10 @@ END_TEST
 
 START_TEST (test_SBase_appendNotesString4)
 { // add html to body
-  char * notes = "<body xmlns=\"http://www.w3.org/1999/xhtml\">\n"
+  const char * notes = "<body xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "  <p>This is a test note </p>\n"
                  "</body>";
-  char * taggednewnotes = 
+  const char * taggednewnotes = 
                  "<notes>\n"
                  "  <html xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "    <head>\n"
@@ -1760,7 +1760,7 @@ START_TEST (test_SBase_appendNotesString4)
                  "    </body>\n"
                  "  </html>\n"
                  "</notes>";
-  char * addnotes = "<html xmlns=\"http://www.w3.org/1999/xhtml\">\n"
+  const char * addnotes = "<html xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "  <head>\n"
                  "    <title/>\n"
                  "  </head>\n"
@@ -1768,7 +1768,7 @@ START_TEST (test_SBase_appendNotesString4)
                  "    <p>This is more test notes </p>\n"
                  "  </body>\n"
                  "</html>";
-  char * addnotes2 =
+  const char * addnotes2 =
                  "<notes>\n"
                  "  <html xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "    <head>\n"
@@ -1808,8 +1808,8 @@ END_TEST
 
 START_TEST (test_SBase_appendNotesString5)
 { // add html to p
-  char * notes = "<p xmlns=\"http://www.w3.org/1999/xhtml\">This is a test note </p>";
-  char * taggednewnotes = 
+  const char * notes = "<p xmlns=\"http://www.w3.org/1999/xhtml\">This is a test note </p>";
+  const char * taggednewnotes = 
                  "<notes>\n"
                  "  <html xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "    <head>\n"
@@ -1821,7 +1821,7 @@ START_TEST (test_SBase_appendNotesString5)
                  "    </body>\n"
                  "  </html>\n"
                  "</notes>";
-  char * addnotes = "<html xmlns=\"http://www.w3.org/1999/xhtml\">\n"
+  const char * addnotes = "<html xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "  <head>\n"
                  "    <title/>\n"
                  "  </head>\n"
@@ -1829,7 +1829,7 @@ START_TEST (test_SBase_appendNotesString5)
                  "    <p>This is more test notes </p>\n"
                  "  </body>\n"
                  "</html>";
-  char * addnotes2 = 
+  const char * addnotes2 = 
                  "<notes>\n"
                  "  <html xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "    <head>\n"
@@ -1869,20 +1869,20 @@ END_TEST
 
 START_TEST (test_SBase_appendNotesString6)
 { // add body to body
-  char * notes = "<body xmlns=\"http://www.w3.org/1999/xhtml\">\n"
+  const char * notes = "<body xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "  <p>This is a test note </p>\n"
                  "</body>";
-  char * taggednewnotes = 
+  const char * taggednewnotes = 
                  "<notes>\n"
                  "  <body xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "    <p>This is a test note </p>\n"
                  "    <p>This is more test notes </p>\n"
                  "  </body>\n"
                  "</notes>";
-  char * addnotes = "<body xmlns=\"http://www.w3.org/1999/xhtml\">\n"
+  const char * addnotes = "<body xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "  <p>This is more test notes </p>\n"
                  "</body>";
-  char * addnotes2 = 
+  const char * addnotes2 = 
                  "<notes>\n"
                  "  <body xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "    <p>This is more test notes </p>\n"
@@ -1917,18 +1917,18 @@ END_TEST
 
 START_TEST (test_SBase_appendNotesString7)
 { // add body to p
-  char * notes = "<p xmlns=\"http://www.w3.org/1999/xhtml\">This is a test note </p>";
-  char * taggednewnotes = 
+  const char * notes = "<p xmlns=\"http://www.w3.org/1999/xhtml\">This is a test note </p>";
+  const char * taggednewnotes = 
                  "<notes>\n"
                  "  <body xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "    <p xmlns=\"http://www.w3.org/1999/xhtml\">This is a test note </p>\n"
                  "    <p>This is more test notes </p>\n"
                  "  </body>\n"
                  "</notes>";
-  char * addnotes = "<body xmlns=\"http://www.w3.org/1999/xhtml\">\n"
+  const char * addnotes = "<body xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "  <p>This is more test notes </p>\n"
                  "</body>";
-  char * addnotes2 = 
+  const char * addnotes2 = 
                  "<notes>\n"
                  "  <body xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "    <p>This is more test notes </p>\n"
@@ -1963,17 +1963,17 @@ END_TEST
 
 START_TEST (test_SBase_appendNotesString8)
 { // add p to body
-  char * notes = "<body xmlns=\"http://www.w3.org/1999/xhtml\">\n"
+  const char * notes = "<body xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "  <p>This is a test note </p>\n"
                  "</body>";
-  char * taggednewnotes = 
+  const char * taggednewnotes = 
                  "<notes>\n"
                  "  <body xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "    <p>This is a test note </p>\n"
                  "    <p xmlns=\"http://www.w3.org/1999/xhtml\">This is more test notes </p>\n"
                  "  </body>\n"
                  "</notes>";
-  char * taggednewnotes2 = 
+  const char * taggednewnotes2 = 
                  "<notes>\n"
                  "  <body xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "    <p>This is a test note </p>\n"
@@ -1981,14 +1981,14 @@ START_TEST (test_SBase_appendNotesString8)
                  "    <p xmlns=\"http://www.w3.org/1999/xhtml\">This is more test notes 2</p>\n"
                  "  </body>\n"
                  "</notes>";
-  char * addnotes = "<p xmlns=\"http://www.w3.org/1999/xhtml\">This is more test notes </p>";
-  char * addnotes2 = "<p xmlns=\"http://www.w3.org/1999/xhtml\">This is more test notes 1</p>\n"
+  const char * addnotes = "<p xmlns=\"http://www.w3.org/1999/xhtml\">This is more test notes </p>";
+  const char * addnotes2 = "<p xmlns=\"http://www.w3.org/1999/xhtml\">This is more test notes 1</p>\n"
                      "<p xmlns=\"http://www.w3.org/1999/xhtml\">This is more test notes 2</p>";
-  char * addnotes3 = 
+  const char * addnotes3 = 
                  "<notes>\n"
                  "  <p xmlns=\"http://www.w3.org/1999/xhtml\">This is more test notes </p>\n"
                  "</notes>";
-  char * addnotes4 = 
+  const char * addnotes4 = 
                  "<notes>\n"
                  "  <p xmlns=\"http://www.w3.org/1999/xhtml\">This is more test notes 1</p>\n"
                  "  <p xmlns=\"http://www.w3.org/1999/xhtml\">This is more test notes 2</p>\n"
@@ -2221,7 +2221,7 @@ void setOrAppendNotes(SBase* base, std::string note)
 START_TEST(test_SBase_appendNotesWithGlobalNamespace)
 {
 
-  char * notes = 
+  const char * notes = 
 		"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
 		"<sbml xmlns=\"http://www.sbml.org/sbml/level2/version4\" xmlns:html=\"http://www.w3.org/1999/xhtml\" level=\"2\" version=\"4\">\n"
 		"  <model id=\"test\" name=\"name\">\n"

--- a/src/sbml/test/TestSBase.cpp
+++ b/src/sbml/test/TestSBase.cpp
@@ -1613,10 +1613,10 @@ START_TEST (test_SBase_appendNotesString2)
                  "    </body>\n"
                  "  </html>\n"
                  "</notes>";
-  char * addnotes = "<body xmlns=\"http://www.w3.org/1999/xhtml\">\n"
+  const char * addnotes = "<body xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                     "  <p>This is more test notes </p>\n"
                     "</body>\n";
-  char * addnotes2 =
+  const char * addnotes2 =
                     "<notes>\n"
                     "  <body xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                     "    <p>This is more test notes </p>\n"

--- a/src/sbml/test/TestSBase_newSetters.cpp
+++ b/src/sbml/test/TestSBase_newSetters.cpp
@@ -368,9 +368,9 @@ END_TEST
 
 START_TEST (test_SBase_setNotesString)
 {
-  char * notes = "<p xmlns=\"http://www.w3.org/1999/xhtml\">This is a test note </p>";
-  char * taggednotes = "<notes><p xmlns=\"http://www.w3.org/1999/xhtml\">This is a test note </p></notes>";
-  char * badnotes = "<notes>This is a test note</notes>";
+  const char * notes = "<p xmlns=\"http://www.w3.org/1999/xhtml\">This is a test note </p>";
+  const char * taggednotes = "<notes><p xmlns=\"http://www.w3.org/1999/xhtml\">This is a test note </p></notes>";
+  const char * badnotes = "<notes>This is a test note</notes>";
 
   int i = SBase_setNotesString(S, notes);
 
@@ -403,8 +403,8 @@ END_TEST
 
 START_TEST (test_SBase_setAnnotationString)
 {
-  char * annotation = "This is a test note";
-  char * taggedannotation = "<annotation>This is a test note</annotation>";
+  const char * annotation = "This is a test note";
+  const char * taggedannotation = "<annotation>This is a test note</annotation>";
 
   int i = SBase_setAnnotationString(S, annotation);
 
@@ -594,7 +594,7 @@ START_TEST (test_SBase_appendAnnotation2)
   fail_unless(XMLNode_getNumChildren(c1) == 0);
   fail_unless(!strcmp(XMLNode_getCharacters(c1), "This is additional"));
 
-  char * newann =
+  const char * newann =
     "<annotation>"
     "<prA:other xmlns:prA=\"http://some\">This is additional repeat</prA:other>"
     "<rdf:RDF xmlns:rdf=\"http://rdf\">This is a new annotation</rdf:RDF>"
@@ -1520,16 +1520,16 @@ END_TEST
 
 START_TEST (test_SBase_appendNotesString)
 {
-  char * notes = "<p xmlns=\"http://www.w3.org/1999/xhtml\">This is a test note </p>";
-  char * taggednotes = "<notes>\n"
+  const char * notes = "<p xmlns=\"http://www.w3.org/1999/xhtml\">This is a test note </p>";
+  const char * taggednotes = "<notes>\n"
                        "  <p xmlns=\"http://www.w3.org/1999/xhtml\">This is a test note </p>\n"
                        "</notes>";
-  char * taggednewnotes = "<notes>\n"
+  const char * taggednewnotes = "<notes>\n"
                        "  <p xmlns=\"http://www.w3.org/1999/xhtml\">This is a test note </p>\n"
                        "  <p xmlns=\"http://www.w3.org/1999/xhtml\">This is more test notes </p>\n"
                        "</notes>";
-  char * badnotes = "<notes>This is a test note</notes>";
-  char * newnotes = "<p xmlns=\"http://www.w3.org/1999/xhtml\">This is more test notes </p>";
+  const char * badnotes = "<notes>This is a test note</notes>";
+  const char * newnotes = "<p xmlns=\"http://www.w3.org/1999/xhtml\">This is more test notes </p>";
 
   int i = SBase_setNotesString(S, notes);
 
@@ -1559,7 +1559,7 @@ END_TEST
 
 START_TEST (test_SBase_appendNotesString1)
 { // add html to html
-  char * notes = "<html xmlns=\"http://www.w3.org/1999/xhtml\">\n"
+  const char * notes = "<html xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "  <head>\n"
                  "    <title/>\n"
                  "  </head>\n"
@@ -1567,7 +1567,7 @@ START_TEST (test_SBase_appendNotesString1)
                  "    <p>This is a test note </p>\n"
                  "  </body>\n"
                  "</html>";
-  char * taggednewnotes = 
+  const char * taggednewnotes = 
                  "<notes>\n"
                  "  <html xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "    <head>\n"
@@ -1579,7 +1579,7 @@ START_TEST (test_SBase_appendNotesString1)
                  "    </body>\n"
                  "  </html>\n"
                  "</notes>";
-  char * addnotes = "<html xmlns=\"http://www.w3.org/1999/xhtml\">\n"
+  const char * addnotes = "<html xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "  <head>\n"
                  "    <title/>\n"
                  "  </head>\n"
@@ -1604,7 +1604,7 @@ END_TEST
 
 START_TEST (test_SBase_appendNotesString2)
 { // add body to html
-  char * notes = "<html xmlns=\"http://www.w3.org/1999/xhtml\">\n"
+  const char * notes = "<html xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "  <head>\n"
                  "    <title/>\n"
                  "  </head>\n"
@@ -1612,7 +1612,7 @@ START_TEST (test_SBase_appendNotesString2)
                  "    <p>This is a test note </p>\n"
                  "  </body>\n"
                  "</html>";
-  char * taggednewnotes = 
+  const char * taggednewnotes = 
                  "<notes>\n"
                  "  <html xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "    <head>\n"
@@ -1624,7 +1624,7 @@ START_TEST (test_SBase_appendNotesString2)
                  "    </body>\n"
                  "  </html>\n"
                  "</notes>";
-  char * addnotes = "<body xmlns=\"http://www.w3.org/1999/xhtml\">\n"
+  const char * addnotes = "<body xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                     "  <p>This is more test notes </p>\n"
                     "</body>\n";
 
@@ -1644,7 +1644,7 @@ END_TEST
 
 START_TEST (test_SBase_appendNotesString3)
 { // add p to html
-  char * notes = "<html xmlns=\"http://www.w3.org/1999/xhtml\">\n"
+const char * notes = "<html xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "  <head>\n"
                  "    <title/>\n"
                  "  </head>\n"
@@ -1652,7 +1652,7 @@ START_TEST (test_SBase_appendNotesString3)
                  "    <p>This is a test note </p>\n"
                  "  </body>\n"
                  "</html>";
-  char * taggednewnotes = 
+const char * taggednewnotes = 
                  "<notes>\n"
                  "  <html xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "    <head>\n"
@@ -1664,7 +1664,7 @@ START_TEST (test_SBase_appendNotesString3)
                  "    </body>\n"
                  "  </html>\n"
                  "</notes>";
-  char * addnotes = "<p xmlns=\"http://www.w3.org/1999/xhtml\">This is more test notes </p>";
+  const char * addnotes = "<p xmlns=\"http://www.w3.org/1999/xhtml\">This is more test notes </p>";
 
   int i = SBase_setNotesString(S, notes);
   i = SBase_appendNotesString(S, addnotes);
@@ -1682,10 +1682,10 @@ END_TEST
 
 START_TEST (test_SBase_appendNotesString4)
 { // add html to body
-  char * notes = "<body xmlns=\"http://www.w3.org/1999/xhtml\">\n"
+  const char * notes = "<body xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "  <p>This is a test note </p>\n"
                  "</body>";
-  char * taggednewnotes = 
+  const char * taggednewnotes = 
                  "<notes>\n"
                  "  <html xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "    <head>\n"
@@ -1697,7 +1697,7 @@ START_TEST (test_SBase_appendNotesString4)
                  "    </body>\n"
                  "  </html>\n"
                  "</notes>";
-  char * addnotes = "<html xmlns=\"http://www.w3.org/1999/xhtml\">\n"
+  const char * addnotes = "<html xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "  <head>\n"
                  "    <title/>\n"
                  "  </head>\n"
@@ -1722,8 +1722,8 @@ END_TEST
 
 START_TEST (test_SBase_appendNotesString5)
 { // add html to p
-  char * notes = "<p xmlns=\"http://www.w3.org/1999/xhtml\">This is a test note </p>";
-  char * taggednewnotes = 
+  const char * notes = "<p xmlns=\"http://www.w3.org/1999/xhtml\">This is a test note </p>";
+  const char * taggednewnotes = 
                  "<notes>\n"
                  "  <html xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "    <head>\n"
@@ -1735,7 +1735,7 @@ START_TEST (test_SBase_appendNotesString5)
                  "    </body>\n"
                  "  </html>\n"
                  "</notes>";
-  char * addnotes = "<html xmlns=\"http://www.w3.org/1999/xhtml\">\n"
+  const char * addnotes = "<html xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "  <head>\n"
                  "    <title/>\n"
                  "  </head>\n"
@@ -1760,17 +1760,17 @@ END_TEST
 
 START_TEST (test_SBase_appendNotesString6)
 { // add body to body
-  char * notes = "<body xmlns=\"http://www.w3.org/1999/xhtml\">\n"
+  const char * notes = "<body xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "  <p>This is a test note </p>\n"
                  "</body>";
-  char * taggednewnotes = 
+  const char * taggednewnotes = 
                  "<notes>\n"
                  "  <body xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "    <p>This is a test note </p>\n"
                  "    <p>This is more test notes </p>\n"
                  "  </body>\n"
                  "</notes>";
-  char * addnotes = "<body xmlns=\"http://www.w3.org/1999/xhtml\">\n"
+  const char * addnotes = "<body xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "  <p>This is more test notes </p>\n"
                  "</body>";
 
@@ -1790,15 +1790,15 @@ END_TEST
 
 START_TEST (test_SBase_appendNotesString7)
 { // add body to p
-  char * notes = "<p xmlns=\"http://www.w3.org/1999/xhtml\">This is a test note </p>";
-  char * taggednewnotes = 
+  const char * notes = "<p xmlns=\"http://www.w3.org/1999/xhtml\">This is a test note </p>";
+  const char * taggednewnotes = 
                  "<notes>\n"
                  "  <body xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "    <p xmlns=\"http://www.w3.org/1999/xhtml\">This is a test note </p>\n"
                  "    <p>This is more test notes </p>\n"
                  "  </body>\n"
                  "</notes>";
-  char * addnotes = "<body xmlns=\"http://www.w3.org/1999/xhtml\">\n"
+  const char * addnotes = "<body xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "  <p>This is more test notes </p>\n"
                  "</body>";
 
@@ -1818,17 +1818,17 @@ END_TEST
 
 START_TEST (test_SBase_appendNotesString8)
 { // add p to body
-  char * notes = "<body xmlns=\"http://www.w3.org/1999/xhtml\">\n"
+  const char * notes = "<body xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "  <p>This is a test note </p>\n"
                  "</body>";
-  char * taggednewnotes = 
+  const char * taggednewnotes = 
                  "<notes>\n"
                  "  <body xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "    <p>This is a test note </p>\n"
                  "    <p xmlns=\"http://www.w3.org/1999/xhtml\">This is more test notes </p>\n"
                  "  </body>\n"
                  "</notes>";
-  char * addnotes = "<p xmlns=\"http://www.w3.org/1999/xhtml\">This is more test notes </p>";
+  const char * addnotes = "<p xmlns=\"http://www.w3.org/1999/xhtml\">This is more test notes </p>";
 
   int i = SBase_setNotesString(S, notes);
   i = SBase_appendNotesString(S, addnotes);

--- a/src/sbml/validator/test/TestValidator.cpp
+++ b/src/sbml/validator/test/TestValidator.cpp
@@ -79,7 +79,7 @@ TestValidator::~TestValidator ()
  * Function Object: Return true if the given SBMLError has the given
  * id, false otherwise.
  */
-struct HasId : public unary_function<SBMLError, bool>
+struct HasId
 {
   unsigned int id;
 
@@ -91,7 +91,7 @@ struct HasId : public unary_function<SBMLError, bool>
 /**
  * Function Object: Takes a SBMLError and returns its integer id.
  */
-struct ToId : public unary_function<SBMLError, unsigned int>
+struct ToId
 {
   unsigned int operator() (const SBMLError& msg) { return msg.getErrorId(); }
 };


### PR DESCRIPTION
## Description
This PR 
- runs the rapid CI on push with both C++98 and C++20, by updating SWIG to > 4 for the Windows runs.
- removes instances of `unary_function` from the code (`unary_function` was removed in C++17)
- specifies the `const` modifier when `char *` are assigned to hard-coded strings ([see MSCV error C2440](https://docs.microsoft.com/en-us/cpp/error-messages/compiler-errors-1/compiler-error-c2440?view=msvc-160)).

Note to reviewers: I am not familiar enough with the code to know whether the changes introduced have any unwanted side-effects, but they seem reasonable to me?

SWIG is not cached anymore on Windows, but seeing that this caching saves ~10 seconds over ~40 minutes I didn't think it was worth the effort.

## Motivation and Context
The current code uses several C++ features that were deprecated in C++11 and removed in C++17. It was also previously compiled with SWIG 3.0.1. on Windows, which also

The code therefore failed to compile with standards > C++17, but this wasn't picked up by the CI.

The changes introduced here ensure that the code is built and tested successfully with both the earliest (C++98) and latest (C++20) standards (as long as SWIG > 4 is used!).

The CI run should take the same amount of time as before, as the 3 additional runs can run in parallel with the existing ones in the rapid build, and will now pick up changes to the code that are not compatible with the latest C++ standard (provided they are touched by one of the rapid build configurations).

Fixes #132 (see second bullet point above) amongst other things.
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Change in documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have updated all documentation necessary. CI documentation is in separate doc currently.
- [x] I have checked spelling in (new) comments.

## Testing
- [ ] Testing is done automatically and codecov shows test coverage
- [x] This cannot be tested automatically <!-- describe how it has been tested -->

