### PR TITLE
Update Windows R Header version in CI

### DIFF
--- a/.github/workflows/extensive.yml
+++ b/.github/workflows/extensive.yml
@@ -124,7 +124,7 @@ jobs:
           echo RUNTIME_LINKING_OPTION="-DWITH_STATIC_RUNTIME=ON" >> "${GITHUB_ENV}"
           ./dev/utilities/expdef/expdef64.exe -dRlib.def -l R.dll
           echo R_PLATFORM_SPECIFIC_OPTIONS="-DR_LIB=${GITHUB_WORKSPACE}\Rlib.lib" >> "${GITHUB_ENV}"
-          echo R_INCLUDE_PATH="/c/Program Files/R/R-4.1.0/include" >> "${GITHUB_ENV}"
+          echo R_INCLUDE_PATH="/c/Program Files/R/R-4.1.1/include" >> "${GITHUB_ENV}"
 
       - name: Install Ubuntu dependencies
         # ubuntu already has SWIG and libxml2 by default

--- a/.github/workflows/store-artefact.yml
+++ b/.github/workflows/store-artefact.yml
@@ -76,7 +76,7 @@ jobs:
           echo RUNTIME_LINKING_OPTION="-DWITH_STATIC_RUNTIME=ON" >> "${GITHUB_ENV}"
           ./dev/utilities/expdef/expdef64.exe -dRlib.def -l R.dll
           echo R_PLATFORM_SPECIFIC_OPTIONS="-DR_LIB=${GITHUB_WORKSPACE}\Rlib.lib" >> "${GITHUB_ENV}"
-          echo R_INCLUDE_PATH="/c/Program Files/R/R-4.1.0/include" >> "${GITHUB_ENV}"
+          echo R_INCLUDE_PATH="/c/Program Files/R/R-4.1.1/include" >> "${GITHUB_ENV}"
 
       - name: Install Ubuntu dependencies
         # ubuntu already has SWIG and libxml2 by default


### PR DESCRIPTION
## Description
Updates the hardcoded path to the windows R headers in the CI YAML files (the R version of the GitHub actions Windows VM changed last week).

I haven't found an easy way to prevent this failure happening when future R updates to the underlying OS configuration are made.
It may even help to leave this hard-coded so we know what R version we're using and notice when it changes (maybe?).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fixes #161 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Change in documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have updated all documentation necessary.
- [x] I have checked spelling in (new) comments.

## Testing
- [ ] Testing is done automatically and codecov shows test coverage
- [x] This cannot be tested automatically. I've tested that the `store-artefact.yml` workflow [completes successfully on push ](https://github.com/alessandrofelder/libsbml/runs/3410139674)(and then reverted the necessary change to achieve this test).

