### PR TITLE
Add R builds to CI system

### DIFF
--- a/.github/workflows/brief.yml
+++ b/.github/workflows/brief.yml
@@ -22,7 +22,10 @@ jobs:
         with_examples: ["True"]
         package_option: ["-DWITH_ALL_PACKAGES=ON"]
         language_bindings:
-          ["-DWITH_JAVA=True -DWITH_CSHARP=True -DWITH_PYTHON=True"]
+          [
+            "-DWITH_JAVA=True -DWITH_CSHARP=True -DWITH_PYTHON=True
+            -DWITH_R=True",
+          ]
         cpp_standard: [98, 20]
     runs-on: ${{ matrix.platform }}
 
@@ -73,6 +76,9 @@ jobs:
         shell: bash
         run: |
           echo RUNTIME_LINKING_OPTION="-DWITH_STATIC_RUNTIME=ON" >> "${GITHUB_ENV}"
+          ./dev/utilities/expdef/expdef64.exe -dRlib.def -l R.dll
+          echo R_PLATFORM_SPECIFIC_OPTIONS="-DR_LIB=${GITHUB_WORKSPACE}\Rlib.lib" >> "${GITHUB_ENV}"
+          echo R_INCLUDE_PATH="/c/Program Files/R/R-4.1.0/include" >> "${GITHUB_ENV}"
 
       - name: Install Ubuntu dependencies
         # ubuntu already has SWIG and libxml2 by default
@@ -87,8 +93,15 @@ jobs:
         if: matrix.platform == 'macos-latest'
         shell: bash
         run: |
-          brew install check swig ccache
+          brew install check swig ccache gcc
           echo PYTHON_LINKING_OPTION="-DPYTHON_USE_DYNAMIC_LOOKUP=ON" >> "${GITHUB_ENV}"
+
+      - name: Unix R options
+        if: matrix.platform != 'windows-latest'
+        shell: bash
+        run:
+          echo R_PLATFORM_SPECIFIC_OPTIONS="-DWITH_CREATE_R_SOURCE=ON
+          -DWITH_SKIP_R_BINARY=ON" >> "${GITHUB_ENV}"
 
       ### setup ccache, not on Windows ###
       - name: Prepare ccache timestamp
@@ -136,6 +149,8 @@ jobs:
           -DWITH_EXAMPLES=${{matrix.with_examples}} \
           ${{matrix.package_option}} \
           ${{matrix.language_bindings}} \
+          ${R_PLATFORM_SPECIFIC_OPTIONS} \
+          -DR_INCLUDE_DIRS="$R_INCLUDE_PATH" \
           ${RUNTIME_LINKING_OPTION} \
           ${PYTHON_LINKING_OPTION}
 
@@ -143,6 +158,14 @@ jobs:
         working-directory: ${{runner.workspace}}/build
         shell: bash
         run: cmake --build . --config $BUILD_TYPE
+
+      - name: Build Unix R binaries from source package
+        if: matrix.platform != 'windows-latest'
+        shell: bash
+        working-directory: ${{runner.workspace}}/build
+        run: |
+          mkdir r-binaries
+          R CMD INSTALL -l r-binaries --build ./src/bindings/r/out/libSBML_5.19.1.tar.gz
 
       ### run tests ###
       - name: Test
@@ -166,7 +189,7 @@ jobs:
         package_option: ["-DWITH_STABLE_PACKAGES=ON"]
         cpp_standard: [98, 20]
         language_bindings:
-          ["-DWITH_JAVA=True -DWITH_PYTHON=True -DWITH_CSHARP=True"]
+          ["-DWITH_JAVA=True -DWITH_PYTHON=True -DWITH_CSHARP=True -DWITH_R=True"]
         container: ["quay.io/pypa/manylinux2010_x86_64"]
     runs-on: ${{ matrix.platform }}
     container: ${{ matrix.container}}
@@ -185,7 +208,6 @@ jobs:
           make -j 2
           make install
           swig -version
-
       - name: install CMake using pip
         run: |
           /opt/python/cp38-cp38/bin/pip install cmake
@@ -193,16 +215,13 @@ jobs:
           ln -s /opt/python/cp38-cp38/bin/ctest /usr/bin/ctest
           cmake --version
           ctest --version
-
       - name: Install dependencies, configure, build
         run: |
