### PR TITLE
Fix spatial validation crash.

### DIFF
--- a/src/sbml/packages/spatial/validator/constraints/UniqueSpatialIds.cpp
+++ b/src/sbml/packages/spatial/validator/constraints/UniqueSpatialIds.cpp
@@ -213,8 +213,14 @@ UniqueSpatialIds::doCheck (const Model& m)
     {
       const CoordinateComponent *cc = g->getCoordinateComponent(n);
       doCheckId(*cc);
-      doCheckId(*cc->getBoundaryMax());
-      doCheckId(*cc->getBoundaryMin());
+      if (cc->isSetBoundaryMax())
+      {
+          doCheckId(*cc->getBoundaryMax());
+      }
+      if (cc->isSetBoundaryMin())
+      {
+          doCheckId(*cc->getBoundaryMin());
+      }
     }
 
     size = g->getNumDomainTypes();


### PR DESCRIPTION
When checking to see if spatial ids are unique, would crash if boundaryMax or boundaryMin objects were missing.  This adds a check to prevent this.