### PR TITLE
Fix ci status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ LibSBML is an open-source library for working with SBML (the Systems Biology Mar
 [![Experimental release](https://img.shields.io/badge/Experimental_release-5.19.0-b44e88.svg?style=flat-square)](https://sourceforge.net/projects/sbml/files/libsbml/5.19.0/experimental/)
 [![Pivotal Tracker](https://img.shields.io/badge/Project_management-Pivotal-d07a3e.svg?style=flat-square)](https://www.pivotaltracker.com/n/projects/248655)
 [![Discussion](https://img.shields.io/badge/Discussion-libsbml--development-lightgray.svg?style=flat-square)]()
+[![Nightly build (binaries)](https://github.com/sbmlteam/libsbml/actions/workflows/store-artefact.yml/badge.svg)](https://github.com/sbmlteam/libsbml/actions/workflows/store-artefact.yml)
 
 
 Table of contents

--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@ LibSBML is an open-source library for working with SBML (the Systems Biology Mar
 [![Experimental release](https://img.shields.io/badge/Experimental_release-5.19.0-b44e88.svg?style=flat-square)](https://sourceforge.net/projects/sbml/files/libsbml/5.19.0/experimental/)
 [![Pivotal Tracker](https://img.shields.io/badge/Project_management-Pivotal-d07a3e.svg?style=flat-square)](https://www.pivotaltracker.com/n/projects/248655)
 [![Discussion](https://img.shields.io/badge/Discussion-libsbml--development-lightgray.svg?style=flat-square)]()
-![GitHub Workflow Status](https://img.shields.io/github/workflow/status/sbmlteam/libsbml/Nightly%20build%20(binaries)?label=Nightly%20build&style=flat-square)
-
 
 
 Table of contents


### PR DESCRIPTION
## Description
Replaces the CI status badge that was pointing nowhere with the official GHA badge that points to the artefact-creating workflow.

## Motivation and Context
Status badge for the CI was pointing nowhere.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Change in documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have updated all documentation necessary.
- [ ] I have checked spelling in (new) comments.

## Testing
- [ ] Testing is done automatically and codecov shows test coverage
- [x] This cannot be tested automatically. I checked that the markdown preview works as expected.

