### PR TITLE
Fix signature of prototypes of `FbcSpeciesPlugin`

### DIFF
--- a/src/sbml/packages/fbc/extension/FbcReactionPlugin.h
+++ b/src/sbml/packages/fbc/extension/FbcReactionPlugin.h
@@ -733,7 +733,7 @@ BEGIN_C_DECLS
  */
 LIBSBML_EXTERN
 char *
-FbcReactionPlugin_getUpperFluxBound(SBasePlugin_t * fbc);
+FbcReactionPlugin_getUpperFluxBound(FbcSBasePlugin_t * fbc);
 
 
 /**
@@ -749,7 +749,7 @@ FbcReactionPlugin_getUpperFluxBound(SBasePlugin_t * fbc);
  */
 LIBSBML_EXTERN
 int
-FbcReactionPlugin_isSetUpperFluxBound(SBasePlugin_t * fbc);
+FbcReactionPlugin_isSetUpperFluxBound(FbcSBasePlugin_t * fbc);
 
 
 /**
@@ -769,7 +769,7 @@ FbcReactionPlugin_isSetUpperFluxBound(SBasePlugin_t * fbc);
  */
 LIBSBML_EXTERN
 int
-FbcReactionPlugin_setUpperFluxBound(SBasePlugin_t * fbc, const char * UpperFluxBound);
+FbcReactionPlugin_setUpperFluxBound(FbcSBasePlugin_t * fbc, const char * UpperFluxBound);
 
 
 /**
@@ -785,7 +785,7 @@ FbcReactionPlugin_setUpperFluxBound(SBasePlugin_t * fbc, const char * UpperFluxB
  */
 LIBSBML_EXTERN
 int
-FbcReactionPlugin_unsetUpperFluxBound(SBasePlugin_t * fbc);
+FbcReactionPlugin_unsetUpperFluxBound(FbcSBasePlugin_t * fbc);
 
 
 /**
@@ -799,7 +799,7 @@ FbcReactionPlugin_unsetUpperFluxBound(SBasePlugin_t * fbc);
  */
 LIBSBML_EXTERN
 char *
-FbcReactionPlugin_getLowerFluxBound(SBasePlugin_t * fbc);
+FbcReactionPlugin_getLowerFluxBound(FbcSBasePlugin_t * fbc);
 
 
 /**
@@ -815,7 +815,7 @@ FbcReactionPlugin_getLowerFluxBound(SBasePlugin_t * fbc);
  */
 LIBSBML_EXTERN
 int
-FbcReactionPlugin_isSetLowerFluxBound(SBasePlugin_t * fbc);
+FbcReactionPlugin_isSetLowerFluxBound(FbcSBasePlugin_t * fbc);
 
 
 /**
@@ -835,7 +835,7 @@ FbcReactionPlugin_isSetLowerFluxBound(SBasePlugin_t * fbc);
  */
 LIBSBML_EXTERN
 int
-FbcReactionPlugin_setLowerFluxBound(SBasePlugin_t * fbc, const char * LowerFluxBound);
+FbcReactionPlugin_setLowerFluxBound(FbcSBasePlugin_t * fbc, const char * LowerFluxBound);
 
 
 /**
@@ -851,7 +851,7 @@ FbcReactionPlugin_setLowerFluxBound(SBasePlugin_t * fbc, const char * LowerFluxB
  */
 LIBSBML_EXTERN
 int
-FbcReactionPlugin_unsetUpperFluxBound(SBasePlugin_t * fbc);
+FbcReactionPlugin_unsetUpperFluxBound(FbcSBasePlugin_t * fbc);
 
 
 /**
@@ -867,7 +867,7 @@ FbcReactionPlugin_unsetUpperFluxBound(SBasePlugin_t * fbc);
  */
 LIBSBML_EXTERN
 int
-FbcReactionPlugin_isSetGeneProductAssociation(SBasePlugin_t * fbc);
+FbcReactionPlugin_isSetGeneProductAssociation(FbcSBasePlugin_t * fbc);
 
 
 /**
@@ -881,7 +881,7 @@ FbcReactionPlugin_isSetGeneProductAssociation(SBasePlugin_t * fbc);
  */
 LIBSBML_EXTERN
 GeneProductAssociation_t*
-FbcReactionPlugin_getGeneProductAssociation(SBasePlugin_t * fbc);
+FbcReactionPlugin_getGeneProductAssociation(FbcSBasePlugin_t * fbc);
 
 
 /**
@@ -898,7 +898,7 @@ FbcReactionPlugin_getGeneProductAssociation(SBasePlugin_t * fbc);
  */
 LIBSBML_EXTERN
 int