-          yum install -y libxml2-devel check-devel java-devel mono-devel
+          yum install -y libxml2-devel check-devel java-devel mono-devel R
           cd ..
           mkdir build
           cd build
-          mkdir ../install
           cmake ../libsbml \
-          -DCMAKE_INSTALL_PREFIX=../install \
           -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
           -DCMAKE_CXX_STANDARD=${{matrix.cpp_standard}} \
           -DWITH_CHECK=True \
@@ -211,12 +230,13 @@ jobs:
           -DWITH_EXAMPLES=${{matrix.with_examples}} \
           ${{matrix.package_option}} \
           ${{matrix.language_bindings}} \
+          -DWITH_CREATE_R_SOURCE=ON \
+          -DWITH_SKIP_R_BINARY=ON \
           -DPYTHON_EXECUTABLE=/opt/python/cp38-cp38/bin/python \
           -DPYTHON_INCLUDE_DIR=/opt/python/cp38-cp38/include/python3.8/ \
           -DWITH_STATIC_RUNTIME=ON \
           -DPYTHON_USE_DYNAMIC_LOOKUP=ON
           cmake --build . --config $BUILD_TYPE
-
       - name: Test
         run: |
           cd ../build

--- a/.github/workflows/brief.yml
+++ b/.github/workflows/brief.yml
@@ -93,7 +93,7 @@ jobs:
         if: matrix.platform == 'macos-latest'
         shell: bash
         run: |
-          brew install check swig ccache gcc
+          brew install check swig ccache
           echo PYTHON_LINKING_OPTION="-DPYTHON_USE_DYNAMIC_LOOKUP=ON" >> "${GITHUB_ENV}"
 
       - name: Unix R options
@@ -237,6 +237,8 @@ jobs:
           -DWITH_STATIC_RUNTIME=ON \
           -DPYTHON_USE_DYNAMIC_LOOKUP=ON
           cmake --build . --config $BUILD_TYPE
+          mkdir r-binaries
+          R CMD INSTALL -l r-binaries --build ./src/bindings/r/out/libSBML_5.19.1.tar.gz
       - name: Test
         run: |
           cd ../build

--- a/.github/workflows/brief.yml
+++ b/.github/workflows/brief.yml
@@ -81,7 +81,7 @@ jobs:
         run: |
           sudo apt-get install -y check ccache
           echo PYTHON_LINKING_OPTION="-DPYTHON_USE_DYNAMIC_LOOKUP=ON" >> "${GITHUB_ENV}"
-          echo R_BINDINGS="-DWITH_R=True"
+          echo R_BINDINGS="-DWITH_R=True" >> "${GITHUB_ENV}"
 
       - name: Install MacOS dependencies
         # MacOS already has libxml2 by default

--- a/.github/workflows/brief.yml
+++ b/.github/workflows/brief.yml
@@ -22,10 +22,7 @@ jobs:
         with_examples: ["True"]
         package_option: ["-DWITH_ALL_PACKAGES=ON"]
         language_bindings:
-          [
-            "-DWITH_JAVA=True -DWITH_CSHARP=True -DWITH_PYTHON=True
-            -DWITH_R=True",
-          ]
+          [ "-DWITH_JAVA=True -DWITH_CSHARP=True -DWITH_PYTHON=True"]
         cpp_standard: [98, 20]
     runs-on: ${{ matrix.platform }}
 
@@ -76,9 +73,6 @@ jobs:
         shell: bash
         run: |
           echo RUNTIME_LINKING_OPTION="-DWITH_STATIC_RUNTIME=ON" >> "${GITHUB_ENV}"
-          ./dev/utilities/expdef/expdef64.exe -dRlib.def -l R.dll
-          echo R_PLATFORM_SPECIFIC_OPTIONS="-DR_LIB=${GITHUB_WORKSPACE}\Rlib.lib" >> "${GITHUB_ENV}"
-          echo R_INCLUDE_PATH="/c/Program Files/R/R-4.1.0/include" >> "${GITHUB_ENV}"
 
       - name: Install Ubuntu dependencies
         # ubuntu already has SWIG and libxml2 by default
@@ -87,6 +81,7 @@ jobs:
         run: |
           sudo apt-get install -y check ccache
           echo PYTHON_LINKING_OPTION="-DPYTHON_USE_DYNAMIC_LOOKUP=ON" >> "${GITHUB_ENV}"
