### PR TITLE
Improve legibility of `cmake` configuration command in the CI/CD

### DIFF
--- a/.github/workflows/brief.yml
+++ b/.github/workflows/brief.yml
@@ -7,7 +7,7 @@ env:
 
 jobs:
   build:
-    name: ${{ matrix.platform }}, Parser option ${{ matrix.xml_parser_option }}, with namespaces ${{ matrix.with_namespace}}, strict includes ${{ matrix.strict }}, with examples ${{ matrix.with_examples}}, package option ${{ matrix.package_option}}
+    name: ${{ matrix.platform }}, Parser option ${{ matrix.xml_parser_option }}, with namespaces ${{ matrix.with_namespace}}, strict includes ${{ matrix.strict }}, with examples ${{ matrix.with_examples}}, package option ${{ matrix.package_option}}, c++  standard ${{matrix.cpp_standard}}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/brief.yml
+++ b/.github/workflows/brief.yml
@@ -7,7 +7,11 @@ env:
 
 jobs:
   build:
-    name: ${{ matrix.platform }}, Parser option ${{ matrix.xml_parser_option }}, with namespaces ${{ matrix.with_namespace}}, strict includes ${{ matrix.strict }}, with examples ${{ matrix.with_examples}}, package option ${{ matrix.package_option}}, c++  standard ${{matrix.cpp_standard}}
+    name:
+      ${{ matrix.platform }}, Parser option ${{ matrix.xml_parser_option }},
+      with namespaces ${{ matrix.with_namespace}}, strict includes ${{
+      matrix.strict }}, with examples ${{ matrix.with_examples}}, package option
+      ${{ matrix.package_option}}, c++  standard ${{matrix.cpp_standard}}
     strategy:
       fail-fast: false
       matrix:
@@ -40,7 +44,9 @@ jobs:
       - name: Download pre-built Windows dependencies and SWIG
         # Windows dependencies have to be in a subfolder called `dependencies`, directly under the git repository root.
         # also gets SWIG, completing the set of dependencies needed for windows
-        if: matrix.platform == 'windows-latest' && steps.cache-win-dependencies-static.outputs.cache-hit != 'true'
+        if:
+          matrix.platform == 'windows-latest' &&
+          steps.cache-win-dependencies-static.outputs.cache-hit != 'true'
         shell: bash
         run: |
           curl -L https://sourceforge.net/projects/sbml/files/libsbml/win-dependencies/libSBML_dependencies_vs15_release_x64_static.zip/download > dependencies.zip
@@ -98,7 +104,9 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{runner.workspace}}/.ccache
-          key: ${{ runner.os }}-${{ steps.ccache_cache_timestamp.outputs.timestamp }}
+          key:
+            ${{ runner.os }}-${{ steps.ccache_cache_timestamp.outputs.timestamp
+            }}
           restore-keys: |
             ${{ runner.os }}-${{ steps.ccache_cache_timestamp.outputs.timestamp }}
             ${{ runner.os }}-
@@ -111,20 +119,20 @@ jobs:
         shell: bash
         working-directory: ${{runner.workspace}}/build
         run: |
-          cmake $GITHUB_WORKSPACE ^
-          -DCMAKE_BUILD_TYPE=$BUILD_TYPE ^
-          -DCMAKE_C_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} ^
-          -DCMAKE_CXX_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} ^
-          -DCMAKE_CXX_STANDARD=${{matrix.cpp_standard}} ^
-          -DWITH_CHECK=True ^
-          -DWITH_CPP_NAMESPACE=${{matrix.with_namespace}} ^
-          -DLIBSBML_USE_STRICT_INCLUDES=${{matrix.strict}} ^
-          -DWITH_EXAMPLES=${{matrix.with_examples}} ^
-          ${{matrix.package_option}} ^
-          ${{matrix.language_bindings}} ^
-          ${RUNTIME_LINKING_OPTION} ^
+          cmake $GITHUB_WORKSPACE \
+          -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
+          -DCMAKE_C_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} \
+          -DCMAKE_CXX_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} \
+          -DCMAKE_CXX_STANDARD=${{matrix.cpp_standard}} \
+          -DWITH_CHECK=True \
+          -DWITH_CPP_NAMESPACE=${{matrix.with_namespace}} \
+          -DLIBSBML_USE_STRICT_INCLUDES=${{matrix.strict}} \
+          -DWITH_EXAMPLES=${{matrix.with_examples}} \
+          ${{matrix.package_option}} \
+          ${{matrix.language_bindings}} \
+          ${RUNTIME_LINKING_OPTION} \
           ${PYTHON_LINKING_OPTION}
-          
+
       - name: Build
         working-directory: ${{runner.workspace}}/build
         shell: bash

--- a/.github/workflows/brief.yml
+++ b/.github/workflows/brief.yml
@@ -19,6 +19,7 @@ jobs:
         package_option: ["-DWITH_ALL_PACKAGES=ON"]
         language_bindings:
           ["-DWITH_JAVA=True -DWITH_CSHARP=True -DWITH_PYTHON=True"]
+        cpp_standard: [98, 20]
     runs-on: ${{ matrix.platform }}
 
     steps:
@@ -106,7 +107,7 @@ jobs:
         shell: bash
         working-directory: ${{runner.workspace}}/build
         run: |
-          cmake $GITHUB_WORKSPACE ${RUNTIME_LINKING_OPTION} ${PYTHON_LINKING_OPTION} -DCMAKE_C_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} -DCMAKE_CXX_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} ${{ matrix.package_option }}-DCMAKE_BUILD_TYPE=$BUILD_TYPE -DWITH_CHECK=True ${{matrix.language_bindings}} -DWITH_CPP_NAMESPACE=${{matrix.with_namespace}} -DLIBSBML_USE_STRICT_INCLUDES=${{matrix.strict}} -DWITH_EXAMPLES=${{matrix.with_examples}}
+          cmake $GITHUB_WORKSPACE ${RUNTIME_LINKING_OPTION} ${PYTHON_LINKING_OPTION} -DCMAKE_CXX_STANDARD=${{matrix.cpp_standard}} -DCMAKE_C_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} -DCMAKE_CXX_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} ${{ matrix.package_option }}-DCMAKE_BUILD_TYPE=$BUILD_TYPE -DWITH_CHECK=True ${{matrix.language_bindings}} -DWITH_CPP_NAMESPACE=${{matrix.with_namespace}} -DLIBSBML_USE_STRICT_INCLUDES=${{matrix.strict}} -DWITH_EXAMPLES=${{matrix.with_examples}}
 
       - name: Build
         working-directory: ${{runner.workspace}}/build

--- a/.github/workflows/brief.yml
+++ b/.github/workflows/brief.yml
@@ -112,18 +112,19 @@ jobs:
         working-directory: ${{runner.workspace}}/build
         run: |
           cmake $GITHUB_WORKSPACE ^
-          ${RUNTIME_LINKING_OPTION} ^
-          ${PYTHON_LINKING_OPTION} ^
-          -DCMAKE_CXX_STANDARD=${{matrix.cpp_standard}} ^
+          -DCMAKE_BUILD_TYPE=$BUILD_TYPE ^
           -DCMAKE_C_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} ^
           -DCMAKE_CXX_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} ^
-          ${{ matrix.package_option }} ^
-          -DCMAKE_BUILD_TYPE=$BUILD_TYPE ^
-          -DWITH_CHECK=True ${{matrix.language_bindings}} ^
+          -DCMAKE_CXX_STANDARD=${{matrix.cpp_standard}} ^
+          -DWITH_CHECK=True ^
           -DWITH_CPP_NAMESPACE=${{matrix.with_namespace}} ^
           -DLIBSBML_USE_STRICT_INCLUDES=${{matrix.strict}} ^
