### PR TITLE
The const version of getElementBySId should be virtual.

### DIFF
--- a/src/sbml/SBase.h
+++ b/src/sbml/SBase.h
@@ -246,7 +246,7 @@ public:
    *
    * @return pointer to the first element found with the given identifier.
    */
-  const SBase* getElementBySId(const std::string& id) const;
+  virtual const SBase* getElementBySId(const std::string& id) const;
   
   /**
    * Returns the first child element it can find with a specific "metaid"


### PR DESCRIPTION
This makes it match everything else, and also means it gets properly overwritten when it should be.