+          echo R_BINDINGS="-DWITH_R=True"
 
       - name: Install MacOS dependencies
         # MacOS already has libxml2 by default
@@ -95,13 +90,6 @@ jobs:
         run: |
           brew install check swig ccache
           echo PYTHON_LINKING_OPTION="-DPYTHON_USE_DYNAMIC_LOOKUP=ON" >> "${GITHUB_ENV}"
-
-      - name: Unix R options
-        if: matrix.platform != 'windows-latest'
-        shell: bash
-        run:
-          echo R_PLATFORM_SPECIFIC_OPTIONS="-DWITH_CREATE_R_SOURCE=ON
-          -DWITH_SKIP_R_BINARY=ON" >> "${GITHUB_ENV}"
 
       ### setup ccache, not on Windows ###
       - name: Prepare ccache timestamp
@@ -149,8 +137,7 @@ jobs:
           -DWITH_EXAMPLES=${{matrix.with_examples}} \
           ${{matrix.package_option}} \
           ${{matrix.language_bindings}} \
-          ${R_PLATFORM_SPECIFIC_OPTIONS} \
-          -DR_INCLUDE_DIRS="$R_INCLUDE_PATH" \
+          ${R_BINDINGS} \
           ${RUNTIME_LINKING_OPTION} \
           ${PYTHON_LINKING_OPTION}
 
@@ -158,14 +145,6 @@ jobs:
         working-directory: ${{runner.workspace}}/build
         shell: bash
         run: cmake --build . --config $BUILD_TYPE
-
-      - name: Build Unix R binaries from source package
-        if: matrix.platform != 'windows-latest'
-        shell: bash
-        working-directory: ${{runner.workspace}}/build
-        run: |
-          mkdir r-binaries
-          R CMD INSTALL -l r-binaries --build ./src/bindings/r/out/libSBML_5.19.1.tar.gz
 
       ### run tests ###
       - name: Test
@@ -189,7 +168,7 @@ jobs:
         package_option: ["-DWITH_STABLE_PACKAGES=ON"]
         cpp_standard: [98, 20]
         language_bindings:
-          ["-DWITH_JAVA=True -DWITH_PYTHON=True -DWITH_CSHARP=True -DWITH_R=True"]
+          ["-DWITH_JAVA=True -DWITH_PYTHON=True -DWITH_CSHARP=True"]
         container: ["quay.io/pypa/manylinux2010_x86_64"]
     runs-on: ${{ matrix.platform }}
     container: ${{ matrix.container}}
@@ -217,7 +196,7 @@ jobs:
           ctest --version
       - name: Install dependencies, configure, build
         run: |
-          yum install -y libxml2-devel check-devel java-devel mono-devel R
+          yum install -y libxml2-devel check-devel java-devel mono-devel
           cd ..
           mkdir build
           cd build
@@ -230,15 +209,12 @@ jobs:
           -DWITH_EXAMPLES=${{matrix.with_examples}} \
           ${{matrix.package_option}} \
           ${{matrix.language_bindings}} \
-          -DWITH_CREATE_R_SOURCE=ON \
-          -DWITH_SKIP_R_BINARY=ON \
           -DPYTHON_EXECUTABLE=/opt/python/cp38-cp38/bin/python \
           -DPYTHON_INCLUDE_DIR=/opt/python/cp38-cp38/include/python3.8/ \
           -DWITH_STATIC_RUNTIME=ON \
           -DPYTHON_USE_DYNAMIC_LOOKUP=ON
           cmake --build . --config $BUILD_TYPE
-          mkdir r-binaries
-          R CMD INSTALL -l r-binaries --build ./src/bindings/r/out/libSBML_5.19.1.tar.gz
+
       - name: Test
         run: |
           cd ../build

--- a/.github/workflows/extensive.yml
+++ b/.github/workflows/extensive.yml
@@ -235,7 +235,7 @@ jobs:
         run: cmake --build . --config $BUILD_TYPE
 
       - name: Build Unix R binaries from source package
-        if: matrix.platform != 'windows-latest'
+        if: matrix.platform != 'windows-latest' && matrix.xml_parser_option == '-DWITH_LIBXML'
         shell: bash
         working-directory: ${{runner.workspace}}/build
         run: |