-          -DWITH_EXAMPLES=${{matrix.with_examples}}
-
+          -DWITH_EXAMPLES=${{matrix.with_examples}} ^
+          ${{matrix.package_option}} ^
+          ${{matrix.language_bindings}} ^
+          ${RUNTIME_LINKING_OPTION} ^
+          ${PYTHON_LINKING_OPTION}
+          
       - name: Build
         working-directory: ${{runner.workspace}}/build
         shell: bash

--- a/.github/workflows/brief.yml
+++ b/.github/workflows/brief.yml
@@ -111,7 +111,18 @@ jobs:
         shell: bash
         working-directory: ${{runner.workspace}}/build
         run: |
-          cmake $GITHUB_WORKSPACE ${RUNTIME_LINKING_OPTION} ${PYTHON_LINKING_OPTION} -DCMAKE_CXX_STANDARD=${{matrix.cpp_standard}} -DCMAKE_C_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} -DCMAKE_CXX_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} ${{ matrix.package_option }}-DCMAKE_BUILD_TYPE=$BUILD_TYPE -DWITH_CHECK=True ${{matrix.language_bindings}} -DWITH_CPP_NAMESPACE=${{matrix.with_namespace}} -DLIBSBML_USE_STRICT_INCLUDES=${{matrix.strict}} -DWITH_EXAMPLES=${{matrix.with_examples}}
+          cmake $GITHUB_WORKSPACE ^
+          ${RUNTIME_LINKING_OPTION} ^
+          ${PYTHON_LINKING_OPTION} ^
+          -DCMAKE_CXX_STANDARD=${{matrix.cpp_standard}} ^
+          -DCMAKE_C_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} ^
+          -DCMAKE_CXX_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} ^
+          ${{ matrix.package_option }} ^
+          -DCMAKE_BUILD_TYPE=$BUILD_TYPE ^
+          -DWITH_CHECK=True ${{matrix.language_bindings}} ^
+          -DWITH_CPP_NAMESPACE=${{matrix.with_namespace}} ^
+          -DLIBSBML_USE_STRICT_INCLUDES=${{matrix.strict}} ^
+          -DWITH_EXAMPLES=${{matrix.with_examples}}
 
       - name: Build
         working-directory: ${{runner.workspace}}/build

--- a/.github/workflows/brief.yml
+++ b/.github/workflows/brief.yml
@@ -35,7 +35,6 @@ jobs:
         with:
           path: |
             ./dependencies
-            ./swig
           key: ${{ runner.os }}-dependencies-static
 
       - name: Download pre-built Windows dependencies and SWIG