-FbcReactionPlugin_setGeneProductAssociation(SBasePlugin_t * fbc, 
+FbcReactionPlugin_setGeneProductAssociation(FbcSBasePlugin_t * fbc, 
                                             GeneProductAssociation_t* gpa);
 
 

--- a/src/sbml/packages/fbc/extension/FbcReactionPlugin.h
+++ b/src/sbml/packages/fbc/extension/FbcReactionPlugin.h
@@ -839,7 +839,7 @@ FbcReactionPlugin_setLowerFluxBound(FbcSBasePlugin_t * fbc, const char * LowerFl
 
 
 /**
- * Unsets the "upperFluxBound" attribute of the given FbcReactionPlugin_t structure.
+ * Unsets the "lowerFluxBound" attribute of the given FbcReactionPlugin_t structure.
  *
  * @param fbc the FbcReactionPlugin_t structure to unset.
  *
@@ -851,7 +851,7 @@ FbcReactionPlugin_setLowerFluxBound(FbcSBasePlugin_t * fbc, const char * LowerFl
  */
 LIBSBML_EXTERN
 int
-FbcReactionPlugin_unsetUpperFluxBound(FbcSBasePlugin_t * fbc);
+FbcReactionPlugin_unsetLowerFluxBound(FbcSBasePlugin_t * fbc);
 
 
 /**

--- a/src/sbml/packages/fbc/extension/FbcSpeciesPlugin.h
+++ b/src/sbml/packages/fbc/extension/FbcSpeciesPlugin.h
@@ -644,7 +644,7 @@ BEGIN_C_DECLS
  */
 LIBSBML_EXTERN
 int
-FbcSpeciesPlugin_getCharge(SBasePlugin_t * fbc);
+FbcSpeciesPlugin_getCharge(FbcSBasePlugin_t * fbc);
 
 
 /**
@@ -658,7 +658,7 @@ FbcSpeciesPlugin_getCharge(SBasePlugin_t * fbc);
 */
 LIBSBML_EXTERN
 double
-FbcSpeciesPlugin_getChargeAsDouble(SBasePlugin_t * fbc);
+FbcSpeciesPlugin_getChargeAsDouble(FbcSBasePlugin_t * fbc);
 
 
 /**
@@ -674,7 +674,7 @@ FbcSpeciesPlugin_getChargeAsDouble(SBasePlugin_t * fbc);
  */
 LIBSBML_EXTERN
 int
-FbcSpeciesPlugin_isSetCharge(SBasePlugin_t * fbc);
+FbcSpeciesPlugin_isSetCharge(FbcSBasePlugin_t * fbc);
 
 
 /**
@@ -693,7 +693,7 @@ FbcSpeciesPlugin_isSetCharge(SBasePlugin_t * fbc);
  */
 LIBSBML_EXTERN
 int
-FbcSpeciesPlugin_setCharge(SBasePlugin_t * fbc, int charge);
+FbcSpeciesPlugin_setCharge(FbcSBasePlugin_t * fbc, int charge);
 
 
 /**
@@ -712,7 +712,7 @@ FbcSpeciesPlugin_setCharge(SBasePlugin_t * fbc, int charge);
 */
 LIBSBML_EXTERN
 int
-FbcSpeciesPlugin_setChargeAsDouble(SBasePlugin_t * fbc, double charge);
+FbcSpeciesPlugin_setChargeAsDouble(FbcSBasePlugin_t * fbc, double charge);
 
 
 /**
@@ -728,7 +728,7 @@ FbcSpeciesPlugin_setChargeAsDouble(SBasePlugin_t * fbc, double charge);
  */
 LIBSBML_EXTERN
 int
-FbcSpeciesPlugin_unsetCharge(SBasePlugin_t * fbc);
+FbcSpeciesPlugin_unsetCharge(FbcSBasePlugin_t * fbc);
 
 
 /**
@@ -742,7 +742,7 @@ FbcSpeciesPlugin_unsetCharge(SBasePlugin_t * fbc);
  */
 LIBSBML_EXTERN
 char *
-FbcSpeciesPlugin_getChemicalFormula(SBasePlugin_t * fbc);
+FbcSpeciesPlugin_getChemicalFormula(FbcSBasePlugin_t * fbc);
 
 
 /**
@@ -758,7 +758,7 @@ FbcSpeciesPlugin_getChemicalFormula(SBasePlugin_t * fbc);
  */
 LIBSBML_EXTERN
 int
-FbcSpeciesPlugin_isSetChemicalFormula(SBasePlugin_t * fbc);
+FbcSpeciesPlugin_isSetChemicalFormula(FbcSBasePlugin_t * fbc);
 
 
 /**
@@ -778,7 +778,7 @@ FbcSpeciesPlugin_isSetChemicalFormula(SBasePlugin_t * fbc);
  */
 LIBSBML_EXTERN
 int
-FbcSpeciesPlugin_setChemicalFormula(SBasePlugin_t * fbc, const char * chemicalFormula);
+FbcSpeciesPlugin_setChemicalFormula(FbcSBasePlugin_t * fbc, const char * chemicalFormula);
 
 
 /**
@@ -794,7 +794,7 @@ FbcSpeciesPlugin_setChemicalFormula(SBasePlugin_t * fbc, const char * chemicalFo
  */
 LIBSBML_EXTERN
 int
-FbcSpeciesPlugin_unsetChemicalFormula(SBasePlugin_t * fbc);
+FbcSpeciesPlugin_unsetChemicalFormula(FbcSBasePlugin_t * fbc);
 
 END_C_DECLS
 LIBSBML_CPP_NAMESPACE_END


### PR DESCRIPTION
## Description

There is a mismatch between the signature of these functions in the header
files (here they use `SBasePlugin_t * fbc`) and their implementations (here they
use `FbcSBasePlugin_t * fbc`), as a result the C API does not correctly export
these functions because they get C++ name mangling.

The change was introduced in https://github.com/sbmlteam/libsbml/commit/64763c38de7cd8b151306e2a921368c4412cb38c without the corresponding change in the header file.

## Motivation and Context

Issue reported in https://github.com/sbmlteam/libsbml/issues/182#issuecomment-998879962.  See https://github.com/JuliaPackaging/Yggdrasil/pull/4100#issuecomment-998901265 for a confirmation that this patch fixes the issue.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Change in documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have updated all documentation necessary.
- [ ] I have checked spelling in (new) comments.

## Testing
- [X] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested -->

