### PR TITLE
Fix typo in docstring of `ASTNode_isLogical`

### DIFF
--- a/src/sbml/math/ASTNode.h
+++ b/src/sbml/math/ASTNode.h
@@ -3294,7 +3294,7 @@ ASTNode_isLog10 (const ASTNode_t *node);
  * @param node the node to query.
  *
  * @return @c 1 (true) if @p node is a MathML logical operator (@c and, @c or,
- * @c not, @c xor), @c 0otherwise.
+ * @c not, @c xor), @c 0 otherwise.
  *
  * @memberof ASTNode_t
  */


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context

Docstring of this function is currently rendered in this way: https://sbml.org/software/libsbml/5.18.0/docs/formatted/c-api/class_a_s_t_node__t.html#a023b6d785bf900a974168d2ea14fa9dc

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Change in documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have updated all documentation necessary.
- [x] I have checked spelling in (new) comments.

## Testing
- [X] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested -->

