### PR TITLE
Independent cmake modules

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -161,6 +161,9 @@ include(CPack)
 # add local modules to module path
 set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules;${CMAKE_MODULE_PATH}")
 
+# install find modules, so they can readily be used by others
+file(GLOB find_modules "${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules/Find*.cmake")
+install(FILES ${find_modules} DESTINATION share/cmake/Modules)
 
 ###############################################################################
 #

--- a/CMakeModules/FindBZ2.cmake
+++ b/CMakeModules/FindBZ2.cmake
@@ -1,9 +1,12 @@
+string(TOUPPER ${PROJECT_NAME} _UPPER_PROJECT_NAME)
+set(_PROJECT_DEPENDENCY_DIR ${_UPPER_PROJECT_NAME}_DEPENDENCY_DIR)
+
 if (NOT LIBBZ_LIBRARY)
 find_library(LIBBZ_LIBRARY
     NAMES bzip2.lib bz2 libbz2.lib
     PATHS /usr/lib /usr/local/lib
           ${CMAKE_OSX_SYSROOT}/usr/lib
-          ${LIBSBML_DEPENDENCY_DIR}/lib
+          ${${_PROJECT_DEPENDENCY_DIR}}/lib
           NO_DEFAULT_PATH
           NO_CMAKE_ENVIRONMENT_PATH
           NO_CMAKE_PATH
@@ -19,7 +22,7 @@ find_library(LIBBZ_LIBRARY
     NAMES bzip2.lib bz2 libbz2.lib
     PATHS /usr/lib /usr/local/lib
           ${CMAKE_OSX_SYSROOT}/usr/lib
-          ${LIBSBML_DEPENDENCY_DIR}/lib
+          ${${_PROJECT_DEPENDENCY_DIR}}/lib
     DOC "The file name of the bzip2 library."
 )
 endif()
@@ -29,7 +32,7 @@ find_path(LIBBZ_INCLUDE_DIR
     NAMES bzlib.h bzip2/bzlib.h
     PATHS ${CMAKE_OSX_SYSROOT}/usr/include
           /usr/include /usr/local/include
-          ${LIBSBML_DEPENDENCY_DIR}/include
+          ${${_PROJECT_DEPENDENCY_DIR}}/include
           NO_DEFAULT_PATH
     DOC "The directory containing the bzip2 include files."
     )
@@ -40,7 +43,7 @@ if (NOT LIBBZ_INCLUDE_DIR)
     NAMES bzlib.h bzip2/bzlib.h
     PATHS ${CMAKE_OSX_SYSROOT}/usr/include
           /usr/include /usr/local/include
-          ${LIBSBML_DEPENDENCY_DIR}/include
+          ${${_PROJECT_DEPENDENCY_DIR}}/include
     DOC "The directory containing the bzip2 include files."
           )
 endif()

--- a/CMakeModules/FindCHECK.cmake
+++ b/CMakeModules/FindCHECK.cmake
@@ -1,7 +1,9 @@
+string(TOUPPER ${PROJECT_NAME} _UPPER_PROJECT_NAME)
+set(_PROJECT_DEPENDENCY_DIR ${_UPPER_PROJECT_NAME}_DEPENDENCY_DIR)
 
 find_library(LIBCHECK_LIBRARY
         NAMES check libcheck
-        PATHS /usr/lib /usr/local/lib ${LIBSBML_DEPENDENCY_DIR}/lib
+        PATHS /usr/lib /usr/local/lib ${${_PROJECT_DEPENDENCY_DIR}}/lib
         DOC "The file name of the libcheck library."
 )
 