@@ -48,15 +47,20 @@ jobs:
           unzip dependencies.zip -d dependencies
           cp -r dependencies/libSBML\ Dependencies-1.0.0-b1-win64/* dependencies
           rm -r dependencies/libSBML*
-          curl -L https://prdownloads.sourceforge.net/swig/swigwin-3.0.12.zip > swig.zip
+
+      - name: Download SWIG on Windows
+        if: matrix.platform == 'windows-latest'
+        shell: bash
+        run: |
+          curl -L https://sourceforge.net/projects/swig/files/swigwin/swigwin-4.0.2/swigwin-4.0.2.zip/download > swig.zip
           unzip -o swig.zip -d swig
+          echo $GITHUB_WORKSPACE"/swig/swigwin-4.0.2/" >> $GITHUB_PATH
 
       - name: setup Windows environment
         # this is separate from the SWIG download itself, because it needs to be added to the path also when SWIG is cached
         if: matrix.platform == 'windows-latest'
         shell: bash
         run: |
-          echo $GITHUB_WORKSPACE"/swig/swigwin-3.0.12/" >> $GITHUB_PATH
           echo RUNTIME_LINKING_OPTION="-DWITH_STATIC_RUNTIME=ON" >> "${GITHUB_ENV}"
 
       - name: Install Ubuntu dependencies

--- a/.github/workflows/extensive.yml
+++ b/.github/workflows/extensive.yml
@@ -12,7 +12,11 @@ env:
 jobs:
   build:
     if: github.event.pull_request.draft == false # avoid triggering on draft
-    name: ${{ matrix.platform }}, Parser option ${{ matrix.xml_parser_option }}, with namespaces ${{ matrix.with_namespace}}, strict includes ${{ matrix.strict }}, with examples ${{ matrix.with_examples}}, package option ${{ matrix.package_option}}
+    name:
+      ${{ matrix.platform }}, Parser option ${{ matrix.xml_parser_option }},
+      with namespaces ${{ matrix.with_namespace}}, strict includes ${{
+      matrix.strict }}, with examples ${{ matrix.with_examples}}, package option
+      ${{ matrix.package_option}}
     strategy:
       fail-fast: false
       matrix:
@@ -94,7 +98,9 @@ jobs:
       - name: Download pre-built Windows dependencies and SWIG
         # Windows dependencies have to be in a subfolder called `dependencies`, directly under the git repository root.
         # also gets SWIG, completing the set of dependencies needed for windows
-        if: matrix.platform == 'windows-latest' && steps.cache-win-dependencies.outputs.cache-hit != 'true'
+        if:
+          matrix.platform == 'windows-latest' &&
+          steps.cache-win-dependencies.outputs.cache-hit != 'true'
         shell: bash
         run: |
           curl -L https://sourceforge.net/projects/sbml/files/libsbml/win-dependencies/libSBML_dependencies_vs15_release_x64_static.zip/download > dependencies.zip
@@ -147,7 +153,10 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{runner.workspace}}/.ccache
-          key: ${{ runner.os }}-test-${{ matrix.xml_parser_option }}-${{ matrix.with_namespace }}-${{ matrix.strict }}-${{ steps.ccache_cache_timestamp.outputs.timestamp }}
+          key:
+            ${{ runner.os }}-test-${{ matrix.xml_parser_option }}-${{
+            matrix.with_namespace }}-${{ matrix.strict }}-${{
+            steps.ccache_cache_timestamp.outputs.timestamp }}
           restore-keys: |
             ${{ runner.os }}-test-${{ matrix.xml_parser_option }}-${{ matrix.with_namespace }}-${{ matrix.strict }}-${{ steps.ccache_cache_timestamp.outputs.timestamp }}
             ${{ runner.os }}-test-${{ matrix.xml_parser_option }}-${{ matrix.with_namespace }}-${{ matrix.strict }}-
@@ -167,14 +176,40 @@ jobs:
         shell: bash
         working-directory: ${{runner.workspace}}/build
         run: |
-          cmake $GITHUB_WORKSPACE ${RUNTIME_LINKING_OPTION} ${PYTHON_LINKING_OPTION} -DCMAKE_C_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} -DCMAKE_CXX_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} ${{ matrix.package_option }}-DCMAKE_BUILD_TYPE=$BUILD_TYPE -DWITH_CHECK=True ${{matrix.language_bindings}} -DWITH_CPP_NAMESPACE=${{matrix.with_namespace}} -DLIBSBML_USE_STRICT_INCLUDES=${{matrix.strict}} -DWITH_EXAMPLES=${{matrix.with_examples}}
+          cmake $GITHUB_WORKSPACE \
+          -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
+          -DCMAKE_C_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} \
+          -DCMAKE_CXX_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} \
+          -DCMAKE_CXX_STANDARD=98 \
+          -DWITH_CHECK=True \
+          -DWITH_CPP_NAMESPACE=${{matrix.with_namespace}} \
+          -DLIBSBML_USE_STRICT_INCLUDES=${{matrix.strict}} \
+          -DWITH_EXAMPLES=${{matrix.with_examples}} \
+          ${{matrix.package_option}} \
+          ${{matrix.language_bindings}} \
+          ${RUNTIME_LINKING_OPTION} \
+          ${PYTHON_LINKING_OPTION}
 
       - name: Configure CMake for non-default XML_parser
         if: matrix.xml_parser_option != '-DWITH_LIBXML'
         shell: bash
         working-directory: ${{runner.workspace}}/build
         run: |
-          cmake $GITHUB_WORKSPACE ${RUNTIME_LINKING_OPTION} ${PYTHON_LINKING_OPTION} -DCMAKE_CXX_STANDARD=98 -DCMAKE_C_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} -DCMAKE_CXX_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} ${{ matrix.package_option}} -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DWITH_CHECK=True ${{matrix.language_bindings}} -DWITH_LIBXML=False ${{matrix.xml_parser_option}}=True -DWITH_CPP_NAMESPACE=${{matrix.with_namespace}} -DLIBSBML_USE_STRICT_INCLUDES=${{matrix.strict}} -DWITH_EXAMPLES=${{matrix.with_examples}}
+          cmake $GITHUB_WORKSPACE \
+          -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
+          -DCMAKE_C_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} \
+          -DCMAKE_CXX_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} \
+          -DCMAKE_CXX_STANDARD=98 \
+          -DWITH_CHECK=True \
+          -DWITH_CPP_NAMESPACE=${{matrix.with_namespace}} \
+          -DLIBSBML_USE_STRICT_INCLUDES=${{matrix.strict}} \
+          -DWITH_EXAMPLES=${{matrix.with_examples}} \
+          -DWITH_LIBXML=False \
+          ${{matrix.xml_parser_option}}=True\
+          ${{matrix.package_option}} \
+          ${{matrix.language_bindings}} \
+          ${RUNTIME_LINKING_OPTION} \
+          ${PYTHON_LINKING_OPTION}
 
       - name: Build
         working-directory: ${{runner.workspace}}/build

--- a/.github/workflows/store-artefact.yml
+++ b/.github/workflows/store-artefact.yml
@@ -109,7 +109,20 @@ jobs:
         working-directory: ${{runner.workspace}}/build
         run: |
           mkdir ../install
-          cmake ${RUNTIME_LINKING_OPTION} $GITHUB_WORKSPACE ${PYTHON_LINKING_OPTION} -DCMAKE_CXX_STANDARD=98 -DCMAKE_INSTALL_PREFIX=../install -DCMAKE_C_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} -DCMAKE_CXX_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} ${{ matrix.package_option }}-DCMAKE_BUILD_TYPE=$BUILD_TYPE -DWITH_CHECK=True ${{matrix.language_bindings}} -DWITH_CPP_NAMESPACE=${{matrix.with_namespace}} -DLIBSBML_USE_STRICT_INCLUDES=${{matrix.strict}} -DWITH_EXAMPLES=${{matrix.with_examples}}
+          cmake $GITHUB_WORKSPACE \
+          -DCMAKE_INSTALL_PREFIX=../install \
+          -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
+          -DCMAKE_C_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} \
+          -DCMAKE_CXX_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} \
+          -DCMAKE_CXX_STANDARD=98 \
+          -DWITH_CHECK=True \
+          -DWITH_CPP_NAMESPACE=${{matrix.with_namespace}} \
+          -DLIBSBML_USE_STRICT_INCLUDES=${{matrix.strict}} \
+          -DWITH_EXAMPLES=${{matrix.with_examples}} \
+          ${{matrix.package_option}} \
+          ${{matrix.language_bindings}} \
+          ${RUNTIME_LINKING_OPTION} \
+          ${PYTHON_LINKING_OPTION} \
 
       - name: Build
         working-directory: ${{runner.workspace}}/build

--- a/.github/workflows/store-artefact.yml
+++ b/.github/workflows/store-artefact.yml
@@ -9,7 +9,11 @@ env:
 
 jobs:
   build:
-    name: ${{ matrix.platform }}, Parser option ${{ matrix.xml_parser_option }}, with namespaces ${{ matrix.with_namespace}}, strict includes ${{ matrix.strict }}, with examples ${{ matrix.with_examples}}, package option ${{ matrix.package_option}}
+    name:
+      ${{ matrix.platform }}, Parser option ${{ matrix.xml_parser_option }},
+      with namespaces ${{ matrix.with_namespace}}, strict includes ${{
+      matrix.strict }}, with examples ${{ matrix.with_examples}}, package option
+      ${{ matrix.package_option}}
     strategy:
       fail-fast: false
       matrix:
@@ -42,7 +46,9 @@ jobs:
       - name: Download pre-built Windows dependencies and SWIG
         # Windows dependencies have to be in a subfolder called `dependencies`, directly under the git repository root.
         # also gets SWIG, completing the set of dependencies needed for windows
-        if: matrix.platform == 'windows-latest' && steps.cache-win-dependencies-static.outputs.cache-hit != 'true'
+        if:
+          matrix.platform == 'windows-latest' &&
+          steps.cache-win-dependencies-static.outputs.cache-hit != 'true'
         shell: bash
         run: |
           curl -L https://sourceforge.net/projects/sbml/files/libsbml/win-dependencies/libSBML_dependencies_vs15_release_x64_static.zip/download > dependencies.zip
@@ -95,7 +101,9 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ${{runner.workspace}}/.ccache
-          key: ${{ runner.os }}-${{ steps.ccache_cache_timestamp.outputs.timestamp }}
+          key:
+            ${{ runner.os }}-${{ steps.ccache_cache_timestamp.outputs.timestamp
+            }}
           restore-keys: |
             ${{ runner.os }}-${{ steps.ccache_cache_timestamp.outputs.timestamp }}
             ${{ runner.os }}-
@@ -135,7 +143,7 @@ jobs:
         working-directory: ${{runner.workspace}}/build
         shell: bash
         run: ctest -C $BUILD_TYPE
-      
+
       ### create binaries ###
       - name: Install
         working-directory: ${{runner.workspace}}/build
@@ -143,7 +151,7 @@ jobs:
         run: cmake --install . --config $BUILD_TYPE
 
       - name: Remove large .lib file on Windows
-      ### file temporarily needed for bindings ###
+        ### file temporarily needed for bindings ###
         if: matrix.platform == 'windows-latest'
         working-directory: ${{runner.workspace}}/install
         shell: bash
@@ -171,7 +179,9 @@ jobs:
         if: matrix.platform == 'windows-latest'
         uses: actions/upload-artifact@v2
         with:
-          name: Windows (zip, libSBML ${{env.LIBSBML_VERSION}}, ${{env.ARTIFACT_NAME_SUFFIX}})
+          name:
+            Windows (zip, libSBML ${{env.LIBSBML_VERSION}},
+            ${{env.ARTIFACT_NAME_SUFFIX}})
           path: ${{runner.workspace}}/install/*
           retention-days: 1
           if-no-files-found: error
@@ -180,7 +190,9 @@ jobs:
         if: matrix.platform == 'macos-latest'
         uses: actions/upload-artifact@v2
         with:
-          name: MacOS (zip, libSBML ${{env.LIBSBML_VERSION}}, ${{env.ARTIFACT_NAME_SUFFIX}})
+          name:
+            MacOS (zip, libSBML ${{env.LIBSBML_VERSION}},
+            ${{env.ARTIFACT_NAME_SUFFIX}})
           path: ${{runner.workspace}}/install/*
           retention-days: 1
           if-no-files-found: error
@@ -189,7 +201,9 @@ jobs:
         if: matrix.platform == 'ubuntu-16.04'
         uses: actions/upload-artifact@v2
         with:
-          name: Ubuntu nightly (zip, libSBML ${{env.LIBSBML_VERSION}}, ${{env.ARTIFACT_NAME_SUFFIX}})
+          name:
+            Ubuntu nightly (zip, libSBML ${{env.LIBSBML_VERSION}},
+            ${{env.ARTIFACT_NAME_SUFFIX}})
           path: ${{runner.workspace}}/install/*
           retention-days: 1
           if-no-files-found: error

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ LibSBML is an open-source library for working with SBML (the Systems Biology Mar
 [![Experimental release](https://img.shields.io/badge/Experimental_release-5.19.0-b44e88.svg?style=flat-square)](https://sourceforge.net/projects/sbml/files/libsbml/5.19.0/experimental/)
 [![Pivotal Tracker](https://img.shields.io/badge/Project_management-Pivotal-d07a3e.svg?style=flat-square)](https://www.pivotaltracker.com/n/projects/248655)
 [![Discussion](https://img.shields.io/badge/Discussion-libsbml--development-lightgray.svg?style=flat-square)]()
-[![GitHub Workflow Status](https://img.shields.io/github/workflow/status/sbmlteam/libsbml/Nightly%20build%20(binaries)?label=Nightly%20build&style=flat-square)]
+![GitHub Workflow Status](https://img.shields.io/github/workflow/status/sbmlteam/libsbml/Nightly%20build%20(binaries)?label=Nightly%20build&style=flat-square)
 
 
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ LibSBML is an open-source library for working with SBML (the Systems Biology Mar
 [![Experimental release](https://img.shields.io/badge/Experimental_release-5.19.0-b44e88.svg?style=flat-square)](https://sourceforge.net/projects/sbml/files/libsbml/5.19.0/experimental/)
 [![Pivotal Tracker](https://img.shields.io/badge/Project_management-Pivotal-d07a3e.svg?style=flat-square)](https://www.pivotaltracker.com/n/projects/248655)
 [![Discussion](https://img.shields.io/badge/Discussion-libsbml--development-lightgray.svg?style=flat-square)]()
-
+[![GitHub Workflow Status](https://img.shields.io/github/workflow/status/sbmlteam/libsbml/Nightly%20build%20(binaries)?label=Nightly%20build&style=flat-square)]
 
 
 

--- a/dev/utilities/sboTree/SBO.cpp.cmake
+++ b/dev/utilities/sboTree/SBO.cpp.cmake
@@ -187,7 +187,7 @@ SBO::intToString (int sboTerm)
   * functions for checking the SBO term is from correct part of SBO
   * Unary Functor returns the parent portion of a ParentMap pair.
   */
