### PR TITLE
chore: clarify getPackageRequired's doc

### DIFF
--- a/src/sbml/SBMLDocument.h
+++ b/src/sbml/SBMLDocument.h
@@ -1391,7 +1391,10 @@ public:
    * prefix will be written when writing elements defined in the given
    * package extension if @c true is given as second argument.
    *
-   * @param package the name or URI of the package extension.
+   * @param package the name or URI of the package extension. Passing a package
+   * name (or "nickname") is only supported if libSBML was compiled with support for
+   * that particular package, see the installation documentation for more details.
+   * Passing the package URI is supported regardless of the installation configuration.
    * @param flag boolean value to indicate whether to write a namespace
    * prefix.
    *
@@ -1410,7 +1413,10 @@ public:
    * This basically checks if the attribute
    * <code>xmlns=&quot;...&quot;</code> is present.
    *   
-   * @param package the name or URI of the package extension.
+   * @param package the name or URI of the package extension. Passing a package
+   * name (or "nickname") is only supported if libSBML was compiled with support for
+   * that particular package, see the installation documentation for more details.
+   * Passing the package URI is supported regardless of the installation configuration.
    *
    * @return a boolean indicating whether the given package's default namespace is enabled.
    */
@@ -1421,7 +1427,10 @@ public:
    * Sets the <code>required</code> attribute value of the given package
    * extension.
    *
-   * @param package the name or URI of the package extension.
+   * @param package the name or URI of the package extension. Passing a package
+   * name (or "nickname") is only supported if libSBML was compiled with support for
+   * that particular package, see the installation documentation for more details.
+   * Passing the package URI is supported regardless of the installation configuration.
    * @param flag Boolean value indicating whether the package is required.
    *
    * @copydetails doc_returns_success_code
@@ -1435,7 +1444,10 @@ public:
    * Returns the <code>required</code> attribute of the given package
    * extension.
    *
-   * @param package the name or URI of the package extension.
+   * @param package the name or URI of the package extension. Passing a package
+   * name (or "nickname") is only supported if libSBML was compiled with support for
+   * that particular package, see the installation documentation for more details.
+   * Passing the package URI is supported regardless of the installation configuration.
    *
    * @return Boolean flag indicating whether the package is flagged as
    * being required.
@@ -1447,7 +1459,10 @@ public:
    * Returns @c true if the required attribute of the given package extension
    * is defined, otherwise returns @c false.
    *
-   * @param package the name or URI of the package extension.
+   * @param package the name or URI of the package extension. Passing a package
+   * name (or "nickname") is only supported if libSBML was compiled with support for
+   * that particular package, see the installation documentation for more details.
+   * Passing the package URI is supported regardless of the installation configuration.
    *
    * @return a Boolean indicating whether the package's 'required' flag is set.
    */
@@ -1490,7 +1505,10 @@ public:
    * Sets the value of the <code>required</code> attribute for the given
    * package.
    *
-   * @param package the name or URI of the package extension.
+   * @param package the name or URI of the package extension. Passing a package
+   * name (or "nickname") is only supported if libSBML was compiled with support for
+   * that particular package, see the installation documentation for more details.
+   * Passing the package URI is supported regardless of the installation configuration.
    * @param flag a Boolean value.
    *
    * @copydetails doc_returns_success_code
@@ -1507,7 +1525,10 @@ public:
    * Returns the <code>required</code> attribute of the given package
    * extension.
    *
-   * @param package the name or URI of the package extension.
+   * @param package the name or URI of the package extension. Passing a package
+   * name (or "nickname") is only supported if libSBML was compiled with support for
+   * that particular package, see the installation documentation for more details.
+   * Passing the package URI is supported regardless of the installation configuration.
    *
    * @return a Boolean value indicating whether the package is flagged as
    * being required in this SBML document.
@@ -1522,7 +1543,10 @@ public:
    * Returns @c true if the required attribute of the given package extension
    * is defined, otherwise returns @c false.
    *
-   * @param package the name or URI of the package extension.
+   * @param package the name or URI of the package extension. Passing a package
+   * name (or "nickname") is only supported if libSBML was compiled with support for
+   * that particular package, see the installation documentation for more details.
+   * Passing the package URI is supported regardless of the installation configuration.
    *
    * @return a Boolean value.
    *
