### PR TITLE
add `WITH_THREADSAFE_PARSER` option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -315,6 +315,11 @@ option(WITH_XERCES   "Use the Xerces XML parser library."    OFF)
 # Use C++ namespace.
 option(WITH_CPP_NAMESPACE "Use a C++ namespace for libSBML."   OFF)
 
+option(WITH_THREADSAFE_PARSER "Use a threadsafe parser."   OFF)
+if(WITH_THREADSAFE_PARSER)
+    add_definitions(-DLIBSBML_WITH_THREADSAFE_PARSER=1)
+endif()
+
 # Generate documentation.
 option(WITH_DOXYGEN  "Generate documentation for libSBML using Doxygen."  OFF )
 # marks as advanced, so as to hide documentation generation

--- a/src/sbml/math/L3Parser.cpp
+++ b/src/sbml/math/L3Parser.cpp
@@ -110,6 +110,9 @@
 
 #include <sstream>
 #include <set>
+#ifdef LIBSBML_WITH_THREADSAFE_PARSER
+#include <mutex>
+#endif
 
 LIBSBML_CPP_NAMESPACE_USE
 LIBSBML_CPP_NAMESPACE_BEGIN
@@ -336,7 +339,9 @@ LIBSBML_CPP_NAMESPACE_END
 
   int sbml_yylex(void);
   L3Parser* l3p = NULL;
-
+#ifdef LIBSBML_WITH_THREADSAFE_PARSER
+  std::mutex l3p_mutex;
+#endif
 
 LIBSBML_CPP_NAMESPACE_BEGIN
 L3Parser* L3Parser_getInstance()
@@ -3263,6 +3268,9 @@ SBML_parseL3FormulaWithSettings (const char *formula, const L3ParserSettings_t *
     L3ParserSettings l3ps = l3p->getDefaultL3ParserSettings();
     return SBML_parseL3FormulaWithSettings(formula, &l3ps);
   }
+#ifdef LIBSBML_WITH_THREADSAFE_PARSER
+    const std::lock_guard<std::mutex> lock(l3p_mutex);
+#endif
   l3p->clear();
   l3p->setInput(formula);
   l3p->model = settings->getModel();

--- a/src/sbml/math/L3Parser.ypp
+++ b/src/sbml/math/L3Parser.ypp
@@ -91,6 +91,9 @@
 
 #include <sstream>
 #include <set>
+#ifdef LIBSBML_WITH_THREADSAFE_PARSER
+#include <mutex>
+#endif
 
 LIBSBML_CPP_NAMESPACE_USE
 LIBSBML_CPP_NAMESPACE_BEGIN
@@ -317,6 +320,9 @@ LIBSBML_CPP_NAMESPACE_END
 
   int sbml_yylex(void);
   L3Parser* l3p = NULL;
+#ifdef LIBSBML_WITH_THREADSAFE_PARSER
+  std::mutex l3p_mutex;
+#endif
 
 
 LIBSBML_CPP_NAMESPACE_BEGIN
@@ -1500,6 +1506,9 @@ SBML_parseL3FormulaWithSettings (const char *formula, const L3ParserSettings_t *
     L3ParserSettings l3ps = l3p->getDefaultL3ParserSettings();
     return SBML_parseL3FormulaWithSettings(formula, &l3ps);
   }
+#ifdef LIBSBML_WITH_THREADSAFE_PARSER
+    const std::lock_guard<std::mutex> lock(l3p_mutex);
+#endif
   l3p->clear();
   l3p->setInput(formula);
   l3p->model = settings->getModel();


### PR DESCRIPTION
## Description
- add CMake option `WITH_THREADSAFE_PARSER`, default to OFF
- if enabled
  - adds a mutex to allow `SBML_parseL3FormulaWithSettings` to be safely called from multiple threads
  - this requires c++11 or greater

## Motivation and Context
fixes #197 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Change in documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have updated all documentation necessary.
- [ ] I have checked spelling in (new) comments.

## Testing
- [X] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested -->