-struct GetSecond : public unary_function<const pair<const int, int>, int>
+struct GetSecond
 {
   int operator() (const pair<const int, int>& pair) { return pair.second; }
 };

--- a/src/sbml/packages/comp/validator/test/TestValidator.cpp
+++ b/src/sbml/packages/comp/validator/test/TestValidator.cpp
@@ -72,7 +72,7 @@ TestValidator::~TestValidator ()
  * Function Object: Return true if the given SBMLError has the given
  * id, false otherwise.
  */
-struct HasId : public unary_function<SBMLError, bool>
+struct HasId
 {
   unsigned int id;
 
@@ -84,7 +84,7 @@ struct HasId : public unary_function<SBMLError, bool>
 /**
  * Function Object: Takes a SBMLError and returns its integer id.
  */
-struct ToId : public unary_function<SBMLError, unsigned int>
+struct ToId
 {
   unsigned int operator() (const SBMLError& msg) { return msg.getErrorId(); }
 };

--- a/src/sbml/packages/distrib/validator/test/TestValidator.cpp
+++ b/src/sbml/packages/distrib/validator/test/TestValidator.cpp
@@ -72,7 +72,7 @@ TestValidator::~TestValidator ()
  * Function Object: Return true if the given SBMLError has the given
  * id, false otherwise.
  */
-struct HasId : public unary_function<SBMLError, bool>
+struct HasId
 {
   unsigned int id;
 
@@ -84,7 +84,7 @@ struct HasId : public unary_function<SBMLError, bool>
 /**
  * Function Object: Takes a SBMLError and returns its integer id.
  */
-struct ToId : public unary_function<SBMLError, unsigned int>
+struct ToId
 {
   unsigned int operator() (const SBMLError& msg) { return msg.getErrorId(); }
 };

--- a/src/sbml/packages/fbc/validator/test/TestValidator.cpp
+++ b/src/sbml/packages/fbc/validator/test/TestValidator.cpp
@@ -72,7 +72,7 @@ TestValidator::~TestValidator ()
  * Function Object: Return true if the given SBMLError has the given
  * id, false otherwise.
  */
-struct HasId : public unary_function<SBMLError, bool>
+struct HasId
 {
   unsigned int id;
 
@@ -84,7 +84,7 @@ struct HasId : public unary_function<SBMLError, bool>
 /**
  * Function Object: Takes a SBMLError and returns its integer id.
  */
-struct ToId : public unary_function<SBMLError, unsigned int>
+struct ToId
 {
   unsigned int operator() (const SBMLError& msg) { return msg.getErrorId(); }
 };

--- a/src/sbml/packages/groups/validator/test/TestValidator.cpp
+++ b/src/sbml/packages/groups/validator/test/TestValidator.cpp
@@ -72,7 +72,7 @@ TestValidator::~TestValidator ()
  * Function Object: Return true if the given SBMLError has the given
  * id, false otherwise.
  */
-struct HasId : public unary_function<SBMLError, bool>
+struct HasId
 {
   unsigned int id;
 
@@ -84,7 +84,7 @@ struct HasId : public unary_function<SBMLError, bool>
 /**
  * Function Object: Takes a SBMLError and returns its integer id.
  */
-struct ToId : public unary_function<SBMLError, unsigned int>
+struct ToId
 {
   unsigned int operator() (const SBMLError& msg) { return msg.getErrorId(); }
 };

--- a/src/sbml/packages/l3v2extendedmath/validator/test/TestValidator.cpp
+++ b/src/sbml/packages/l3v2extendedmath/validator/test/TestValidator.cpp
@@ -72,7 +72,7 @@ TestValidator::~TestValidator ()
  * Function Object: Return true if the given SBMLError has the given
  * id, false otherwise.
  */
-struct HasId : public unary_function<SBMLError, bool>
+struct HasId
 {
   unsigned int id;
 
@@ -84,7 +84,7 @@ struct HasId : public unary_function<SBMLError, bool>
 /**
  * Function Object: Takes a SBMLError and returns its integer id.
  */
-struct ToId : public unary_function<SBMLError, unsigned int>
+struct ToId
 {
   unsigned int operator() (const SBMLError& msg) { return msg.getErrorId(); }
 };

--- a/src/sbml/packages/layout/validator/test/TestValidator.cpp
+++ b/src/sbml/packages/layout/validator/test/TestValidator.cpp
@@ -79,7 +79,7 @@ TestValidator::~TestValidator ()
  * Function Object: Return true if the given SBMLError has the given
  * id, false otherwise.
  */
-struct HasId : public unary_function<SBMLError, bool>
+struct HasId
 {
   unsigned int id;
 
@@ -91,7 +91,7 @@ struct HasId : public unary_function<SBMLError, bool>
 /**
  * Function Object: Takes a SBMLError and returns its integer id.
  */
-struct ToId : public unary_function<SBMLError, unsigned int>
+struct ToId
 {
   unsigned int operator() (const SBMLError& msg) { return msg.getErrorId(); }
 };

--- a/src/sbml/packages/multi/validator/test/TestValidator.cpp
+++ b/src/sbml/packages/multi/validator/test/TestValidator.cpp
@@ -72,7 +72,7 @@ TestValidator::~TestValidator ()
  * Function Object: Return true if the given SBMLError has the given
  * id, false otherwise.
  */
-struct HasId : public unary_function<SBMLError, bool>
+struct HasId
 {
   unsigned int id;
 
@@ -84,7 +84,7 @@ struct HasId : public unary_function<SBMLError, bool>
 /**
  * Function Object: Takes a SBMLError and returns its integer id.
  */
-struct ToId : public unary_function<SBMLError, unsigned int>
+struct ToId
 {
   unsigned int operator() (const SBMLError& msg) { return msg.getErrorId(); }
 };

--- a/src/sbml/packages/qual/validator/test/TestValidator.cpp
+++ b/src/sbml/packages/qual/validator/test/TestValidator.cpp
@@ -79,7 +79,7 @@ TestValidator::~TestValidator ()
  * Function Object: Return true if the given SBMLError has the given
  * id, false otherwise.
  */
-struct HasId : public unary_function<SBMLError, bool>
+struct HasId
 {
   unsigned int id;
 
@@ -91,7 +91,7 @@ struct HasId : public unary_function<SBMLError, bool>
 /**
  * Function Object: Takes a SBMLError and returns its integer id.
  */
-struct ToId : public unary_function<SBMLError, unsigned int>
+struct ToId
 {
   unsigned int operator() (const SBMLError& msg) { return msg.getErrorId(); }
 };

--- a/src/sbml/packages/render/validator/test/TestValidator.cpp
+++ b/src/sbml/packages/render/validator/test/TestValidator.cpp
@@ -79,7 +79,7 @@ TestValidator::~TestValidator ()
  * Function Object: Return true if the given SBMLError has the given
  * id, false otherwise.
  */
-struct HasId : public unary_function<SBMLError, bool>
+struct HasId
 {
   unsigned int id;
 
@@ -91,7 +91,7 @@ struct HasId : public unary_function<SBMLError, bool>
 /**
  * Function Object: Takes a SBMLError and returns its integer id.
  */
-struct ToId : public unary_function<SBMLError, unsigned int>
+struct ToId
 {
   unsigned int operator() (const SBMLError& msg) { return msg.getErrorId(); }
 };

--- a/src/sbml/packages/spatial/validator/test/TestValidator.cpp
+++ b/src/sbml/packages/spatial/validator/test/TestValidator.cpp
@@ -72,7 +72,7 @@ TestValidator::~TestValidator ()
  * Function Object: Return true if the given SBMLError has the given
  * id, false otherwise.
  */
-struct HasId : public unary_function<SBMLError, bool>
+struct HasId
 {
   unsigned int id;
 
@@ -84,7 +84,7 @@ struct HasId : public unary_function<SBMLError, bool>
 /**
  * Function Object: Takes a SBMLError and returns its integer id.
  */
-struct ToId : public unary_function<SBMLError, unsigned int>
+struct ToId
 {
   unsigned int operator() (const SBMLError& msg) { return msg.getErrorId(); }
 };

--- a/src/sbml/test/TestSBase.cpp
+++ b/src/sbml/test/TestSBase.cpp
@@ -429,8 +429,8 @@ END_TEST
 START_TEST (test_SBase_setNotesString)
 {
   Model_t *c = new(std::nothrow) Model(1,2);
-  char * notes = "This is a test note";
-  char * taggednotes = "<notes>This is a test note</notes>";
+  const char * notes = "This is a test note";
+  const char * taggednotes = "<notes>This is a test note</notes>";
 
   SBase_setNotesString(c, notes);
 
@@ -505,8 +505,8 @@ END_TEST
 START_TEST (test_SBase_setNotesString_l3_addMarkup)
 {
   Model_t *c = new(std::nothrow) Model(3, 1);
-  char * notes = "This is a test note";
-  char * taggednotes = "<notes>\n  <p xmlns=\"http://www.w3.org/1999/xhtml\">This is a test note</p>\n</notes>";
+  const char * notes = "This is a test note";
+  const char * taggednotes = "<notes>\n  <p xmlns=\"http://www.w3.org/1999/xhtml\">This is a test note</p>\n</notes>";
 
   SBase_setNotesStringAddMarkup(c, notes);
 
@@ -554,8 +554,8 @@ END_TEST
 
 START_TEST (test_SBase_setAnnotationString)
 {
-  char * annotation = "This is a test note";
-  char * taggedannotation = "<annotation>This is a test note</annotation>";
+  const char * annotation = "This is a test note";
+  const char * taggedannotation = "<annotation>This is a test note</annotation>";
 
   SBase_setAnnotationString(S, annotation);
 
@@ -1447,23 +1447,23 @@ END_TEST
 START_TEST (test_SBase_appendNotesString)
 {
   // add p to p 
-  char * notes = "<p xmlns=\"http://www.w3.org/1999/xhtml\">This is a test note </p>";
-  char * taggednewnotes = "<notes>\n"
+  const char * notes = "<p xmlns=\"http://www.w3.org/1999/xhtml\">This is a test note </p>";
+  const char * taggednewnotes = "<notes>\n"
                        "  <p xmlns=\"http://www.w3.org/1999/xhtml\">This is a test note </p>\n"
                        "  <p xmlns=\"http://www.w3.org/1999/xhtml\">This is more test notes </p>\n"
                        "</notes>";
-  char * taggednewnotes2 = "<notes>\n"
+  const char * taggednewnotes2 = "<notes>\n"
                        "  <p xmlns=\"http://www.w3.org/1999/xhtml\">This is a test note </p>\n"
                        "  <p xmlns=\"http://www.w3.org/1999/xhtml\">This is more test notes 1</p>\n"
                        "  <p xmlns=\"http://www.w3.org/1999/xhtml\">This is more test notes 2</p>\n"
                        "</notes>";
-  char * newnotes = "<p xmlns=\"http://www.w3.org/1999/xhtml\">This is more test notes </p>";
-  char * newnotes2 = "<p xmlns=\"http://www.w3.org/1999/xhtml\">This is more test notes 1</p>"
+  const char * newnotes = "<p xmlns=\"http://www.w3.org/1999/xhtml\">This is more test notes </p>";
+  const char * newnotes2 = "<p xmlns=\"http://www.w3.org/1999/xhtml\">This is more test notes 1</p>"
                      "<p xmlns=\"http://www.w3.org/1999/xhtml\">This is more test notes 2</p>";
-  char * newnotes3= "<notes>\n"
+  const char * newnotes3= "<notes>\n"
                     "  <p xmlns=\"http://www.w3.org/1999/xhtml\">This is more test notes </p>\n"
                     "</notes>";
-  char * newnotes4 = "<notes>\n"
+  const char * newnotes4 = "<notes>\n"
                      "  <p xmlns=\"http://www.w3.org/1999/xhtml\">This is more test notes 1</p>\n"
                      "  <p xmlns=\"http://www.w3.org/1999/xhtml\">This is more test notes 2</p>\n"
                      "</notes>";
@@ -1525,7 +1525,7 @@ END_TEST
 
 START_TEST (test_SBase_appendNotesString1)
 { // add html to html
-  char * notes = "<html xmlns=\"http://www.w3.org/1999/xhtml\">\n"
+  const char * notes = "<html xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "  <head>\n"
                  "    <title/>\n"
                  "  </head>\n"
@@ -1533,7 +1533,7 @@ START_TEST (test_SBase_appendNotesString1)
                  "    <p>This is a test note </p>\n"
                  "  </body>\n"
                  "</html>";
-  char * taggednewnotes = 
+  const char * taggednewnotes = 
                  "<notes>\n"
                  "  <html xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "    <head>\n"
@@ -1545,7 +1545,7 @@ START_TEST (test_SBase_appendNotesString1)
                  "    </body>\n"
                  "  </html>\n"
                  "</notes>";
-  char * addnotes = "<html xmlns=\"http://www.w3.org/1999/xhtml\">\n"
+  const char * addnotes = "<html xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "  <head>\n"
                  "    <title/>\n"
                  "  </head>\n"
@@ -1553,7 +1553,7 @@ START_TEST (test_SBase_appendNotesString1)
                  "    <p>This is more test notes </p>\n"
                  "  </body>\n"
                  "</html>";
-  char * addnotes2 =
+  const char * addnotes2 =
                  "<notes>\n"
                  "  <html xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "    <head>\n"
@@ -1593,7 +1593,7 @@ END_TEST
 
 START_TEST (test_SBase_appendNotesString2)
 { // add body to html
-  char * notes = "<html xmlns=\"http://www.w3.org/1999/xhtml\">\n"
+  const char * notes = "<html xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "  <head>\n"
                  "    <title/>\n"
                  "  </head>\n"
@@ -1601,7 +1601,7 @@ START_TEST (test_SBase_appendNotesString2)
                  "    <p>This is a test note </p>\n"
                  "  </body>\n"
                  "</html>";
-  char * taggednewnotes = 
+  const char * taggednewnotes = 
                  "<notes>\n"
                  "  <html xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "    <head>\n"
@@ -1651,7 +1651,7 @@ END_TEST
 
 START_TEST (test_SBase_appendNotesString3)
 { // add p to html
-  char * notes = "<html xmlns=\"http://www.w3.org/1999/xhtml\">\n"
+  const char * notes = "<html xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "  <head>\n"
                  "    <title/>\n"
                  "  </head>\n"
@@ -1659,7 +1659,7 @@ START_TEST (test_SBase_appendNotesString3)
                  "    <p>This is a test note </p>\n"
                  "  </body>\n"
                  "</html>";
-  char * taggednewnotes = 
+  const char * taggednewnotes = 
                  "<notes>\n"
                  "  <html xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "    <head>\n"
@@ -1671,7 +1671,7 @@ START_TEST (test_SBase_appendNotesString3)
                  "    </body>\n"
                  "  </html>\n"
                  "</notes>";
-  char * taggednewnotes2 =
+  const char * taggednewnotes2 =
                  "<notes>\n"
                  "  <html xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "    <head>\n"
@@ -1684,13 +1684,13 @@ START_TEST (test_SBase_appendNotesString3)
                  "    </body>\n"
                  "  </html>\n"
                  "</notes>";
-  char * addnotes = "<p xmlns=\"http://www.w3.org/1999/xhtml\">This is more test notes </p>\n";
-  char * addnotes2 = "<p xmlns=\"http://www.w3.org/1999/xhtml\">This is more test notes 1</p>\n"
+  const char * addnotes = "<p xmlns=\"http://www.w3.org/1999/xhtml\">This is more test notes </p>\n";
+  const char * addnotes2 = "<p xmlns=\"http://www.w3.org/1999/xhtml\">This is more test notes 1</p>\n"
                      "<p xmlns=\"http://www.w3.org/1999/xhtml\">This is more test notes 2</p>";
-  char * addnotes3 = "<notes>\n"
+  const char * addnotes3 = "<notes>\n"
                      "  <p xmlns=\"http://www.w3.org/1999/xhtml\">This is more test notes </p>\n"
                      "</notes>";
-  char * addnotes4 = "<notes>\n"
+  const char * addnotes4 = "<notes>\n"
                      "  <p xmlns=\"http://www.w3.org/1999/xhtml\">This is more test notes 1</p>\n"
                      "  <p xmlns=\"http://www.w3.org/1999/xhtml\">This is more test notes 2</p>\n"
                      "</notes>";
@@ -1745,10 +1745,10 @@ END_TEST
 
 START_TEST (test_SBase_appendNotesString4)
 { // add html to body
-  char * notes = "<body xmlns=\"http://www.w3.org/1999/xhtml\">\n"
+  const char * notes = "<body xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "  <p>This is a test note </p>\n"
                  "</body>";
-  char * taggednewnotes = 
+  const char * taggednewnotes = 
                  "<notes>\n"
                  "  <html xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "    <head>\n"
@@ -1760,7 +1760,7 @@ START_TEST (test_SBase_appendNotesString4)
                  "    </body>\n"
                  "  </html>\n"
                  "</notes>";
-  char * addnotes = "<html xmlns=\"http://www.w3.org/1999/xhtml\">\n"
+  const char * addnotes = "<html xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "  <head>\n"
                  "    <title/>\n"
                  "  </head>\n"
@@ -1768,7 +1768,7 @@ START_TEST (test_SBase_appendNotesString4)
                  "    <p>This is more test notes </p>\n"
                  "  </body>\n"
                  "</html>";
-  char * addnotes2 =
+  const char * addnotes2 =
                  "<notes>\n"
                  "  <html xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "    <head>\n"
@@ -1808,8 +1808,8 @@ END_TEST
 
 START_TEST (test_SBase_appendNotesString5)
 { // add html to p
-  char * notes = "<p xmlns=\"http://www.w3.org/1999/xhtml\">This is a test note </p>";
-  char * taggednewnotes = 
+  const char * notes = "<p xmlns=\"http://www.w3.org/1999/xhtml\">This is a test note </p>";
+  const char * taggednewnotes = 
                  "<notes>\n"
                  "  <html xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "    <head>\n"
@@ -1821,7 +1821,7 @@ START_TEST (test_SBase_appendNotesString5)
                  "    </body>\n"
                  "  </html>\n"
                  "</notes>";
-  char * addnotes = "<html xmlns=\"http://www.w3.org/1999/xhtml\">\n"
+  const char * addnotes = "<html xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "  <head>\n"
                  "    <title/>\n"
                  "  </head>\n"
@@ -1829,7 +1829,7 @@ START_TEST (test_SBase_appendNotesString5)
                  "    <p>This is more test notes </p>\n"
                  "  </body>\n"
                  "</html>";
-  char * addnotes2 = 
+  const char * addnotes2 = 
                  "<notes>\n"
                  "  <html xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "    <head>\n"
@@ -1869,20 +1869,20 @@ END_TEST
 
 START_TEST (test_SBase_appendNotesString6)
 { // add body to body
-  char * notes = "<body xmlns=\"http://www.w3.org/1999/xhtml\">\n"
+  const char * notes = "<body xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "  <p>This is a test note </p>\n"
                  "</body>";
-  char * taggednewnotes = 
+  const char * taggednewnotes = 
                  "<notes>\n"
                  "  <body xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "    <p>This is a test note </p>\n"
                  "    <p>This is more test notes </p>\n"
                  "  </body>\n"
                  "</notes>";
-  char * addnotes = "<body xmlns=\"http://www.w3.org/1999/xhtml\">\n"
+  const char * addnotes = "<body xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "  <p>This is more test notes </p>\n"
                  "</body>";
-  char * addnotes2 = 
+  const char * addnotes2 = 
                  "<notes>\n"
                  "  <body xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "    <p>This is more test notes </p>\n"
@@ -1917,18 +1917,18 @@ END_TEST
 
 START_TEST (test_SBase_appendNotesString7)
 { // add body to p
-  char * notes = "<p xmlns=\"http://www.w3.org/1999/xhtml\">This is a test note </p>";
-  char * taggednewnotes = 
+  const char * notes = "<p xmlns=\"http://www.w3.org/1999/xhtml\">This is a test note </p>";
+  const char * taggednewnotes = 
                  "<notes>\n"
                  "  <body xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "    <p xmlns=\"http://www.w3.org/1999/xhtml\">This is a test note </p>\n"
                  "    <p>This is more test notes </p>\n"
                  "  </body>\n"
                  "</notes>";
-  char * addnotes = "<body xmlns=\"http://www.w3.org/1999/xhtml\">\n"
+  const char * addnotes = "<body xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "  <p>This is more test notes </p>\n"
                  "</body>";
-  char * addnotes2 = 
+  const char * addnotes2 = 
                  "<notes>\n"
                  "  <body xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "    <p>This is more test notes </p>\n"
@@ -1963,17 +1963,17 @@ END_TEST
 
 START_TEST (test_SBase_appendNotesString8)
 { // add p to body
-  char * notes = "<body xmlns=\"http://www.w3.org/1999/xhtml\">\n"
+  const char * notes = "<body xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "  <p>This is a test note </p>\n"
                  "</body>";
-  char * taggednewnotes = 
+  const char * taggednewnotes = 
                  "<notes>\n"
                  "  <body xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "    <p>This is a test note </p>\n"
                  "    <p xmlns=\"http://www.w3.org/1999/xhtml\">This is more test notes </p>\n"
                  "  </body>\n"
                  "</notes>";
-  char * taggednewnotes2 = 
+  const char * taggednewnotes2 = 
                  "<notes>\n"
                  "  <body xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "    <p>This is a test note </p>\n"
@@ -1981,14 +1981,14 @@ START_TEST (test_SBase_appendNotesString8)
                  "    <p xmlns=\"http://www.w3.org/1999/xhtml\">This is more test notes 2</p>\n"
                  "  </body>\n"
                  "</notes>";
-  char * addnotes = "<p xmlns=\"http://www.w3.org/1999/xhtml\">This is more test notes </p>";
-  char * addnotes2 = "<p xmlns=\"http://www.w3.org/1999/xhtml\">This is more test notes 1</p>\n"
+  const char * addnotes = "<p xmlns=\"http://www.w3.org/1999/xhtml\">This is more test notes </p>";
+  const char * addnotes2 = "<p xmlns=\"http://www.w3.org/1999/xhtml\">This is more test notes 1</p>\n"
                      "<p xmlns=\"http://www.w3.org/1999/xhtml\">This is more test notes 2</p>";
-  char * addnotes3 = 
+  const char * addnotes3 = 
                  "<notes>\n"
                  "  <p xmlns=\"http://www.w3.org/1999/xhtml\">This is more test notes </p>\n"
                  "</notes>";
-  char * addnotes4 = 
+  const char * addnotes4 = 
                  "<notes>\n"
                  "  <p xmlns=\"http://www.w3.org/1999/xhtml\">This is more test notes 1</p>\n"
                  "  <p xmlns=\"http://www.w3.org/1999/xhtml\">This is more test notes 2</p>\n"
@@ -2221,7 +2221,7 @@ void setOrAppendNotes(SBase* base, std::string note)
 START_TEST(test_SBase_appendNotesWithGlobalNamespace)
 {
 
-  char * notes = 
+  const char * notes = 
 		"<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
 		"<sbml xmlns=\"http://www.sbml.org/sbml/level2/version4\" xmlns:html=\"http://www.w3.org/1999/xhtml\" level=\"2\" version=\"4\">\n"
 		"  <model id=\"test\" name=\"name\">\n"

--- a/src/sbml/test/TestSBase.cpp
+++ b/src/sbml/test/TestSBase.cpp
@@ -1613,10 +1613,10 @@ START_TEST (test_SBase_appendNotesString2)
                  "    </body>\n"
                  "  </html>\n"
                  "</notes>";
-  char * addnotes = "<body xmlns=\"http://www.w3.org/1999/xhtml\">\n"
+  const char * addnotes = "<body xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                     "  <p>This is more test notes </p>\n"
                     "</body>\n";
-  char * addnotes2 =
+  const char * addnotes2 =
                     "<notes>\n"
                     "  <body xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                     "    <p>This is more test notes </p>\n"

--- a/src/sbml/test/TestSBase_newSetters.cpp
+++ b/src/sbml/test/TestSBase_newSetters.cpp
@@ -368,9 +368,9 @@ END_TEST
 
 START_TEST (test_SBase_setNotesString)
 {
-  char * notes = "<p xmlns=\"http://www.w3.org/1999/xhtml\">This is a test note </p>";
-  char * taggednotes = "<notes><p xmlns=\"http://www.w3.org/1999/xhtml\">This is a test note </p></notes>";
-  char * badnotes = "<notes>This is a test note</notes>";
+  const char * notes = "<p xmlns=\"http://www.w3.org/1999/xhtml\">This is a test note </p>";
+  const char * taggednotes = "<notes><p xmlns=\"http://www.w3.org/1999/xhtml\">This is a test note </p></notes>";
+  const char * badnotes = "<notes>This is a test note</notes>";
 
   int i = SBase_setNotesString(S, notes);
 
@@ -403,8 +403,8 @@ END_TEST
 
 START_TEST (test_SBase_setAnnotationString)
 {
-  char * annotation = "This is a test note";
-  char * taggedannotation = "<annotation>This is a test note</annotation>";
+  const char * annotation = "This is a test note";
+  const char * taggedannotation = "<annotation>This is a test note</annotation>";
 
   int i = SBase_setAnnotationString(S, annotation);
 
@@ -594,7 +594,7 @@ START_TEST (test_SBase_appendAnnotation2)
   fail_unless(XMLNode_getNumChildren(c1) == 0);
   fail_unless(!strcmp(XMLNode_getCharacters(c1), "This is additional"));
 
-  char * newann =
+  const char * newann =
     "<annotation>"
     "<prA:other xmlns:prA=\"http://some\">This is additional repeat</prA:other>"
     "<rdf:RDF xmlns:rdf=\"http://rdf\">This is a new annotation</rdf:RDF>"
@@ -1520,16 +1520,16 @@ END_TEST
 
 START_TEST (test_SBase_appendNotesString)
 {
-  char * notes = "<p xmlns=\"http://www.w3.org/1999/xhtml\">This is a test note </p>";
-  char * taggednotes = "<notes>\n"
+  const char * notes = "<p xmlns=\"http://www.w3.org/1999/xhtml\">This is a test note </p>";
+  const char * taggednotes = "<notes>\n"
                        "  <p xmlns=\"http://www.w3.org/1999/xhtml\">This is a test note </p>\n"
                        "</notes>";
-  char * taggednewnotes = "<notes>\n"
+  const char * taggednewnotes = "<notes>\n"
                        "  <p xmlns=\"http://www.w3.org/1999/xhtml\">This is a test note </p>\n"
                        "  <p xmlns=\"http://www.w3.org/1999/xhtml\">This is more test notes </p>\n"
                        "</notes>";
-  char * badnotes = "<notes>This is a test note</notes>";
-  char * newnotes = "<p xmlns=\"http://www.w3.org/1999/xhtml\">This is more test notes </p>";
+  const char * badnotes = "<notes>This is a test note</notes>";
+  const char * newnotes = "<p xmlns=\"http://www.w3.org/1999/xhtml\">This is more test notes </p>";
 
   int i = SBase_setNotesString(S, notes);
 
@@ -1559,7 +1559,7 @@ END_TEST
 
 START_TEST (test_SBase_appendNotesString1)
 { // add html to html
-  char * notes = "<html xmlns=\"http://www.w3.org/1999/xhtml\">\n"
+  const char * notes = "<html xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "  <head>\n"
                  "    <title/>\n"
                  "  </head>\n"
@@ -1567,7 +1567,7 @@ START_TEST (test_SBase_appendNotesString1)
                  "    <p>This is a test note </p>\n"
                  "  </body>\n"
                  "</html>";
-  char * taggednewnotes = 
+  const char * taggednewnotes = 
                  "<notes>\n"
                  "  <html xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "    <head>\n"
@@ -1579,7 +1579,7 @@ START_TEST (test_SBase_appendNotesString1)
                  "    </body>\n"
                  "  </html>\n"
                  "</notes>";
-  char * addnotes = "<html xmlns=\"http://www.w3.org/1999/xhtml\">\n"
+  const char * addnotes = "<html xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "  <head>\n"
                  "    <title/>\n"
                  "  </head>\n"
@@ -1604,7 +1604,7 @@ END_TEST
 
 START_TEST (test_SBase_appendNotesString2)
 { // add body to html
-  char * notes = "<html xmlns=\"http://www.w3.org/1999/xhtml\">\n"
+  const char * notes = "<html xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "  <head>\n"
                  "    <title/>\n"
                  "  </head>\n"
@@ -1612,7 +1612,7 @@ START_TEST (test_SBase_appendNotesString2)
                  "    <p>This is a test note </p>\n"
                  "  </body>\n"
                  "</html>";
-  char * taggednewnotes = 
+  const char * taggednewnotes = 
                  "<notes>\n"
                  "  <html xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "    <head>\n"
@@ -1624,7 +1624,7 @@ START_TEST (test_SBase_appendNotesString2)
                  "    </body>\n"
                  "  </html>\n"
                  "</notes>";
-  char * addnotes = "<body xmlns=\"http://www.w3.org/1999/xhtml\">\n"
+  const char * addnotes = "<body xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                     "  <p>This is more test notes </p>\n"
                     "</body>\n";
 
@@ -1644,7 +1644,7 @@ END_TEST
 
 START_TEST (test_SBase_appendNotesString3)
 { // add p to html
-  char * notes = "<html xmlns=\"http://www.w3.org/1999/xhtml\">\n"
+const char * notes = "<html xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "  <head>\n"
                  "    <title/>\n"
                  "  </head>\n"
@@ -1652,7 +1652,7 @@ START_TEST (test_SBase_appendNotesString3)
                  "    <p>This is a test note </p>\n"
                  "  </body>\n"
                  "</html>";
-  char * taggednewnotes = 
+const char * taggednewnotes = 
                  "<notes>\n"
                  "  <html xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "    <head>\n"
@@ -1664,7 +1664,7 @@ START_TEST (test_SBase_appendNotesString3)
                  "    </body>\n"
                  "  </html>\n"
                  "</notes>";
-  char * addnotes = "<p xmlns=\"http://www.w3.org/1999/xhtml\">This is more test notes </p>";
+  const char * addnotes = "<p xmlns=\"http://www.w3.org/1999/xhtml\">This is more test notes </p>";
 
   int i = SBase_setNotesString(S, notes);
   i = SBase_appendNotesString(S, addnotes);
@@ -1682,10 +1682,10 @@ END_TEST
 
 START_TEST (test_SBase_appendNotesString4)
 { // add html to body
-  char * notes = "<body xmlns=\"http://www.w3.org/1999/xhtml\">\n"
+  const char * notes = "<body xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "  <p>This is a test note </p>\n"
                  "</body>";
-  char * taggednewnotes = 
+  const char * taggednewnotes = 
                  "<notes>\n"
                  "  <html xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "    <head>\n"
@@ -1697,7 +1697,7 @@ START_TEST (test_SBase_appendNotesString4)
                  "    </body>\n"
                  "  </html>\n"
                  "</notes>";
-  char * addnotes = "<html xmlns=\"http://www.w3.org/1999/xhtml\">\n"
+  const char * addnotes = "<html xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "  <head>\n"
                  "    <title/>\n"
                  "  </head>\n"
@@ -1722,8 +1722,8 @@ END_TEST
 
 START_TEST (test_SBase_appendNotesString5)
 { // add html to p
-  char * notes = "<p xmlns=\"http://www.w3.org/1999/xhtml\">This is a test note </p>";
-  char * taggednewnotes = 
+  const char * notes = "<p xmlns=\"http://www.w3.org/1999/xhtml\">This is a test note </p>";
+  const char * taggednewnotes = 
                  "<notes>\n"
                  "  <html xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "    <head>\n"
@@ -1735,7 +1735,7 @@ START_TEST (test_SBase_appendNotesString5)
                  "    </body>\n"
                  "  </html>\n"
                  "</notes>";
-  char * addnotes = "<html xmlns=\"http://www.w3.org/1999/xhtml\">\n"
+  const char * addnotes = "<html xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "  <head>\n"
                  "    <title/>\n"
                  "  </head>\n"
@@ -1760,17 +1760,17 @@ END_TEST
 
 START_TEST (test_SBase_appendNotesString6)
 { // add body to body
-  char * notes = "<body xmlns=\"http://www.w3.org/1999/xhtml\">\n"
+  const char * notes = "<body xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "  <p>This is a test note </p>\n"
                  "</body>";
-  char * taggednewnotes = 
+  const char * taggednewnotes = 
                  "<notes>\n"
                  "  <body xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "    <p>This is a test note </p>\n"
                  "    <p>This is more test notes </p>\n"
                  "  </body>\n"
                  "</notes>";
-  char * addnotes = "<body xmlns=\"http://www.w3.org/1999/xhtml\">\n"
+  const char * addnotes = "<body xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "  <p>This is more test notes </p>\n"
                  "</body>";
 
@@ -1790,15 +1790,15 @@ END_TEST
 
 START_TEST (test_SBase_appendNotesString7)
 { // add body to p
-  char * notes = "<p xmlns=\"http://www.w3.org/1999/xhtml\">This is a test note </p>";
-  char * taggednewnotes = 
+  const char * notes = "<p xmlns=\"http://www.w3.org/1999/xhtml\">This is a test note </p>";
+  const char * taggednewnotes = 
                  "<notes>\n"
                  "  <body xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "    <p xmlns=\"http://www.w3.org/1999/xhtml\">This is a test note </p>\n"
                  "    <p>This is more test notes </p>\n"
                  "  </body>\n"
                  "</notes>";
-  char * addnotes = "<body xmlns=\"http://www.w3.org/1999/xhtml\">\n"
+  const char * addnotes = "<body xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "  <p>This is more test notes </p>\n"
                  "</body>";
 
@@ -1818,17 +1818,17 @@ END_TEST
 
 START_TEST (test_SBase_appendNotesString8)
 { // add p to body
-  char * notes = "<body xmlns=\"http://www.w3.org/1999/xhtml\">\n"
+  const char * notes = "<body xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "  <p>This is a test note </p>\n"
                  "</body>";
-  char * taggednewnotes = 
+  const char * taggednewnotes = 
                  "<notes>\n"
                  "  <body xmlns=\"http://www.w3.org/1999/xhtml\">\n"
                  "    <p>This is a test note </p>\n"
                  "    <p xmlns=\"http://www.w3.org/1999/xhtml\">This is more test notes </p>\n"
                  "  </body>\n"
                  "</notes>";
-  char * addnotes = "<p xmlns=\"http://www.w3.org/1999/xhtml\">This is more test notes </p>";
+  const char * addnotes = "<p xmlns=\"http://www.w3.org/1999/xhtml\">This is more test notes </p>";
 
   int i = SBase_setNotesString(S, notes);
   i = SBase_appendNotesString(S, addnotes);

--- a/src/sbml/validator/test/TestValidator.cpp
+++ b/src/sbml/validator/test/TestValidator.cpp
@@ -79,7 +79,7 @@ TestValidator::~TestValidator ()
  * Function Object: Return true if the given SBMLError has the given
  * id, false otherwise.
  */
-struct HasId : public unary_function<SBMLError, bool>
+struct HasId
 {
   unsigned int id;
 
@@ -91,7 +91,7 @@ struct HasId : public unary_function<SBMLError, bool>
 /**
  * Function Object: Takes a SBMLError and returns its integer id.
  */
-struct ToId : public unary_function<SBMLError, unsigned int>
+struct ToId
 {
   unsigned int operator() (const SBMLError& msg) { return msg.getErrorId(); }
 };


### PR DESCRIPTION
## Description
This PR only reformats the cmake configuration step, to have one option per line. The step is otherwise very hard to read, in particular when comparing differences between versions!

Please merge after #135 . Changes from #135 are already part of the history of this branch.

This PR also adds a status badge for the nightly build to the Readme.

## Motivation and Context
This makes the configuration step of each GH actions workflow a lot easier to read.
<!--- If it fixes an open issue, please link to the issue here, using the 'fixes #<issue>' syntax. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Change in documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have updated all documentation necessary. CI docs in separate document for now.
- [x] I have checked spelling in (new) comments.

## Testing
- [ ] Testing is done automatically and codecov shows test coverage
- [x] This cannot be tested automatically, as it is the CI/CD itself... the changes should only be aesthetic in this PR though.

