### PR TITLE
don't run nightly binary builds on forks

### DIFF
--- a/.github/workflows/store-artefact.yml
+++ b/.github/workflows/store-artefact.yml
@@ -9,6 +9,7 @@ env:
 
 jobs:
   build:
+    if: github.repository_owner == 'sbmlteam'
     name:
       ${{ matrix.platform }}, Parser option ${{ matrix.xml_parser_option }},
       with namespaces ${{ matrix.with_namespace}}, strict includes ${{


### PR DESCRIPTION
The new CI is great! One very minor issue: currently the nightly builds run for every fork of libsbml on github, probably they should only run for this repo?

