### PR TITLE
Add initial CI/CD docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ We provide Zenodo DOIs for specific releases, so that you can cite the exact ver
 * libSBML-5.16.0 &rArr; [10.5281/zenodo.1095483](https://doi.org/10.5281/zenodo.)
 * libSBML-5.15.0 &rArr; [10.5281/zenodo.495344](https://doi.org/10.5281/zenodo.)
 
-If you'd like to include the latest features, binaries of the latest `development` branch of `SBMLTeam/libsbml` are built nightly and made available [here](https://github.com/sbmlteam/libsbml/actions/workflows/store-artefact.yml) by the CI/CD system.
+If you'd like to include the latest features, binaries of the latest `development` branch of `SBMLTeam/libsbml` are [built nightly](artefacts.md) by the CI/CD system.
 Further information for developers about the CI/CD system can be found [here](ci.md).
 
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ We provide Zenodo DOIs for specific releases, so that you can cite the exact ver
 * libSBML-5.16.0 &rArr; [10.5281/zenodo.1095483](https://doi.org/10.5281/zenodo.)
 * libSBML-5.15.0 &rArr; [10.5281/zenodo.495344](https://doi.org/10.5281/zenodo.)
 
+If you'd like to include the latest features, binaries of the latest `development` branch of `SBMLTeam/libsbml` are built nightly and made available [here](libsbml/actions/workflows/store-artefact.yml) by the CI/CD system.
+Further information for developers about the CI/CD system can be found [here](ci.md).
+
 
 Usage
 -----

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ We provide Zenodo DOIs for specific releases, so that you can cite the exact ver
 * libSBML-5.16.0 &rArr; [10.5281/zenodo.1095483](https://doi.org/10.5281/zenodo.)
 * libSBML-5.15.0 &rArr; [10.5281/zenodo.495344](https://doi.org/10.5281/zenodo.)
 
-If you'd like to include the latest features, binaries of the latest `development` branch of `SBMLTeam/libsbml` are built nightly and made available [here](libsbml/actions/workflows/store-artefact.yml) by the CI/CD system.
+If you'd like to include the latest features, binaries of the latest `development` branch of `SBMLTeam/libsbml` are built nightly and made available [here](https://github.com/sbmlteam/libsbml/actions/workflows/store-artefact.yml) by the CI/CD system.
 Further information for developers about the CI/CD system can be found [here](ci.md).
 
 

--- a/artefacts.md
+++ b/artefacts.md
@@ -1,7 +1,11 @@
 # Description of artefacts provided by CI/CD system
 The nightly build artefacts are available via the [Actions tab of the libSBML Github repository site](https://github.com/sbmlteam/libsbml/actions/workflows/store-artefact.yml) and are regenerated every 24 hours at 5 AM GMT. Their contents are described below - the [developer documentation](https://github.com/sbmlteam/libsbml/blob/development/ci.md) contains more details about the underlying CI/CD system. 
 
-Each artefact is provided as a zip file, and has a version that includes all packages (stable and experimental) and another version that contains only the stable packages. The artefacts are built using [virtual machines provided by GitHub Actions](https://github.com/actions/virtual-environments).
+Each artefact is provided as a zip file, and has a version that includes all packages (stable and experimental) and another version that contains only the stable packages. Stable packages include the SBML `comp`, `distrib`, `fbc`, `groups`, `l3v2extendedmath`, `layout`, `multi`, `qual`, and `render` packages, while experimental packages additionally include the SBML `arrays`, `dyn`, `req`, and `spatial` packages.
+
+All artefacts are compiled with namespace and strict includes enabled. Writing compressed SBML is possible with all artefacts in `.zip` and `.gz` format, and in `.bz2` format in all OS except CentOS 6.
+
+The artefacts are built using [virtual machines provided by GitHub Actions](https://github.com/actions/virtual-environments).
 
 ## Windows
 - Precompiled version of libSBML, built using the [libxml2](http://xmlsoft.org/) parser. Contains interfaces to C, C++, C# (.NET), Python, and R.

--- a/artefacts.md
+++ b/artefacts.md
@@ -1,25 +1,19 @@
 # Description of artefacts provided by CI/CD system
-
 The nightly build artefacts are available via the [Actions tab of the libSBML Github repository site](https://github.com/sbmlteam/libsbml/actions/workflows/store-artefact.yml) and are regenerated every 24 hours at 5 AM GMT. Their contents are described below - the [developer documentation](https://github.com/sbmlteam/libsbml/blob/development/ci.md) contains more details about the underlying CI/CD system. 
 
 Each artefact is provided as a zip file, and has a version that includes all packages (stable and experimental) and another version that contains only the stable packages. The artefacts are built using [virtual machines provided by GitHub Actions](https://github.com/actions/virtual-environments).
 
 ## Windows
-
 - Precompiled version of libSBML, built using the XML parser library. Contains interfaces to C, C++, C# (.NET), Python, and R.
 
-
 ## Mac OS
-
 - Precompiled version of libSBML, built using the XML parser library. Contains interfaces to C, C++, C# (Mono), Python, and R.
 - Precompiled R package for libSBML. 
 
 ## Ubuntu 16.04
-
 - Precompiled version of libSBML, built using the XML parser library. Contains interfaces to C, C++, C# (Mono), Python, and R.
 - Precompiled R package for libSBML. 
   
 ## CentOS 6 ([ManyLinux2010](quay.io/pypa/manylinux2010_x86_64))
-
 - Precompiled version of libSBML, built using the XML parser library. Contains interfaces to C, C++, C# (Mono), Python, and R.
 - Precompiled R package for libSBML (as a separate artefact). 

--- a/artefacts.md
+++ b/artefacts.md
@@ -1,0 +1,25 @@
+# Description of artefacts provided by CI/CD system
+
+The nightly build artefacts are available via the [Actions tab of the libSBML Github repository site](https://github.com/sbmlteam/libsbml/actions/workflows/store-artefact.yml) and are regenerated every 24 hours at 5 AM GMT. Their contents are described below - the [developer documentation](https://github.com/sbmlteam/libsbml/blob/development/ci.md) contains more details about the underlying CI/CD system. 
+
+Each artefact is provided as a zip file, and has a version that includes all packages (stable and experimental) and another version that contains only the stable packages. The artefacts are built using [virtual machines provided by GitHub Actions](https://github.com/actions/virtual-environments).
+
+## Windows
+
+- Precompiled version of libSBML, built using the XML parser library. Contains interfaces to C, C++, C# (.NET), Python, and R.
+
+
+## Mac OS
+
+- Precompiled version of libSBML, built using the XML parser library. Contains interfaces to C, C++, C# (Mono), Python, and R.
+- Precompiled R package for libSBML. 
+
+## Ubuntu 16.04
+
+- Precompiled version of libSBML, built using the XML parser library. Contains interfaces to C, C++, C# (Mono), Python, and R.
+- Precompiled R package for libSBML. 
+  
+## CentOS 6 ([ManyLinux2010](quay.io/pypa/manylinux2010_x86_64))
+
+- Precompiled version of libSBML, built using the XML parser library. Contains interfaces to C, C++, C# (Mono), Python, and R.
+- Precompiled R package for libSBML. 

--- a/artefacts.md
+++ b/artefacts.md
@@ -22,4 +22,4 @@ Each artefact is provided as a zip file, and has a version that includes all pac
 ## CentOS 6 ([ManyLinux2010](quay.io/pypa/manylinux2010_x86_64))
 
 - Precompiled version of libSBML, built using the XML parser library. Contains interfaces to C, C++, C# (Mono), Python, and R.
-- Precompiled R package for libSBML. 
+- Precompiled R package for libSBML (as a separate artefact). 

--- a/artefacts.md
+++ b/artefacts.md
@@ -4,16 +4,16 @@ The nightly build artefacts are available via the [Actions tab of the libSBML Gi
 Each artefact is provided as a zip file, and has a version that includes all packages (stable and experimental) and another version that contains only the stable packages. The artefacts are built using [virtual machines provided by GitHub Actions](https://github.com/actions/virtual-environments).
 
 ## Windows
-- Precompiled version of libSBML, built using the XML parser library. Contains interfaces to C, C++, C# (.NET), Python, and R.
+- Precompiled version of libSBML, built using the [libxml2](http://xmlsoft.org/) parser. Contains interfaces to C, C++, C# (.NET), Python, and R.
 
 ## Mac OS
-- Precompiled version of libSBML, built using the XML parser library. Contains interfaces to C, C++, C# (Mono), Python, and R.
+- Precompiled version of libSBML, built using the [libxml2](http://xmlsoft.org/) parser. Contains interfaces to C, C++, C# (Mono), Python, and R.
 - Precompiled R package for libSBML. 
 
 ## Ubuntu 16.04
-- Precompiled version of libSBML, built using the XML parser library. Contains interfaces to C, C++, C# (Mono), Python, and R.
+- Precompiled version of libSBML, built using the [libxml2](http://xmlsoft.org/) parser. Contains interfaces to C, C++, C# (Mono), Python, and R.
 - Precompiled R package for libSBML. 
   
 ## CentOS 6 ([ManyLinux2010](quay.io/pypa/manylinux2010_x86_64))
-- Precompiled version of libSBML, built using the XML parser library. Contains interfaces to C, C++, C# (Mono), Python, and R.
+- Precompiled version of libSBML, built using the [libxml2](http://xmlsoft.org/) parser. Contains interfaces to C, C++, C# (Mono), Python, and R.
 - Precompiled R package for libSBML (as a separate artefact). 

--- a/artefacts.md
+++ b/artefacts.md
@@ -3,7 +3,7 @@ The nightly build artefacts are available via the [Actions tab of the libSBML Gi
 
 Each artefact is provided as a zip file, and has a version that includes all packages (stable and experimental) and another version that contains only the stable packages. Stable packages include the SBML `comp`, `distrib`, `fbc`, `groups`, `l3v2extendedmath`, `layout`, `multi`, `qual`, and `render` packages, while experimental packages additionally include the SBML `arrays`, `dyn`, `req`, and `spatial` packages.
 
-All artefacts are compiled with namespace and strict includes enabled. Writing compressed SBML is possible with all artefacts in `.zip` and `.gz` format, and in `.bz2` format in all OS except CentOS 6.
+Writing compressed SBML is possible with all artefacts in `.zip` and `.gz` format, and in `.bz2` format in all OS except CentOS 6.
 
 The artefacts are built using [virtual machines provided by GitHub Actions](https://github.com/actions/virtual-environments).
 

--- a/ci.md
+++ b/ci.md
@@ -121,7 +121,7 @@ Up to libSBML 5.19.0, releases were done manually &mdash; this took a lot of tim
             - installers (32+64 bit, for Debian- and RPM-based) (deb, rpm)
 
 Each folder also contains a `ReadMe.md` describing the contents of the folder.
-All builds contain bindings for.
+All builds contain bindings for C/C++/C#(Mono)/Python/Java/Perl and most of the Ruby.
 
 ### Summary of differences of manual releases to nightly builds
 

--- a/ci.md
+++ b/ci.md
@@ -1,10 +1,13 @@
 
-# CI/CD for libSBML documentation
+# Developer documentation of CI/CD for libSBML
 
-Continuous integration/continuous deployment (CI/CD) for libSMBL is implemented in [GitHub actions](https://docs.github.com/en/actions). This file provides a description of the jobs that make up this CI/CD system. Note that links herein point to the SBML Team GitHub repo default branch, and may differ in branches and forks.
+Continuous integration/continuous deployment (CI/CD) for libSMBL is implemented in [GitHub actions](https://docs.github.com/en/actions). 
+
+This file provides a description of the jobs that make up this CI/CD system, as documentation for developers - a description of the artefacts provided to users can be found in [artefacts.md](https://github.com/sbmlteam/libsbml/blob/development/artefacts.md).
 
 The jobs run differ depending on the event (push, PR, nightly build) and are summarised below. The YAML files triggering each CI/CD run can be found under [`./github/workflows/`](https://github.com/sbmlteam/libsbml/tree/development/.github/workflows).
 
+Note that links herein point to the SBML Team GitHub repo default branch, and may differ in branches and forks.
 ## Nightly builds ([store-artefact.yml](https://github.com/sbmlteam/libsbml/actions/workflows/store-artefact.yml))
 
 ### Configurations
@@ -55,6 +58,7 @@ What is the reasoning behind the more extensive testing.
 ## Understanding the structure of the YAML files
 
 Ninja + other third-party actions used.
+ccache.
 
 ### Further reading
 

--- a/ci.md
+++ b/ci.md
@@ -55,7 +55,7 @@ What is the reasoning behind the more extensive testing.
 ## Understanding the structure of the YAML files
 
 Ninja + other third-party actions used.
-
+Manylinux2010 needs v1 of upload-artefact, which complicated things a little bit.
 
 ### Further reading
 

--- a/ci.md
+++ b/ci.md
@@ -55,3 +55,8 @@ What is the reasoning behind the more extensive testing.
 ## Understanding the structure of the YAML files
 
 Ninja + other third-party actions used.
+
+
+### Further reading
+
+Documentation for [creating R source packages and binary packages](https://cran.r-project.org/doc/manuals/r-release/R-exts.html#Building-binary-packages).

--- a/ci.md
+++ b/ci.md
@@ -15,7 +15,7 @@ Nightly builds are provided for the latest Ubuntu/MacOS and Windows environments
 | OS | `windows-latest`, `macos-latest`, `ubuntu-latest`, `manylinux2010`* |
 | packages | all, stable |
 
-<sub>\* `manylinux2010` runs as a separate job (not as part of the strategy matrix) in the same workflow. This is because it runs inside a container, and not directly in a virtual environment provided by GitHub actions. </sub>
+<sub>\*Note on ManyLinux: `manylinux2010` runs as a separate job (not as part of the strategy matrix) in the same workflow. This is because it runs inside a container, and not directly in a virtual environment provided by GitHub actions. `manylinux2010` also requires `checkout@v1` and `upload-artefact@v1`. Older ManyLinux is incompatible with GitHub Actions, as they require even older versions of `node`. A future workaround would be to run the ManyLinux job "manually" by using `docker` calls inside a more modern GitHub actions runner, instead of the current solution of using the `container: ` syntax.</sub>
 
 The parameters kept constant in the nightly builds are:
 
@@ -55,7 +55,6 @@ What is the reasoning behind the more extensive testing.
 ## Understanding the structure of the YAML files
 
 Ninja + other third-party actions used.
-Manylinux2010 needs v1 of upload-artefact, which complicated things a little bit.
 
 ### Further reading
 

--- a/ci.md
+++ b/ci.md
@@ -3,7 +3,7 @@
 
 Continuous integration/continuous deployment (CI/CD) for libSMBL is implemented in [GitHub actions](https://docs.github.com/en/actions). This file provides a description of the jobs that make up this CI/CD system. Note that links herein point to the SBML Team GitHub repo default branch, and may differ in branches and forks.
 
-The jobs run differ depending on the event (push, PR, nightly build) and are summarised below. The YAML files triggering each CI/CD run can be found under [`./github/workflows/`](https://github.com/sbmlteam/libsbml/actions/workflows/).
+The jobs run differ depending on the event (push, PR, nightly build) and are summarised below. The YAML files triggering each CI/CD run can be found under [`./github/workflows/`](https://github.com/sbmlteam/libsbml/tree/development/.github/workflows).
 
 ## Nightly builds ([store-artefact.yml](https://github.com/sbmlteam/libsbml/actions/workflows/store-artefact.yml))
 
@@ -15,7 +15,7 @@ Nightly builds are provided for the latest Ubuntu/MacOS and Windows environments
 | OS | `windows-latest`, `macos-latest`, `ubuntu-latest`, `manylinux2010`* |
 | packages | all, stable |
 
-<sub>\* `manylinux2010` runs as a separate job, not as part of the strategy matrix. This is because it runs inside a container, and not a virtual environment provided by GitHub actions. </sub>
+<sub>\* `manylinux2010` runs as a separate job (not as part of the strategy matrix) in the same workflow. This is because it runs inside a container, and not directly in a virtual environment provided by GitHub actions. </sub>
 
 The parameters kept constant in the nightly builds are:
 

--- a/ci.md
+++ b/ci.md
@@ -112,6 +112,17 @@ All runs use the `ninja` generator to configure the `cmake` build. This has the 
 We further use `ccache` to take advantage of several runs repeatedly calling the same compilation command (currently on MacOS and Ubuntu only). Essentially, [`ccache` caches compilation outputs and creates a unique hash for each of them](https://ccache.dev/manual/4.3.html#_how_ccache_works). If there is a cache hit, the compilation is not run, but is replaced by the compilation output.
 Windows builds are compiled using the MSVC static runtime (`-DWITH_STATIC_RUNTIME`).
 
+### namespaces and strict includes
+All artefacts are compiled with namespaces and "strict includes" enabled. Using strict includes preserves backwards compatibility with previous routine practice to `#include <SBMLTypes.h>` to access the entirety of SBML, which was achieved via indirect includes (i.e. `SBMLTypes` would call further `#include`s). This provides a simple access to `libSBML`, but leads to longer include chains, and therefore unnecessary re-compilations, when partially re-building.
+
+For quicker re-builds, not using strict includes accelerates compilation through constructs like
+```
+#ifndef LIBSBML_USE_STRICT_INCLUDES
+#include not_totally_necessary.h
+#endif
+```
+but you need to be sure that you're including everything you need directly.
+
 ### Python
 
 Unix-based builds use the `PYTHON_USE_DYNAMIC_LOOKUP` option, which allows libSBML binaries to dynamically link to available Python libraries, instead of being tied to the Python libraries of the OS the binaries were compiled on.

--- a/ci.md
+++ b/ci.md
@@ -110,7 +110,7 @@ All runs use the `ninja` generator to configure the `cmake` build. This has the 
 
 ### ccache
 We further use `ccache` to take advantage of several runs repeatedly calling the same compilation command (currently on MacOS and Ubuntu only). Essentially, [`ccache` caches compilation outputs and creates a unique hash for each of them](https://ccache.dev/manual/4.3.html#_how_ccache_works). If there is a cache hit, the compilation is not run, but is replaced by the compilation output.
-Windows builds are compiled using the MSVC static runtime (`-DWITH_STATIC_RUNTIME`).
+Windows builds are compiled using the MSVC static runtime (`-DWITH_STATIC_RUNTIME`). In our setup, this means that we use [GitHub actions `cache` action](https://docs.github.com/en/actions/guides/caching-dependencies-to-speed-up-workflows) to cache the `.ccache` folder (where the hashes and compilation outputs are stored) with an OS-specific key, meaning runs can take advantage of the `ccache` information from previous CI runs on the same OS to speed up compilation.
 
 ### namespaces and strict includes
 All artefacts are compiled with namespaces and "strict includes" enabled. Using strict includes preserves backwards compatibility with previous routine practice to `#include <SBMLTypes.h>` to access the entirety of SBML, which was achieved via indirect includes (i.e. `SBMLTypes` would call further `#include`s). This provides a simple access to `libSBML`, but leads to longer include chains, and therefore unnecessary re-compilations, when partially re-building.

--- a/ci.md
+++ b/ci.md
@@ -94,7 +94,7 @@ Documentation for [creating R source packages and binary packages](https://cran.
 
 # Using the CI system to make a libSBML release
 
-This section of the documentation is work-in-progress. Knowing the differences will help us develope a process to release libSBML more automatically in the future.
+This section of the documentation is work-in-progress. Knowing the differences will help us develop a process to release libSBML more automatically in the future.
 
 ## Differences to last manual release
 

--- a/ci.md
+++ b/ci.md
@@ -60,3 +60,24 @@ Manylinux2010 needs v1 of upload-artefact, which complicated things a little bit
 ### Further reading
 
 Documentation for [creating R source packages and binary packages](https://cran.r-project.org/doc/manuals/r-release/R-exts.html#Building-binary-packages).
+
+
+# Using the CI system to make a libSBML release
+
+## Differences to last manual release
+
+Up to libSBML 5.19.0, releases were done manually &mdash; this took a lot of time. These can be found on [Sourceforge](https://sourceforge.net/projects/sbml/files/libsbml/5.19.0/) and comprised: 
+
+### Structure of Sourceforge libSBML release 5.19.0
+
+//TODO
+
+### Summary of differences to nightly builds
+
+The latest versions of many of the artefact provided there are now available through the nightly build of the CI system. Differences are documented below. The nightly build does **not** currently contain
+- Installers (dmg, msi, rpm, deb), 
+- Ruby bindings
+- Perl binding
+- Automatic uploading to PyPI on release
+- MATLAB interface
+- precompiled dependencies for Windows

--- a/ci.md
+++ b/ci.md
@@ -1,0 +1,57 @@
+
+# CI/CD for libSBML documentation
+
+Continuous integration/continuous deployment (CI/CD) for libSMBL is implemented in [GitHub actions]. This file provides a description of the
+
+The jobs run differ depending on the event (push, PR, nightly build) and are summarised below. The YAML files triggering each CI/CD run can be found under [`./github/workflows/`](github/workflows/).
+
+## Nightly builds ([store-artefact.yml](github/workflows/store-artefact.yml))
+
+### Configurations
+Nightly builds are provided for the latest Ubuntu/MacOS and Windows environments, as well as a `pep 513`-compliant build (`manylinux2010`) for backwards compatibility with older CentOS-based linux systems (CentOS 6 and more recent). All nightly builds are available via the [Actions tab of the libSBML Github repository site](libsbml/actions/workflows/store-artefact.yml). The varying parameters are summarised below, resulting in 8 artefacts being rebuilt and uploaded every 24 hours.
+
+| parameters | value(s) taken |
+|-----|------------|
+| OS | `windows-latest`, `macos-latest`, `ubuntu-latest`, `manylinux2010`* |
+| packages | all, stable |
+
+<sub>\* `manylinux2010` runs as a separate job, not as part of the strategy matrix. This is because it runs inside a container, and not a virtual environment provided by GitHub actions. </sub>
+
+The parameters kept constant in the nightly builds are:
+
+| constant parameters | value |
+|-------------|------------|
+| bindings    | Java, C#, Python|
+| XML parser  | libxml2 |
+| namespaces  | true |
+| with examples    | true |
+| strict includes  | true |
+
+Note that the nightly builds are run only on the default branch, and only on the SBML team repo (and not on its forks).
+
+
+## On push (brief.yml)
+
+The 6 most important configurations are tested at every push. These are:
+
+OS
+C++ standard
+Packages
+Bindings
+XML parser
+
+The workflow file describing these configurations can be found [here]().
+
+## On PR (extensive.yml)
+
+Testing is more extensive when a full (non-draft) PR is opened. This includes 24 different configurations, 8 per operating system.
+
+beyond the 6, two additional runs are made to check the compatibility of the PR with the two non-default XML parsers.
+
+The workflow file describing these configurations can be found [here]().
+
+What is the reasoning behind the more extensive testing.
+
+## Understanding the structure of the YAML files
+
+Ninja + other third-party actions used.

--- a/ci.md
+++ b/ci.md
@@ -64,20 +64,75 @@ Documentation for [creating R source packages and binary packages](https://cran.
 
 # Using the CI system to make a libSBML release
 
+This section of the documentation is work-in-progress. Knowing the differences will help us develope a process to release libSBML more automatically in the future.
+
 ## Differences to last manual release
 
 Up to libSBML 5.19.0, releases were done manually &mdash; this took a lot of time. These can be found on [Sourceforge](https://sourceforge.net/projects/sbml/files/libsbml/5.19.0/) and comprised: 
 
 ### Structure of Sourceforge libSBML release 5.19.0
 
-//TODO
+- stable
+    - MATLAB interface
+        - MATLAB binaries for all OS (zip + tar)
+    - R interface
+        - R Source Package (tar)
+    - Windows 
+        - R installer for 32/64 bit Windows (zip)
+        - 64-bit
+            - Windows installer with MATLAB (exe)
+            - Windows installer without MATLAB (exe)
+            - Python
+                - python interface installers for py2.7 and py3.6-3.9 (exe)
+        - 32-bit
+            - [analogous to 64-bit]
+    - MacOS
+        - installer (dmg, tar)
+    - Linux
+        - 64-bit
+            - Ubuntu binaries (tar)
+            - CentOS binaries (tar)
+            - Debian installer (deb)
+            - RPM installer (rpm)
+        - 32-bit
+            - [analogous to 64-bit]
+    - core libSMBL source code (zip+tar)
+    - full libSBML source code (zip+tar)
+    - individual accepted level-3 packages source code (zip+tar)
+    - libSBML documentation (zip+tar)
+- experimental
+    - source
+        - R interface
+            - R source package (tar)
+        - libSBML source code (zip, tar)
+        - experimental packages source code (spatial, req, dyn, arrays) (zip)
+    - binaries
+        - Windows
+            - R interface
+                - R interface windows installer (zip)
+            - python
+                - python interface installers (32+64-bit and py2.7+3.6-3.9) (exe)
+            - installer 64-bit (zip)
+            - installer 32-bit (zip)
+        - MacOS
+            - binaries (tar)
+        - Linux
+            - binaries (32+64 bit, for centOS and Ubuntu) (tar)
+            - installers (32+64 bit, for Debian- and RPM-based) (deb, rpm)
 
-### Summary of differences to nightly builds
+Each folder also contains a `ReadMe.md` describing the contents of the folder.
+All builds contain bindings for.
+
+### Summary of differences of manual releases to nightly builds
 
 The latest versions of many of the artefact provided there are now available through the nightly build of the CI system. Differences are documented below. The nightly build does **not** currently contain
 - Installers (dmg, msi, rpm, deb), 
 - Ruby bindings
-- Perl binding
-- Automatic uploading to PyPI on release
+- Perl bindings
+- mechanisms to provide libSBML-python via conda or pyPI
 - MATLAB interface
 - precompiled dependencies for Windows
+- tar archives
+- ReadMe files
+- 32-bit versions
+- python interface installers

--- a/ci.md
+++ b/ci.md
@@ -13,52 +13,79 @@ Note that links herein point to the SBML Team GitHub repo default branch, and ma
 ### Configurations
 Nightly builds are provided for the latest Ubuntu/MacOS and Windows environments, as well as a `pep 513`-compliant build (`manylinux2010`) for backwards compatibility with older CentOS-based linux systems (CentOS 6 and more recent). All nightly builds are available via the [Actions tab of the libSBML Github repository site](https://github.com/sbmlteam/libsbml/actions/workflows/store-artefact.yml). The varying parameters are summarised below, resulting in 8 artefacts being rebuilt and uploaded every 24 hours, at 5 AM GMT.
 
-| parameters | value(s) taken |
-|-----|------------|
-| OS | `windows-latest`, `macos-latest`, `ubuntu-latest`, `manylinux2010`* |
-| packages | all, stable |
+| parameters | value(s) taken                                                     |
+| ---------- | ------------------------------------------------------------------ |
+| OS         | `windows-latest`, `macos-latest`, `ubuntu-16.04`, `manylinux2010`* |
+| packages   | all, stable                                                        |
 
 <sub>\*Note on ManyLinux: `manylinux2010` runs as a separate job (not as part of the strategy matrix) in the same workflow. This is because it runs inside a container, and not directly in a virtual environment provided by GitHub actions. `manylinux2010` also requires `checkout@v1` and `upload-artefact@v1`. Older ManyLinux is incompatible with GitHub Actions, as they require even older versions of `node`. A future workaround would be to run the ManyLinux job "manually" by using `docker` calls inside a more modern GitHub actions runner, instead of the current solution of using the `container: ` syntax.</sub>
 
 The parameters kept constant in the nightly builds are:
 
-| constant parameters | value |
-|-------------|------------|
-| bindings    | Java, C#, Python, R|
-| XML parser  | libxml2 |
-| namespaces  | true |
-| with examples    | true |
-| strict includes  | true |
+| constant parameters | value               |
+| ------------------- | ------------------- |
+| bindings            | Java, C#, Python, R |
+| XML parser          | libxml2             |
+| namespaces          | true                |
+| with examples       | true                |
+| strict includes     | true                |
+| C++ standard        | 98                  |
 
-Note that the nightly builds are run only on the default branch, and only on the SBML team repo (and not on its forks). For Unix-based systems, R binaries are also provided.
+Note that the nightly builds are run only on the default branch, and only on the SBML team repo (and not on its forks).
 
 
-## On push (brief.yml)
+## On push ([brief.yml](https://github.com/sbmlteam/libsbml/actions/workflows/brief.yml))
 
-The 6 most important configurations are tested at every push. These are:
+On every push, we run 8 tests configurations. These differ by the following parameters:
 
-OS
-C++ standard
-Packages
-Bindings
-XML parser
+| parameters   | value(s) taken                                                    |
+| ------------ | ----------------------------------------------------------------- |
+| OS           | `windows-latest`, `macos-latest`, `ubuntu-16.04`, `manylinux2010` |
+| C++ standard | 98, 20                                                            |
 
-The workflow file describing these configurations can be found [here](https://github.com/sbmlteam/libsbml/actions/workflows/brief.yml).
+while these build parameters are kept constant:
 
-## On PR (extensive.yml)
+| constant parameters | value                |
+| ------------------- | -------------------- |
+| bindings            | Java, C#, Python, R* |
+| XML parser          | libxml2              |
+| namespaces          | true                 |
+| with examples       | true                 |
+| strict includes     | true                 |
+| packages            | all                  |
 
-Testing is more extensive when a full (non-draft) PR is opened. This includes 24 different configurations, 8 per operating system.
+<sub>\* R builds only run for Ubuntu, to provide feedback more quickly.</sub>
 
-beyond the 6, two additional runs are made to check the compatibility of the PR with the two non-default XML parsers.
+## On PR ([extensive.yml](https://github.com/sbmlteam/libsbml/actions/workflows/extensive.yml))
 
-The workflow file describing these configurations can be found [here](https://github.com/sbmlteam/libsbml/actions/workflows/extensive.yml).
+Testing is more extensive when a full (non-draft) PR is opened.
 
-What is the reasoning behind the more extensive testing.
+This step includes 24 different configurations, 8 per OS (Windows, Mac, Ubuntu). No `manylinux` build is currently run on PR.
+
+This is the stage where the two non-default XML parsers (`xerces`, `expat`) are also tested. As the XML parsers are largely independent of the rest of the codebase, they are only tested in one configuration/OS - with all packages, but without language bindings.
+
+| parameters | value(s) taken                                   |
+| ---------- | ------------------------------------------------ |
+| OS         | `windows-latest`, `macos-latest`, `ubuntu-16.04` |
+| packages   | all, stable, none                                |
+| namespaces | true, false                                      |
+| XML parser | libxml2, expat*, xerces*                         |
+
+<sub>\* only with all packages and no bindings, for all OS.</sub>
+
+| constant parameters | value               |
+| ------------------- | ------------------- |
+| bindings            | Java, C#, Python, R |
+| C++ standard        | 98                  |
+| with examples       | true                |
+| strict includes     | true                |
+
 
 ## Understanding the structure of the YAML files
 
 Ninja + other third-party actions used.
 ccache.
+dependency installation varies across operating systems.
 
 ### Further reading
 

--- a/ci.md
+++ b/ci.md
@@ -108,8 +108,8 @@ Windows builds require a precompiled dependencies folder, which is downloaded fr
 ### CMake configuration
 All runs use the `ninja` generator to configure the `cmake` build. This has the advantage of automatically parallelising the build under the hood.
 
-We further use `ccache` to take advantage of several runs repeatedly calling the same compilation command.
-
+### ccache
+We further use `ccache` to take advantage of several runs repeatedly calling the same compilation command (currently on MacOS and Ubuntu only). Essentially, [`ccache` caches compilation outputs and creates a unique hash for each of them](https://ccache.dev/manual/4.3.html#_how_ccache_works). If there is a cache hit, the compilation is not run, but is replaced by the compilation output.
 Windows builds are compiled using the MSVC static runtime (`-DWITH_STATIC_RUNTIME`).
 
 ### Python

--- a/ci.md
+++ b/ci.md
@@ -8,7 +8,7 @@ The jobs run differ depending on the event (push, PR, nightly build) and are sum
 ## Nightly builds ([store-artefact.yml](https://github.com/sbmlteam/libsbml/actions/workflows/store-artefact.yml))
 
 ### Configurations
-Nightly builds are provided for the latest Ubuntu/MacOS and Windows environments, as well as a `pep 513`-compliant build (`manylinux2010`) for backwards compatibility with older CentOS-based linux systems (CentOS 6 and more recent). All nightly builds are available via the [Actions tab of the libSBML Github repository site](https://github.com/sbmlteam/libsbml/actions/workflows/store-artefact.yml). The varying parameters are summarised below, resulting in 8 artefacts being rebuilt and uploaded every 24 hours.
+Nightly builds are provided for the latest Ubuntu/MacOS and Windows environments, as well as a `pep 513`-compliant build (`manylinux2010`) for backwards compatibility with older CentOS-based linux systems (CentOS 6 and more recent). All nightly builds are available via the [Actions tab of the libSBML Github repository site](https://github.com/sbmlteam/libsbml/actions/workflows/store-artefact.yml). The varying parameters are summarised below, resulting in 8 artefacts being rebuilt and uploaded every 24 hours, at 5 AM GMT.
 
 | parameters | value(s) taken |
 |-----|------------|
@@ -21,13 +21,13 @@ The parameters kept constant in the nightly builds are:
 
 | constant parameters | value |
 |-------------|------------|
-| bindings    | Java, C#, Python|
+| bindings    | Java, C#, Python, R|
 | XML parser  | libxml2 |
 | namespaces  | true |
 | with examples    | true |
 | strict includes  | true |
 
-Note that the nightly builds are run only on the default branch, and only on the SBML team repo (and not on its forks).
+Note that the nightly builds are run only on the default branch, and only on the SBML team repo (and not on its forks). For Unix-based systems, R binaries are also provided.
 
 
 ## On push (brief.yml)

--- a/ci.md
+++ b/ci.md
@@ -80,7 +80,7 @@ This is the stage where the two non-default XML parsers (`xerces`, `expat`) are 
 ## Notes on the CI/CD system
 
 ### Understanding the structure of the YAML files
-The GitHub Actions `cmake` template was used as a basis. The GitHub Actions quickstart page gives an introduction into important terminology needed to understand the YAML files: strategy matrix, job, step, action.
+The GitHub Actions `cmake` template was used as a basis. [The GitHub Actions introduction page](https://docs.github.com/en/actions/learn-github-actions/introduction-to-github-actions) defines the fundamental terminology needed to understand the YAML files: job, step, action. Understanding [a strategy matrix](https://docs.github.com/en/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix) is also necessary.
 
 For libSBML, the YAML files are generally structured into:
 - define strategy matrix
@@ -106,12 +106,18 @@ On Unix-based systems, missing dependences are typically installed via standard 
 Windows builds require a precompiled dependencies folder, which is downloaded from SourceForge and cached, as well as a "manual" swig set-up by the CI. Additionally, we use the [`ilammy/msvc-dev-cmd`](https://github.com/marketplace/actions/enable-developer-command-prompt) action to ensure `msbuild` remains accessible to `cmake` (it's not by default because we use the `ninja` generator).
 
 ### CMake configuration
-All runs use the `ninja` generator to configure the `cmake` build. This has the advantage of automatically parallelising the build under the hood. We further use `ccache` to take advantage of several runs repeatedly calling the same compilation command.
+All runs use the `ninja` generator to configure the `cmake` build. This has the advantage of automatically parallelising the build under the hood.
 
-### Python bindings
+We further use `ccache` to take advantage of several runs repeatedly calling the same compilation command.
+
+Windows builds are compiled using the MSVC static runtime (`-DWITH_STATIC_RUNTIME`).
+
+### Python
+
+Unix-based builds use the `PYTHON_USE_DYNAMIC_LOOKUP` option, which allows libSBML binaries to dynamically link to available Python libraries, instead of being tied to the Python libraries of the OS the binaries were compiled on.
 
 ### R package and bindings
-Documentation for [creating R source packages and binary packages](https://cran.r-project.org/doc/manuals/r-release/R-exts.html#Building-binary-packages).
+Unix-based systems additionally build a binary R package in two steps: first the compiliation is configured to skip building the R binaries and create a source package instead (`-DWITH_CREATE_R_SOURCE=ON -DWITH_SKIP_R_BINARY=ON`). The binary R package is the created from the source package using the `R CMD INSTALL`.See the documentation for [creating R source packages and binary packages](https://cran.r-project.org/doc/manuals/r-release/R-exts.html#Building-binary-packages).
 
 # Using the CI system to make a libSBML release
 This section of the documentation is work-in-progress. Knowing the differences will help us develop a process to release libSBML more automatically in the future.

--- a/ci.md
+++ b/ci.md
@@ -1,14 +1,14 @@
 
 # CI/CD for libSBML documentation
 
-Continuous integration/continuous deployment (CI/CD) for libSMBL is implemented in [GitHub actions]. This file provides a description of the
+Continuous integration/continuous deployment (CI/CD) for libSMBL is implemented in [GitHub actions](https://docs.github.com/en/actions). This file provides a description of the jobs that make up this CI/CD system. Note that links herein point to the SBML Team GitHub repo default branch, and may differ in branches and forks.
 
-The jobs run differ depending on the event (push, PR, nightly build) and are summarised below. The YAML files triggering each CI/CD run can be found under [`./github/workflows/`](github/workflows/).
+The jobs run differ depending on the event (push, PR, nightly build) and are summarised below. The YAML files triggering each CI/CD run can be found under [`./github/workflows/`](https://github.com/sbmlteam/libsbml/actions/workflows/).
 
-## Nightly builds ([store-artefact.yml](github/workflows/store-artefact.yml))
+## Nightly builds ([store-artefact.yml](https://github.com/sbmlteam/libsbml/actions/workflows/store-artefact.yml))
 
 ### Configurations
-Nightly builds are provided for the latest Ubuntu/MacOS and Windows environments, as well as a `pep 513`-compliant build (`manylinux2010`) for backwards compatibility with older CentOS-based linux systems (CentOS 6 and more recent). All nightly builds are available via the [Actions tab of the libSBML Github repository site](libsbml/actions/workflows/store-artefact.yml). The varying parameters are summarised below, resulting in 8 artefacts being rebuilt and uploaded every 24 hours.
+Nightly builds are provided for the latest Ubuntu/MacOS and Windows environments, as well as a `pep 513`-compliant build (`manylinux2010`) for backwards compatibility with older CentOS-based linux systems (CentOS 6 and more recent). All nightly builds are available via the [Actions tab of the libSBML Github repository site](https://github.com/sbmlteam/libsbml/actions/workflows/store-artefact.yml). The varying parameters are summarised below, resulting in 8 artefacts being rebuilt and uploaded every 24 hours.
 
 | parameters | value(s) taken |
 |-----|------------|
@@ -40,7 +40,7 @@ Packages
 Bindings
 XML parser
 
-The workflow file describing these configurations can be found [here]().
+The workflow file describing these configurations can be found [here](https://github.com/sbmlteam/libsbml/actions/workflows/brief.yml).
 
 ## On PR (extensive.yml)
 
@@ -48,7 +48,7 @@ Testing is more extensive when a full (non-draft) PR is opened. This includes 24
 
 beyond the 6, two additional runs are made to check the compatibility of the PR with the two non-default XML parsers.
 
-The workflow file describing these configurations can be found [here]().
+The workflow file describing these configurations can be found [here](https://github.com/sbmlteam/libsbml/actions/workflows/extensive.yml).
 
 What is the reasoning behind the more extensive testing.
 


### PR DESCRIPTION
## Description
This PR adds at least some initial documentation for developers (`ci.md`) and users that want to download the nightly builds (`artefacts.md`).

## Motivation and Context
There is currently no documentation of the CI system.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Change in documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have updated all documentation necessary. This PR only adds previous lacking docs.
- [x] I have checked spelling in (new) comments.

## Testing
- [ ] Testing is done automatically and codecov shows test coverage
- [x] This cannot be tested automatically <!-- describe how it has been tested -->

