### PR TITLE
In a sort comparator, if things are equal, you must return 'false'.

### DIFF
--- a/src/sbml/ListOf.cpp
+++ b/src/sbml/ListOf.cpp
@@ -641,7 +641,7 @@ struct ListOfComparator
     {
         if (obj1 == NULL || obj2 == NULL) 
         {
-            return true;
+            return false;
         }
 
         if (obj1->getIdAttribute() == obj2->getIdAttribute()) 


### PR DESCRIPTION
This won't affect anything as far as I can tell, but the default return value for comparators is 'false', not 'true'.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here, using the 'fixes #<issue>' syntax. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Change in documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X ] I have updated all documentation necessary.
- [X ] I have checked spelling in (new) comments.

## Testing
- [X] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested -->

