### PR TITLE
Always free document before returning in `convertSBML.c` example

### DIFF
--- a/examples/c/convertSBML.c
+++ b/examples/c/convertSBML.c
@@ -72,6 +72,8 @@ main (int argc, char *argv[])
     printf("Encountered the following SBML error(s):\n");
     SBMLDocument_printErrors(d, stdout);
     printf("Conversion skipped.  Please correct the problems above first.\n");
+
+    SBMLDocument_free(d);
     return errors;
   }
   else
@@ -102,6 +104,8 @@ main (int argc, char *argv[])
       printf("Conversion skipped.  Either libSBML does not (yet) have\n");
       printf("ability to convert this model, or (automatic) conversion\n");
       printf("is not possible in this case.\n");
+
+      SBMLDocument_free(d);
       return errors;
     }
     


### PR DESCRIPTION
## Description

The example in `examples/c/convertSBML.c` doesn't always free the document before returning, in particular when there are errors during the conversion.

## Motivation and Context

This change prevents a potential memory leak in example code.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Change in documentation

## Checklist:

- [x] I have updated all documentation necessary.
- [x] I have checked spelling in (new) comments.

## Testing
- [X] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested -->

