### PR TITLE
Fixes leak.

### DIFF
--- a/src/fbc-package.cmake
+++ b/src/fbc-package.cmake
@@ -38,7 +38,7 @@ include(${LIBSBML_ROOT_SOURCE_DIR}/fbc-package.cmake)
 #build up sources
 set(FBC_SOURCES)
 
-# go through all directtories: common, extension and sbml
+# go through all directories
 foreach(dir common extension sbml util validator validator/constraints)
 
   # add to include directory

--- a/src/sbml/packages/render/sbml/LineEnding.cpp
+++ b/src/sbml/packages/render/sbml/LineEnding.cpp
@@ -118,7 +118,6 @@ LineEnding::LineEnding(const XMLNode& node, unsigned int l2version)
   , mGroup(NULL)
   , mBoundingBox(NULL)
 {
-  mGroup = new RenderGroup(2, l2version);
     const XMLNode* child;
     const XMLAttributes& attributes=node.getAttributes();
      ExpectedAttributes ea;
@@ -142,6 +141,10 @@ LineEnding::LineEnding(const XMLNode& node, unsigned int l2version)
     if (mBoundingBox == NULL)
     {
         mBoundingBox = new BoundingBox(2, l2version);
+    }
+    if (mGroup == NULL)
+    {
+        mGroup = new RenderGroup(2, l2version);
     }
 
     

--- a/src/sbml/packages/render/sbml/LineEnding.cpp
+++ b/src/sbml/packages/render/sbml/LineEnding.cpp
@@ -118,7 +118,6 @@ LineEnding::LineEnding(const XMLNode& node, unsigned int l2version)
   , mGroup(NULL)
   , mBoundingBox(NULL)
 {
-  mBoundingBox = new BoundingBox(2, l2version);
   mGroup = new RenderGroup(2, l2version);
     const XMLNode* child;
     const XMLAttributes& attributes=node.getAttributes();
@@ -132,14 +131,17 @@ LineEnding::LineEnding(const XMLNode& node, unsigned int l2version)
         const std::string& childName=child->getName();
         if(childName=="boundingBox")
         {
-            this->mBoundingBox= new BoundingBox(*child);
-            //this->mBoundingBox.setIsInRenderContext(true);
+            mBoundingBox= new BoundingBox(*child);
         }
         else if(childName=="g")
         {
-            this->mGroup=new RenderGroup(*child);
+            mGroup=new RenderGroup(*child);
         }
         ++n;
+    }
+    if (mBoundingBox == NULL)
+    {
+        mBoundingBox = new BoundingBox(2, l2version);
     }
 
     


### PR DESCRIPTION
If a LineEnding has a child BoundingBox, the BoundingBox that was created at the beginning of the function is leaked in favor of the new one.  This fix doesn't create a blank bounding box unless one doesn't exist.