@@ -2733,7 +2757,10 @@ SBMLDocument_setSBMLNamespaces (SBMLDocument_t *d, SBMLNamespaces_t * sbmlns);
  * extension.
  *
  * @param d the SBMLDocument_t structure to check.
- * @param package the name or URI of the package extension.
+ * @param package the name or URI of the package extension. Passing a package
+ * name (or "nickname") is only supported if libSBML was compiled with support for
+ * that particular package, see the installation documentation for more details.
+ * Passing the package URI is supported regardless of the installation configuration.
  *
  * @return @c 1 (true) if the package is flagged as
  * being required in this SBML document, @c 0 (false) otherwise.
@@ -2752,7 +2779,10 @@ SBMLDocument_getPkgRequired (SBMLDocument_t *d, const char * package);
  * extension.
  *
  * @param d the SBMLDocument_t structure to check.
- * @param package the name or URI of the package extension.
+ * @param package the name or URI of the package extension. Passing a package
+ * name (or "nickname") is only supported if libSBML was compiled with support for
+ * that particular package, see the installation documentation for more details.
+ * Passing the package URI is supported regardless of the installation configuration.
  *
  * @return @c 1 (true) if the package is flagged as
  * being required in this SBML document, @c 0 (false) otherwise.
@@ -2769,7 +2799,10 @@ SBMLDocument_getPackageRequired (SBMLDocument_t *d, const char * package);
  * package.
  *
  * @param d the SBMLDocument_t structure.
- * @param package the name or URI of the package extension.
+ * @param package the name or URI of the package extension. Passing a package
+ * name (or "nickname") is only supported if libSBML was compiled with support for
+ * that particular package, see the installation documentation for more details.
+ * Passing the package URI is supported regardless of the installation configuration.
  * @param flag integer,
  * with @c nonzero indicating @c true, and @c zero indicating @c false.
  *
@@ -2791,7 +2824,10 @@ SBMLDocument_setPkgRequired (SBMLDocument_t *d, const char * package, int flag);
  * package.
  *
  * @param d the SBMLDocument_t structure.
- * @param package the name or URI of the package extension.
+ * @param package the name or URI of the package extension. Passing a package
+ * name (or "nickname") is only supported if libSBML was compiled with support for
+ * that particular package, see the installation documentation for more details.
+ * Passing the package URI is supported regardless of the installation configuration.
  * @param flag integer,
  * with @c nonzero indicating @c true, and @c zero indicating @c false.
  *
@@ -2811,7 +2847,10 @@ SBMLDocument_setPackageRequired (SBMLDocument_t *d, const char * package, int fl
  * is defined.
  *
  * @param d the SBMLDocument_t structure.
- * @param package the name or URI of the package extension.
+ * @param package the name or URI of the package extension. Passing a package
+ * name (or "nickname") is only supported if libSBML was compiled with support for
+ * that particular package, see the installation documentation for more details.
+ * Passing the package URI is supported regardless of the installation configuration.
  *
  * @return @c 1 (true) if the required attribute of the given package extension
  * is defined, @c 0 (false) otherwise.
@@ -2830,7 +2869,10 @@ SBMLDocument_isSetPkgRequired (SBMLDocument_t *d, const char * package);
  * is defined.
  *
  * @param d the SBMLDocument_t structure.
- * @param package the name or URI of the package extension.
+ * @param package the name or URI of the package extension. Passing a package
+ * name (or "nickname") is only supported if libSBML was compiled with support for
+ * that particular package, see the installation documentation for more details.
+ * Passing the package URI is supported regardless of the installation configuration.
  *
  * @return @c 1 (true) if the required attribute of the given package extension
  * is defined, @c 0 (false) otherwise.


### PR DESCRIPTION
## Description

Clarified the doc for the `getPackageRequired` function.

## Motivation and Context

The behavior of the function depends on some configuration options which makes it confusing for the user. According to the current documentation, the function allows passing either the package name (or "nickname") or its URI. However, passing the package name only works if support for that particular package was activated when compiling the library.

Fixes #215 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Change in documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have updated all documentation necessary.
- [x] I have checked spelling in (new) comments.

## Testing
- [X] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested -->