--- a/.github/workflows/extensive.yml
+++ b/.github/workflows/extensive.yml
@@ -28,7 +28,7 @@ jobs:
         package_option:
           ["", "-DWITH_STABLE_PACKAGES=ON", "-DWITH_ALL_PACKAGES=ON"]
         language_bindings:
-          ["-DWITH_JAVA=True -DWITH_CSHARP=True -DWITH_PYTHON=True"]
+          ["-DWITH_JAVA=True -DWITH_CSHARP=True -DWITH_PYTHON=True -DWITH_R=True"]
         include:
           # to test the other two XML parsers while avoiding a combinatorial explosion in the number of jobs,
           # we additionally include just two runs / OS : one for Expat, and one for Xerces
@@ -122,6 +122,9 @@ jobs:
         run: |
           echo $GITHUB_WORKSPACE"/swig/swigwin-3.0.12/" >> $GITHUB_PATH
           echo RUNTIME_LINKING_OPTION="-DWITH_STATIC_RUNTIME=ON" >> "${GITHUB_ENV}"
+          ./dev/utilities/expdef/expdef64.exe -dRlib.def -l R.dll
+          echo R_PLATFORM_SPECIFIC_OPTIONS="-DR_LIB=${GITHUB_WORKSPACE}\Rlib.lib" >> "${GITHUB_ENV}"
+          echo R_INCLUDE_PATH="/c/Program Files/R/R-4.1.0/include" >> "${GITHUB_ENV}"
 
       - name: Install Ubuntu dependencies
         # ubuntu already has SWIG and libxml2 by default
@@ -138,6 +141,13 @@ jobs:
         run: |
           brew install check swig xerces-c expat ccache
           echo PYTHON_LINKING_OPTION="-DPYTHON_USE_DYNAMIC_LOOKUP=ON" >> "${GITHUB_ENV}"
+
+      - name: Unix R options
+        if: matrix.platform != 'windows-latest'
+        shell: bash
+        run:
+          echo R_PLATFORM_SPECIFIC_OPTIONS="-DWITH_CREATE_R_SOURCE=ON
+          -DWITH_SKIP_R_BINARY=ON" >> "${GITHUB_ENV}"
 
       ### setup ccache, not on Windows ###
       - name: Prepare ccache timestamp
@@ -193,6 +203,8 @@ jobs:
           -DWITH_EXAMPLES=${{matrix.with_examples}} \
           ${{matrix.package_option}} \
           ${{matrix.language_bindings}} \
+          ${R_PLATFORM_SPECIFIC_OPTIONS} \
+          -DR_INCLUDE_DIRS="$R_INCLUDE_PATH" \
           ${RUNTIME_LINKING_OPTION} \
           ${PYTHON_LINKING_OPTION}
 
@@ -221,6 +233,14 @@ jobs:
         working-directory: ${{runner.workspace}}/build
         shell: bash
         run: cmake --build . --config $BUILD_TYPE
+
+      - name: Build Unix R binaries from source package
+        if: matrix.platform != 'windows-latest'
+        shell: bash
+        working-directory: ${{runner.workspace}}/build
+        run: |
+          mkdir r-binaries
+          R CMD INSTALL -l r-binaries --build ./src/bindings/r/out/libSBML_5.19.1.tar.gz
 
       ### run tests ###
       - name: Test

--- a/.github/workflows/store-artefact.yml
+++ b/.github/workflows/store-artefact.yml
@@ -259,7 +259,7 @@ jobs:
         package_option: ["-DWITH_ALL_PACKAGES=ON", "-DWITH_STABLE_PACKAGES=ON"]
         cpp_standard: [98]
         language_bindings:
-          ["-DWITH_JAVA=True -DWITH_PYTHON=True -DWITH_CSHARP=True"]
+          ["-DWITH_JAVA=True -DWITH_PYTHON=True -DWITH_CSHARP=True -DWITH_R=True"]
         container: ["quay.io/pypa/manylinux2010_x86_64"]
     runs-on: ${{ matrix.platform }}
     container: ${{ matrix.container}}
@@ -289,7 +289,7 @@ jobs:
 
       - name: Install dependencies, configure, build
         run: |
-          yum install -y libxml2-devel check-devel java-devel mono-devel
+          yum install -y libxml2-devel check-devel java-devel mono-devel R
           cd ..
           mkdir build
           cd build