@@ -9,7 +11,7 @@ find_path(LIBCHECK_INCLUDE_DIR
     NAMES  check.h
     PATHS  /usr/include 
            /usr/local/include  
-           ${LIBSBML_DEPENDENCY_DIR}/include
+           ${${_PROJECT_DEPENDENCY_DIR}}/include
            ~/Library/Frameworks
            /Library/Frameworks
            /sw/include        # Fink

--- a/CMakeModules/FindEXPAT.cmake
+++ b/CMakeModules/FindEXPAT.cmake
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 - 2020 by Pedro Mendes, Rector and Visitors of the 
+# Copyright (C) 2019 - 2022 by Pedro Mendes, Rector and Visitors of the 
 # University of Virginia, University of Heidelberg, and University 
 # of Connecticut School of Medicine. 
 # All rights reserved. 
@@ -18,7 +18,7 @@
 # Once done this will define
 #
 #  EXPAT_FOUND       - system has Expat
-#  EXPAT_LIBRARIES   - Link these to use Expat
+#  EXPAT_LIBRARY   - Link these to use Expat
 #  EXPAT_INCLUDE_DIR - Include directory for using Expat
 #  EXPAT_DEFINITIONS - Compiler switches required for using Expat
 #
@@ -30,24 +30,26 @@ MACRO (FIND_EXPAT)
 
 ENDMACRO ()
 
+string(TOUPPER ${PROJECT_NAME} _UPPER_PROJECT_NAME)
+set(_PROJECT_DEPENDENCY_DIR ${_UPPER_PROJECT_NAME}_DEPENDENCY_DIR)
 
 
 # Check if we have cached results in case the last round was successful.
-if (NOT (EXPAT_INCLUDE_DIR AND EXPAT_LIBRARIES) OR NOT EXPAT_FOUND)
+if (NOT (EXPAT_INCLUDE_DIR AND EXPAT_LIBRARY) OR NOT EXPAT_FOUND)
 
     set(EXPAT_LDFLAGS)
-  
+	
     find_path(EXPAT_INCLUDE_DIR expat.h
-      PATHS $ENV{EXPAT_DIR}/include
-            $ENV{EXPAT_DIR}
-            ${LIBSBML_DEPENDENCY_DIR}/include
-            ~/Library/Frameworks
-            /Library/Frameworks
-            /sw/include        # Fink
-            /opt/local/include # MacPorts
-            /opt/csw/include   # Blastwave
-            /opt/include
-            /usr/freeware/include
+	    PATHS $ENV{EXPAT_DIR}/include
+	          $ENV{EXPAT_DIR}
+              ${${_PROJECT_DEPENDENCY_DIR}}/include
+	          ~/Library/Frameworks
+	          /Library/Frameworks
+	          /sw/include        # Fink
+	          /opt/local/include # MacPorts
+	          /opt/csw/include   # Blastwave
+	          /opt/include
+	          /usr/freeware/include
              NO_DEFAULT_PATH)
 
     if (NOT EXPAT_INCLUDE_DIR)
@@ -55,51 +57,63 @@ if (NOT (EXPAT_INCLUDE_DIR AND EXPAT_LIBRARIES) OR NOT EXPAT_FOUND)
     endif ()
 
     find_library(EXPAT_LIBRARY 
-      NAMES expat
-      PATHS $ENV{EXPAT_DIR}/lib
-            $ENV{EXPAT_DIR}/lib-dbg
-            $ENV{EXPAT_DIR}
-            ${LIBSBML_DEPENDENCY_DIR}/${CMAKE_INSTALL_LIBDIR}
-            ${LIBSBML_DEPENDENCY_DIR}/lib
-            ${COPASI_DEPENDENCY_DIR}/${CMAKE_INSTALL_LIBDIR}
-            ${COPASI_DEPENDENCY_DIR}
-            ~/Library/Frameworks
-            /Library/Frameworks
-            /sw/lib        # Fink
-            /opt/local/lib # MacPorts
-            /opt/csw/lib   # Blastwave
-            /opt/lib
-            /usr/freeware/lib64
+	    NAMES expat
+	    PATHS $ENV{EXPAT_DIR}/${CMAKE_INSTALL_LIBDIR}
+	          $ENV{EXPAT_DIR}/lib-dbg
+	          $ENV{EXPAT_DIR}
+              ${${_PROJECT_DEPENDENCY_DIR}}/${CMAKE_INSTALL_LIBDIR}
+              ${${_PROJECT_DEPENDENCY_DIR}}
+	          ~/Library/Frameworks
+	          /Library/Frameworks
+	          /sw/lib        # Fink
+	          /opt/local/lib # MacPorts
+	          /opt/csw/lib   # Blastwave
+	          /opt/lib
+	          /usr/freeware/lib64
              NO_DEFAULT_PATH)
 
     if (NOT EXPAT_LIBRARY)
         find_library(EXPAT_LIBRARY NAMES expat)
     endif ()
 
-    if (EXPAT_INCLUDE_DIR AND EXISTS "${EXPAT_INCLUDE_DIR}/expat.h")
-    file(STRINGS "${EXPAT_INCLUDE_DIR}/expat.h" expat_version_str
-         REGEX "^#[\t ]*define[\t ]+XML_(MAJOR|MINOR|MICRO)_VERSION[\t ]+[0-9]+$")
+    if (NOT WIN32)
+        find_package(PkgConfig)
+        pkg_check_modules(PC_EXPAT QUIET expat)
 
-    unset(EXPAT_VERSION)
-    foreach(VPART MAJOR MINOR MICRO)
-        foreach(VLINE ${expat_version_str})
-            if(VLINE MATCHES "^#[\t ]*define[\t ]+XML_${VPART}_VERSION[\t ]+([0-9]+)$")
-                set(EXPAT_VERSION_PART "${CMAKE_MATCH_1}")
-                if(EXPAT_VERSION)
-                    string(APPEND EXPAT_VERSION ".${EXPAT_VERSION_PART}")
-                else()
-                    set(EXPAT_VERSION "${EXPAT_VERSION_PART}")
-                endif()
-            endif()
-        endforeach()
-    endforeach()
-    endif ()
+        message(VERBOSE "${PC_EXPAT_STATIC_LDFLAGS}")
+
+        if (PC_EXPAT_FOUND)
+            set(EXPAT_DEFINITIONS ${PC_EXPAT_CFLAGS_OTHER})
+            set(EXPAT_VERSION ${PC_EXPAT_VERSION} CACHE STRING "Expat Version found" )
+        endif (PC_EXPAT_FOUND)
+    endif (NOT WIN32)
     
     mark_as_advanced(EXPAT_INCLUDE_DIR EXPAT_LIBRARY)
 
 endif () # Check for cached values
 
-# create a target to link against
+
+if (EXPAT_INCLUDE_DIR AND EXISTS "${EXPAT_INCLUDE_DIR}/expat.h")
+file(STRINGS "${EXPAT_INCLUDE_DIR}/expat.h" expat_version_str
+     REGEX "^#[\t ]*define[\t ]+XML_(MAJOR|MINOR|MICRO)_VERSION[\t ]+[0-9]+$")
+
+unset(EXPAT_VERSION)
+foreach(VPART MAJOR MINOR MICRO)
+    foreach(VLINE ${expat_version_str})
+        if(VLINE MATCHES "^#[\t ]*define[\t ]+XML_${VPART}_VERSION[\t ]+([0-9]+)$")
+            set(EXPAT_VERSION_PART "${CMAKE_MATCH_1}")
+            if(EXPAT_VERSION)
+                string(APPEND EXPAT_VERSION ".${EXPAT_VERSION_PART}")
+            else()
+                set(EXPAT_VERSION "${EXPAT_VERSION_PART}")
+            endif()
+        endif()
+    endforeach()
+endforeach()
+endif ()
+
+
+# create an expat target to link against
 if(NOT TARGET EXPAT::EXPAT)
   add_library(EXPAT::EXPAT UNKNOWN IMPORTED)
   set_target_properties(EXPAT::EXPAT PROPERTIES
@@ -107,7 +121,6 @@ if(NOT TARGET EXPAT::EXPAT)
     IMPORTED_LOCATION "${EXPAT_LIBRARY}"
     INTERFACE_INCLUDE_DIRECTORIES "${EXPAT_INCLUDE_DIR}")
 endif()
-
 
 include(FindPackageHandleStandardArgs)
 

--- a/CMakeModules/FindLIBXML.cmake
+++ b/CMakeModules/FindLIBXML.cmake
@@ -1,8 +1,11 @@
+string(TOUPPER ${PROJECT_NAME} _UPPER_PROJECT_NAME)
+set(_PROJECT_DEPENDENCY_DIR ${_UPPER_PROJECT_NAME}_DEPENDENCY_DIR)
+
 if (NOT LIBXML_LIBRARY)
     find_library(LIBXML_LIBRARY
         NAMES libxml2.lib xml2
         PATHS /usr/lib /usr/local/lib
-              ${LIBSBML_DEPENDENCY_DIR}/lib
+              ${${_PROJECT_DEPENDENCY_DIR}}/lib
         DOC "The file name of the libxml2 library."
                 )
   endif()
@@ -10,7 +13,7 @@ if (NOT LIBXML_LIBRARY)
   if (NOT LIBXML_INCLUDE_DIR)
     find_path(LIBXML_INCLUDE_DIR
         NAMES libxml/parser.h
-        PATHS ${LIBSBML_DEPENDENCY_DIR}/include
+        PATHS ${${_PROJECT_DEPENDENCY_DIR}}/include
               /usr/include /usr/local/include
               /usr/include/libxml2
               ${CMAKE_OSX_SYSROOT}/usr/include/libxml2
@@ -35,7 +38,7 @@ find_library(LIBICONV_LIBRARY
 NAMES libiconv.lib iconv.lib iconv
 PATHS /usr/lib /usr/local/lib
         ${CMAKE_OSX_SYSROOT}/usr/lib
-        ${LIBSBML_DEPENDENCY_DIR}/lib
+        ${${_PROJECT_DEPENDENCY_DIR}}/lib
 DOC "The file name of the libiconv library."
 )
 

--- a/CMakeModules/FindXERCES.cmake
+++ b/CMakeModules/FindXERCES.cmake
@@ -1,7 +1,10 @@
+string(TOUPPER ${PROJECT_NAME} _UPPER_PROJECT_NAME)
+set(_PROJECT_DEPENDENCY_DIR ${_UPPER_PROJECT_NAME}_DEPENDENCY_DIR)
+
 find_library(XERCES_LIBRARY
 NAMES xerces-c_3.lib xerces-c
 PATHS /usr/lib /usr/local/lib
-      ${LIBSBML_DEPENDENCY_DIR}/lib
+      ${${_PROJECT_DEPENDENCY_DIR}}/lib
 DOC "The file name of the Xerces library."
         )
 
@@ -11,7 +14,7 @@ PATHS /usr/include /usr/local/include
       ${CMAKE_OSX_SYSROOT}/usr/include/xercesc
       /usr/include/xercesc
       /usr/local/include/xercesc
-      ${LIBSBML_DEPENDENCY_DIR}/include
+      ${${_PROJECT_DEPENDENCY_DIR}}/include
 DOC "The directory containing the Xerces include files."
       )
 

--- a/CMakeModules/FindZLIB.cmake
+++ b/CMakeModules/FindZLIB.cmake
@@ -1,16 +1,6 @@
-# Copyright (C) 2019 - 2020 by Pedro Mendes, Rector and Visitors of the 
+# Copyright (C) 2022 by Pedro Mendes, Rector and Visitors of the 
 # University of Virginia, University of Heidelberg, and University 
 # of Connecticut School of Medicine. 
-# All rights reserved. 
-
-# Copyright (C) 2017 - 2018 by Pedro Mendes, Virginia Tech Intellectual 
-# Properties, Inc., University of Heidelberg, and University of 
-# of Connecticut School of Medicine. 
-# All rights reserved. 
-
-# Copyright (C) 2013 - 2016 by Pedro Mendes, Virginia Tech Intellectual 
-# Properties, Inc., University of Heidelberg, and The University 
-# of Manchester. 
 # All rights reserved. 
 
 # - Try to find the Zlib XML parsing library 
@@ -30,25 +20,25 @@ MACRO (FIND_ZLIB)
 
 ENDMACRO ()
 
-
+string(TOUPPER ${PROJECT_NAME} _UPPER_PROJECT_NAME)
+set(_PROJECT_DEPENDENCY_DIR ${_UPPER_PROJECT_NAME}_DEPENDENCY_DIR)
 
 # Check if we have cached results in case the last round was successful.
-if (NOT (ZLIB_INCLUDE_DIR AND ZLIB_LIBRARIES) OR NOT ZLIB_FOUND)
+if (NOT (ZLIB_INCLUDE_DIR AND ZLIB_LIBRARY) OR NOT ZLIB_FOUND)
 
     set(ZLIB_LDFLAGS)
-  
+	
     find_path(ZLIB_INCLUDE_DIR zlib.h zlib/zlib.h
-      PATHS $ENV{ZLIB_DIR}/include
-            $ENV{ZLIB_DIR}
-            ${COPASI_DEPENDENCY_DIR}/include
-            ${COMBINE_DEPENDENCY_DIR}/include
-            ~/Library/Frameworks
-            /Library/Frameworks
-            /sw/include        # Fink
-            /opt/local/include # MacPorts
-            /opt/csw/include   # Blastwave
-            /opt/include
-            /usr/freeware/include
+	    PATHS $ENV{ZLIB_DIR}/include
+	          $ENV{ZLIB_DIR}
+            ${${_PROJECT_DEPENDENCY_DIR}}/include
+	          ~/Library/Frameworks
+	          /Library/Frameworks
+	          /sw/include        # Fink
+	          /opt/local/include # MacPorts
+	          /opt/csw/include   # Blastwave
+	          /opt/include
+	          /usr/freeware/include
             NO_DEFAULT_PATH)
 
     if (NOT ZLIB_INCLUDE_DIR)
@@ -56,20 +46,19 @@ if (NOT (ZLIB_INCLUDE_DIR AND ZLIB_LIBRARIES) OR NOT ZLIB_FOUND)
     endif ()
 
     find_library(ZLIB_LIBRARY 
-      NAMES zdll.lib z zlib.lib libzlib zlib libzlib.a 
-      PATHS $ENV{ZLIB_DIR}/lib
-            $ENV{ZLIB_DIR}/lib-dbg
-            $ENV{ZLIB_DIR}
-            ${COMBINE_DEPENDENCY_DIR}/${CMAKE_INSTALL_LIBDIR}
-            ${COPASI_DEPENDENCY_DIR}/${CMAKE_INSTALL_LIBDIR}
-            ${COPASI_DEPENDENCY_DIR}
-            ~/Library/Frameworks
-            /Library/Frameworks
-            /sw/lib        # Fink
-            /opt/local/lib # MacPorts
-            /opt/csw/lib   # Blastwave
-            /opt/lib
-            /usr/freeware/lib64
+	    NAMES zdll.lib z zlib.lib libzlib zlib libzlib.a 
+	    PATHS $ENV{ZLIB_DIR}/lib
+	          $ENV{ZLIB_DIR}/lib-dbg
+	          $ENV{ZLIB_DIR}
+            ${${_PROJECT_DEPENDENCY_DIR}}/${CMAKE_INSTALL_LIBDIR}
+            ${${_PROJECT_DEPENDENCY_DIR}}
+	          ~/Library/Frameworks
+	          /Library/Frameworks
+	          /sw/lib        # Fink
+	          /opt/local/lib # MacPorts
+	          /opt/csw/lib   # Blastwave
+	          /opt/lib
+	          /usr/freeware/lib64
              NO_DEFAULT_PATH)
 
     if (NOT ZLIB_LIBRARY)
@@ -80,7 +69,7 @@ if (NOT (ZLIB_INCLUDE_DIR AND ZLIB_LIBRARIES) OR NOT ZLIB_FOUND)
         find_package(PkgConfig)
         pkg_check_modules(PC_ZLIB QUIET zlib)
 
-        message(STATUS "${PC_ZLIB_STATIC_LDFLAGS}")
+        message(VERBOSE "${PC_ZLIB_STATIC_LDFLAGS}")
 
         if (PC_ZLIB_FOUND)
             set(ZLIB_DEFINITIONS ${PC_ZLIB_CFLAGS_OTHER})


### PR DESCRIPTION
## Description
The find scripts we introduced work really nice. However, every library consuming libSBML would have to use the same find scripts. What is more, since we hard coded `LIBSBML_DEPENDENCY_DIR`, every other consumer would now have to define this variable. 

This PR does 2 things: 

* the dependency dir variable is computed automatically from the PROJECT_NAME defined. So consumers can just define For example a `LIBSEDML_DEPENDENCY_DIR` variable for the LIBSEDML project. And the values will be read. 
* all find modules are installed into share/cmake/Modules

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here, using the 'fixes #<issue>' syntax. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Change in documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have updated all documentation necessary.
- [ ] I have checked spelling in (new) comments.

## Testing
- [X] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested -->

