### PR TITLE
remove default java compatibility

### DIFF
--- a/examples/java/CMakeLists.txt
+++ b/examples/java/CMakeLists.txt
@@ -35,6 +35,9 @@ file(TO_NATIVE_PATH ${CMAKE_CURRENT_BINARY_DIR} CURRENT_BIN)
 file(TO_NATIVE_PATH ${CMAKE_CURRENT_BINARY_DIR}/../../src/bindings/java/libsbmlj.jar CURRENT_JAR )
 file(TO_NATIVE_PATH $<TARGET_FILE_DIR:binding_java_lib> LIBRARY_PATH)
 
+if (JAVA_COMPATIBILITY)
+SET(COMPAT_ARGS "-source ${JAVA_COMPATIBILITY} -target ${JAVA_COMPATIBILITY}")
+endif()
 
 foreach(file 
     addCustomValidator
@@ -76,8 +79,7 @@ add_custom_command(
     COMMAND "${Java_JAVAC_EXECUTABLE}"
     ARGS -cp ".${FILE_SEP}\"${CURRENT_JAR}\"${FILE_SEP}${CMAKE_CURRENT_SOURCE_DIR}"
         ${CURRENT_FILE}
-        -source "${JAVA_COMPATIBILITY}"
-        -target "${JAVA_COMPATIBILITY}"
+        ${COMPAT_ARGS}
         -d ${CMAKE_CURRENT_BINARY_DIR}
     MAIN_DEPENDENCY "${CMAKE_CURRENT_SOURCE_DIR}/../../src/bindings/java/local.i"
     WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"

--- a/examples/java/arrays/CMakeLists.txt
+++ b/examples/java/arrays/CMakeLists.txt
@@ -6,6 +6,10 @@
 
 find_package(Java COMPONENTS Development REQUIRED)
 
+if (JAVA_COMPATIBILITY)
+SET(COMPAT_ARGS "-source ${JAVA_COMPATIBILITY} -target ${JAVA_COMPATIBILITY}")
+endif()
+
 foreach(file 
 		createArrays1
 		createArrays2
@@ -20,8 +24,7 @@ foreach(file
 		COMMAND "${Java_JAVAC_EXECUTABLE}"
 		ARGS -cp ".${FILE_SEP}\"${CURRENT_JAR}\"${FILE_SEP}${CMAKE_CURRENT_SOURCE_DIR}"
 			 ${CURRENT_FILE}
-			 -source "${JAVA_COMPATIBILITY}"
-			 -target "${JAVA_COMPATIBILITY}"
+			 ${COMPAT_ARGS}
 			 -d ${CMAKE_CURRENT_BINARY_DIR}
 		MAIN_DEPENDENCY "${CMAKE_CURRENT_SOURCE_DIR}/../../../src/bindings/java/local.i"
 		WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"

--- a/examples/java/comp/CMakeLists.txt
+++ b/examples/java/comp/CMakeLists.txt
@@ -31,6 +31,10 @@
 
 find_package(Java COMPONENTS Development REQUIRED)
 
+if (JAVA_COMPATIBILITY)
+SET(COMPAT_ARGS "-source ${JAVA_COMPATIBILITY} -target ${JAVA_COMPATIBILITY}")
+endif()
+
 foreach(file 
 		flattenModel
 		customResolver
@@ -45,8 +49,7 @@ foreach(file
 		COMMAND "${Java_JAVAC_EXECUTABLE}"
 		ARGS -cp ".${FILE_SEP}\"${CURRENT_JAR}\"${FILE_SEP}${CMAKE_CURRENT_SOURCE_DIR}"
 			 ${CURRENT_FILE}
-			 -source "${JAVA_COMPATIBILITY}"
-			 -target "${JAVA_COMPATIBILITY}"
+			 ${COMPAT_ARGS}
 			 -d ${CMAKE_CURRENT_BINARY_DIR}
 		MAIN_DEPENDENCY "${CMAKE_CURRENT_SOURCE_DIR}/../../../src/bindings/java/local.i"
 		WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"

--- a/examples/java/distrib/CMakeLists.txt
+++ b/examples/java/distrib/CMakeLists.txt
@@ -6,6 +6,10 @@
 
 find_package(Java COMPONENTS Development REQUIRED)
 
+if (JAVA_COMPATIBILITY)
+SET(COMPAT_ARGS "-source ${JAVA_COMPATIBILITY} -target ${JAVA_COMPATIBILITY}")
+endif()
+
 foreach(file 
 	
 	createNormalExample
@@ -22,8 +26,7 @@ foreach(file
 		COMMAND "${Java_JAVAC_EXECUTABLE}"
 		ARGS -cp ".${FILE_SEP}\"${CURRENT_JAR}\"${FILE_SEP}${CMAKE_CURRENT_SOURCE_DIR}"
 			 ${CURRENT_FILE}
-			 -source "${JAVA_COMPATIBILITY}"
-			 -target "${JAVA_COMPATIBILITY}"
+			 ${COMPAT_ARGS}
 			 -d ${CMAKE_CURRENT_BINARY_DIR}
 		MAIN_DEPENDENCY "${CMAKE_CURRENT_SOURCE_DIR}/../../../src/bindings/java/local.i"
 		WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"

--- a/examples/java/fbc/CMakeLists.txt
+++ b/examples/java/fbc/CMakeLists.txt
@@ -31,6 +31,10 @@
 
 find_package(Java COMPONENTS Development REQUIRED)
 
+if (JAVA_COMPATIBILITY)
+SET(COMPAT_ARGS "-source ${JAVA_COMPATIBILITY} -target ${JAVA_COMPATIBILITY}")
+endif()
+
 foreach(file 
 		convertCobraToFbc
 		convertFbcToCobra
@@ -46,8 +50,7 @@ foreach(file
 		COMMAND "${Java_JAVAC_EXECUTABLE}"
 		ARGS -cp ".${FILE_SEP}\"${CURRENT_JAR}\"${FILE_SEP}${CMAKE_CURRENT_SOURCE_DIR}"
 			 ${CURRENT_FILE}
-			 -source "${JAVA_COMPATIBILITY}"
-			 -target "${JAVA_COMPATIBILITY}"
+			 ${COMPAT_ARGS}
 			 -d ${CMAKE_CURRENT_BINARY_DIR}
 		MAIN_DEPENDENCY "${CMAKE_CURRENT_SOURCE_DIR}/../../../src/bindings/java/local.i"
 		WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"

--- a/examples/java/groups/CMakeLists.txt
+++ b/examples/java/groups/CMakeLists.txt
@@ -6,6 +6,10 @@
 
 find_package(Java COMPONENTS Development REQUIRED)
 
+if (JAVA_COMPATIBILITY)
+SET(COMPAT_ARGS "-source ${JAVA_COMPATIBILITY} -target ${JAVA_COMPATIBILITY}")
+endif()
+
 foreach(file 
 		groups_example1
 		)
@@ -19,8 +23,7 @@ foreach(file
 		COMMAND "${Java_JAVAC_EXECUTABLE}"
 		ARGS -cp ".${FILE_SEP}\"${CURRENT_JAR}\"${FILE_SEP}${CMAKE_CURRENT_SOURCE_DIR}"
 			 ${CURRENT_FILE}
-			 -source "${JAVA_COMPATIBILITY}"
-			 -target "${JAVA_COMPATIBILITY}"
+			 ${COMPAT_ARGS}
 			 -d ${CMAKE_CURRENT_BINARY_DIR}
 		MAIN_DEPENDENCY "${CMAKE_CURRENT_SOURCE_DIR}/../../../src/bindings/java/local.i"
 		WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"

--- a/examples/java/layout/CMakeLists.txt
+++ b/examples/java/layout/CMakeLists.txt
@@ -31,6 +31,10 @@
 
 find_package(Java COMPONENTS Development REQUIRED)
 
+if (JAVA_COMPATIBILITY)
+SET(COMPAT_ARGS "-source ${JAVA_COMPATIBILITY} -target ${JAVA_COMPATIBILITY}")
+endif()
+
 foreach(file 
 		layout_example1
 		layout_example1_L3
@@ -46,8 +50,7 @@ foreach(file
 		COMMAND "${Java_JAVAC_EXECUTABLE}"
 		ARGS -cp ".${FILE_SEP}\"${CURRENT_JAR}\"${FILE_SEP}${CMAKE_CURRENT_SOURCE_DIR}"
 			 ${CURRENT_FILE}
-			 -source "${JAVA_COMPATIBILITY}"
-			 -target "${JAVA_COMPATIBILITY}"
+			 ${COMPAT_ARGS}
 			 -d ${CMAKE_CURRENT_BINARY_DIR}
 		MAIN_DEPENDENCY "${CMAKE_CURRENT_SOURCE_DIR}/../../../src/bindings/java/local.i"
 		WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"

--- a/examples/java/multi/CMakeLists.txt
+++ b/examples/java/multi/CMakeLists.txt
@@ -31,6 +31,10 @@
 
 find_package(Java COMPONENTS Development REQUIRED)
 
+if (JAVA_COMPATIBILITY)
+SET(COMPAT_ARGS "-source ${JAVA_COMPATIBILITY} -target ${JAVA_COMPATIBILITY}")
+endif()
+
 foreach(file 
 		multi_example1
 		multi_example2
@@ -46,8 +50,7 @@ foreach(file
 		COMMAND "${Java_JAVAC_EXECUTABLE}"
 		ARGS -cp ".${FILE_SEP}\"${CURRENT_JAR}\"${FILE_SEP}${CMAKE_CURRENT_SOURCE_DIR}"
 			 ${CURRENT_FILE}
-			 -source "${JAVA_COMPATIBILITY}"
-			 -target "${JAVA_COMPATIBILITY}"
+			 ${COMPAT_ARGS}
 			 -d ${CMAKE_CURRENT_BINARY_DIR}
 		MAIN_DEPENDENCY "${CMAKE_CURRENT_SOURCE_DIR}/../../../src/bindings/java/local.i"
 		WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"

--- a/examples/java/qual/CMakeLists.txt
+++ b/examples/java/qual/CMakeLists.txt
@@ -31,6 +31,10 @@
 
 find_package(Java COMPONENTS Development REQUIRED)
 
+if (JAVA_COMPATIBILITY)
+SET(COMPAT_ARGS "-source ${JAVA_COMPATIBILITY} -target ${JAVA_COMPATIBILITY}")
+endif()
+
 foreach(file 
 		qual_example1
 		)
@@ -44,8 +48,7 @@ foreach(file
 		COMMAND "${Java_JAVAC_EXECUTABLE}"
 		ARGS -cp ".${FILE_SEP}\"${CURRENT_JAR}\"${FILE_SEP}${CMAKE_CURRENT_SOURCE_DIR}"
 			 ${CURRENT_FILE}
-			 -source "${JAVA_COMPATIBILITY}"
-			 -target "${JAVA_COMPATIBILITY}"
+			 ${COMPAT_ARGS}
 			 -d ${CMAKE_CURRENT_BINARY_DIR}
 		MAIN_DEPENDENCY "${CMAKE_CURRENT_SOURCE_DIR}/../../../src/bindings/java/local.i"
 		WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"

--- a/examples/java/render/CMakeLists.txt
+++ b/examples/java/render/CMakeLists.txt
@@ -6,6 +6,10 @@
 
 find_package(Java COMPONENTS Development REQUIRED)
 
+if (JAVA_COMPATIBILITY)
+SET(COMPAT_ARGS "-source ${JAVA_COMPATIBILITY} -target ${JAVA_COMPATIBILITY}")
+endif()
+
 foreach(file 
 		addRenderInformation
 		printRenderInformation
@@ -21,8 +25,7 @@ foreach(file
 		COMMAND "${Java_JAVAC_EXECUTABLE}"
 		ARGS -cp ".${FILE_SEP}\"${CURRENT_JAR}\"${FILE_SEP}${CMAKE_CURRENT_SOURCE_DIR}"
 			 ${CURRENT_FILE}
-			 -source "${JAVA_COMPATIBILITY}"
-			 -target "${JAVA_COMPATIBILITY}"
+			 ${COMPAT_ARGS}
 			 -d ${CMAKE_CURRENT_BINARY_DIR}
 		MAIN_DEPENDENCY "${CMAKE_CURRENT_SOURCE_DIR}/../../../src/bindings/java/local.i"
 		WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"

--- a/examples/java/spatial/CMakeLists.txt
+++ b/examples/java/spatial/CMakeLists.txt
@@ -31,6 +31,10 @@
 
 find_package(Java COMPONENTS Development REQUIRED)
 
+if (JAVA_COMPATIBILITY)
+SET(COMPAT_ARGS "-source ${JAVA_COMPATIBILITY} -target ${JAVA_COMPATIBILITY}")
+endif()
+
 foreach(file 
 		spatial_example1
 		)
@@ -44,8 +48,7 @@ foreach(file
 		COMMAND "${Java_JAVAC_EXECUTABLE}"
 		ARGS -cp ".${FILE_SEP}\"${CURRENT_JAR}\"${FILE_SEP}${CMAKE_CURRENT_SOURCE_DIR}"
 			 ${CURRENT_FILE}
-			 -source "${JAVA_COMPATIBILITY}"
-			 -target "${JAVA_COMPATIBILITY}"
+			 ${COMPAT_ARGS}
 			 -d ${CMAKE_CURRENT_BINARY_DIR}
 		MAIN_DEPENDENCY "${CMAKE_CURRENT_SOURCE_DIR}/../../../src/bindings/java/local.i"
 		WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"

--- a/src/bindings/java/CMakeLists.txt
+++ b/src/bindings/java/CMakeLists.txt
@@ -74,8 +74,8 @@ if (NOT EXISTS "${PYTHON_EXECUTABLE}")
 endif()
 
 
-set(JAVA_COMPATIBILITY "1.6" CACHE STRING
-  "Specify the source and target compatibility for the libsbml Java bindings. Leave empty to remove the parameter altogether.")
+set(JAVA_COMPATIBILITY "" CACHE STRING
+  "Specify the source and target compatibility for the libsbml Java bindings (for example 1.7). Leave empty to remove the parameter altogether.")
 
 
 ####################################################################


### PR DESCRIPTION

## Description
We used to force compatibility of the compiled class / jars with Java 1.6, which is no longer supported (on newer java versions). The default should be to leave it to the user.

## Motivation and Context
fixes #200

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Change in documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have updated all documentation necessary.
- [ ] I have checked spelling in (new) comments.

## Testing
- [X] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested -->