@@ -304,11 +304,15 @@ jobs:
           -DWITH_EXAMPLES=${{matrix.with_examples}} \
           ${{matrix.package_option}} \
           ${{matrix.language_bindings}} \
+          -DWITH_CREATE_R_SOURCE=ON \
+          -DWITH_SKIP_R_BINARY=ON \
           -DPYTHON_EXECUTABLE=/opt/python/cp38-cp38/bin/python \
           -DPYTHON_INCLUDE_DIR=/opt/python/cp38-cp38/include/python3.8/ \
           -DWITH_STATIC_RUNTIME=ON \
           -DPYTHON_USE_DYNAMIC_LOOKUP=ON
           cmake --build . --config $BUILD_TYPE
+          mkdir r-binaries
+          R CMD INSTALL -l r-binaries --build ./src/bindings/r/out/libSBML_5.19.1.tar.gz
 
       - name: Test
         run: |
@@ -343,3 +347,11 @@ jobs:
             Manylinux2010 nightly (zip, libSBML ${{env.LIBSBML_VERSION}},
             ${{env.ARTIFACT_NAME_SUFFIX}})
           path: ../install # paths handled differently by v1 - note that "./install/*" does not work
+
+      - name: Upload Manylinux2010 R binary archive
+        uses: actions/upload-artifact@v1 # note v1 used here, because v2 incompatible
+        with:
+          name:
+            Manylinux2010 R nightly (zip, libSBML ${{env.LIBSBML_VERSION}},
+            ${{env.ARTIFACT_NAME_SUFFIX}})
+          path: ../build/r-binaries # paths handled differently by v1 - note that v1 doesn't allow multiple paths

--- a/.github/workflows/store-artefact.yml
+++ b/.github/workflows/store-artefact.yml
@@ -223,7 +223,7 @@ jobs:
           name:
             MacOS (zip, libSBML ${{env.LIBSBML_VERSION}},
             ${{env.ARTIFACT_NAME_SUFFIX}})
-          path:
+          path: |
             ${{runner.workspace}}/install/*
             ${{runner.workspace}}/build/r-binaries/*
           retention-days: 1
@@ -236,7 +236,7 @@ jobs:
           name:
             Ubuntu nightly (zip, libSBML ${{env.LIBSBML_VERSION}},
             ${{env.ARTIFACT_NAME_SUFFIX}})
-          path:
+          path: |
             ${{runner.workspace}}/install/*
             ${{runner.workspace}}/build/r-binaries/*
           retention-days: 1

--- a/.github/workflows/store-artefact.yml
+++ b/.github/workflows/store-artefact.yml
@@ -25,7 +25,10 @@ jobs:
         with_examples: ["True"]
         package_option: ["-DWITH_ALL_PACKAGES=ON", "-DWITH_STABLE_PACKAGES=ON"]
         language_bindings:
-          ["-DWITH_JAVA=True -DWITH_CSHARP=True -DWITH_PYTHON=True"]
+          [
+            "-DWITH_JAVA=True -DWITH_CSHARP=True -DWITH_PYTHON=True
+            -DWITH_R=True",
+          ]
     runs-on: ${{ matrix.platform }}
 
     steps:
@@ -71,6 +74,9 @@ jobs:
         run: |
           echo $GITHUB_WORKSPACE"/swig/swigwin-3.0.12/" >> $GITHUB_PATH
           echo RUNTIME_LINKING_OPTION="-DWITH_STATIC_RUNTIME=ON" >> "${GITHUB_ENV}"
+          ./dev/utilities/expdef/expdef64.exe -dRlib.def -l R.dll
+          echo R_PLATFORM_SPECIFIC_OPTIONS="-DR_LIB=${GITHUB_WORKSPACE}\Rlib.lib" >> "${GITHUB_ENV}"
+          echo R_INCLUDE_PATH="/c/Program Files/R/R-4.1.0/include" >> "${GITHUB_ENV}"
 
       - name: Install Ubuntu dependencies
         # ubuntu already has SWIG and libxml2 by default
@@ -87,6 +93,13 @@ jobs:
         run: |
           brew install check swig ccache
           echo PYTHON_LINKING_OPTION="-DPYTHON_USE_DYNAMIC_LOOKUP=ON" >> "${GITHUB_ENV}"
+
+      - name: Unix R options
+        if: matrix.platform != 'windows-latest'
+        shell: bash
+        run:
+          echo R_PLATFORM_SPECIFIC_OPTIONS="-DWITH_CREATE_R_SOURCE=ON
+          -DWITH_SKIP_R_BINARY=ON" >> "${GITHUB_ENV}"
 
       ### setup ccache, not on Windows ###
       - name: Prepare ccache timestamp
@@ -136,6 +149,8 @@ jobs:
           -DWITH_EXAMPLES=${{matrix.with_examples}} \
           ${{matrix.package_option}} \
           ${{matrix.language_bindings}} \
+          ${R_PLATFORM_SPECIFIC_OPTIONS} \
+          -DR_INCLUDE_DIRS="$R_INCLUDE_PATH" \
           ${RUNTIME_LINKING_OPTION} \
           ${PYTHON_LINKING_OPTION} \
 
@@ -144,6 +159,14 @@ jobs:
         shell: bash
         run: |
           cmake --build . --config $BUILD_TYPE
+
+      - name: Build Unix R binaries from source package
+        if: matrix.platform != 'windows-latest'
+        shell: bash
+        working-directory: ${{runner.workspace}}/build
+        run: |
+          mkdir r-binaries
+          R CMD INSTALL -l r-binaries --build ./src/bindings/r/out/libSBML_5.19.1.tar.gz
 
       ### run tests ###
       - name: Test
@@ -200,7 +223,9 @@ jobs:
           name:
             MacOS (zip, libSBML ${{env.LIBSBML_VERSION}},
             ${{env.ARTIFACT_NAME_SUFFIX}})
-          path: ${{runner.workspace}}/install/*
+          path:
+            ${{runner.workspace}}/install/*
+            ${{runner.workspace}}/build/r-binaries/*
           retention-days: 1
           if-no-files-found: error
 
@@ -211,7 +236,9 @@ jobs:
           name:
             Ubuntu nightly (zip, libSBML ${{env.LIBSBML_VERSION}},
             ${{env.ARTIFACT_NAME_SUFFIX}})
-          path: ${{runner.workspace}}/install/*
+          path:
+            ${{runner.workspace}}/install/*
+            ${{runner.workspace}}/build/r-binaries/*
           retention-days: 1
           if-no-files-found: error
   manylinuxbuild:

--- a/src/bindings/r/Makevars.in
+++ b/src/bindings/r/Makevars.in
@@ -5,16 +5,6 @@ ifeq "$(PLATFORM)" ""
   PLATFORM := $(shell uname)
 endif
 
-ifeq "$(PLATFORM)" "Darwin"
-  ifeq ($(shell sw_vers -productVersion | grep -c 10.6),0)
-  ifeq ($(shell sw_vers -productVersion | grep -c 10.7),0)
-    PKG_CXXFLAGS = -std=c++11 -stdlib=libstdc++
-    PKG_LIBS += -stdlib=libstdc++
-    CXX_STD = CXX11
-  endif
-  endif
-endif
-
 CPP_SOURCES = \
     sbml/compress/CompressCommon.cpp                \
     sbml/compress/InputDecompressor.cpp             \


### PR DESCRIPTION
## Description
This PR adds CI/CD related to R. More specifically, this PR:
- Full R binary packages are created for all OS at PR and Nightly Build. For unix-based systems, these runs include creating a source package first, and then compiling it into an R binary package with `R CMD INSTALL`.
- R binaries are built directly on push for ubuntu as part of the libSBML build.
- obsolete, macOS-specific linking options for R binaries are removed from `Makevars.in`.

## Motivation and Context
Solves the problem of needing to provide automatically nightly builds for libSBML R. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Change in documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have updated all documentation necessary. Full CI docs to follow in separate PR soon.
- [x] I have checked spelling in (new) comments.

## Testing
- [ ] Testing is done automatically and codecov shows test coverage
- [x] This cannot be tested automatically. Tests pass (but this doesn't mean the CI setup is sensible). Contents of the created artefacts looks sensible to @alessandrofelder but the reviewer is encouraged to double-check. The artefacts created as part of [this run](https://github.com/alessandrofelder/libsbml/actions/runs/989682756) should match exactly what we'll get in the nightly build when this is merged.

