### PR TITLE
improve thread safety of UnitFormulaFormatter, PowerUnitsCheck

### DIFF
--- a/src/sbml/units/UnitFormulaFormatter.cpp
+++ b/src/sbml/units/UnitFormulaFormatter.cpp
@@ -592,9 +592,9 @@ UnitFormulaFormatter::getUnitDefinitionFromPower(const ASTNode * node,
     exponentNode->isReal() == true ||
     exponentUD->isVariantOfDimensionless())
   {
-    SBMLTransforms::mapComponentValues(model);
-    exponentValue = SBMLTransforms::evaluateASTNode(node->getRightChild(), model);
-    SBMLTransforms::clearComponentValues();
+    SBMLTransforms::IdValueMap values;
+    SBMLTransforms::getComponentValuesForModel(model, values);
+    exponentValue = SBMLTransforms::evaluateASTNode(node->getRightChild(), values, model);
 
     for (unsigned int n = 0; n < variableUD->getNumUnits(); n++)
     {
@@ -749,9 +749,9 @@ UnitFormulaFormatter::getUnitDefinitionFromRoot(const ASTNode * node,
 
           if (tempUD2->isVariantOfDimensionless())
           {
-            SBMLTransforms::mapComponentValues(model);
-            double value = SBMLTransforms::evaluateASTNode(child);
-            SBMLTransforms::clearComponentValues();
+            SBMLTransforms::IdValueMap values;
+            SBMLTransforms::getComponentValuesForModel(model, values);
+            double value = SBMLTransforms::evaluateASTNode(child, values);
             if (!util_isNaN(value))
             {
               double doubleExponent =
@@ -2716,8 +2716,9 @@ UnitFormulaFormatter::inverseFunctionOnUnits(UnitDefinition* expectedUD,
       if (mathUD == NULL || mathUD->getNumUnits() == 0 
         || mathUD->isVariantOfDimensionless() == true)
       {
-        SBMLTransforms::mapComponentValues(this->model);
-        double exp = 1.0/(SBMLTransforms::evaluateASTNode(math, this->model));
+        SBMLTransforms::IdValueMap values;
+        SBMLTransforms::getComponentValuesForModel(this->model, values);
+        double exp = 1.0/(SBMLTransforms::evaluateASTNode(math, values, this->model));
         resolvedUD = new UnitDefinition(*expectedUD);
         for (unsigned int i = 0; i < resolvedUD->getNumUnits(); i++)
         {

--- a/src/sbml/validator/constraints/PowerUnitsCheck.cpp
+++ b/src/sbml/validator/constraints/PowerUnitsCheck.cpp
@@ -233,9 +233,9 @@ PowerUnitsCheck::checkUnitsFromPower (const Model& m,
 
       if (tempUD->isVariantOfDimensionless())
       {
-        SBMLTransforms::mapComponentValues(&m);
-        double value1 = SBMLTransforms::evaluateASTNode(child);
-        SBMLTransforms::clearComponentValues();
+        SBMLTransforms::IdValueMap values;
+        SBMLTransforms::getComponentValuesForModel(&m, values);
+        double value1 = SBMLTransforms::evaluateASTNode(child, values);
         if (!util_isNaN(value1))
         {
           if (floor(value1) != value1)
@@ -319,9 +319,9 @@ PowerUnitsCheck::checkUnitsFromPower (const Model& m,
       {
         // technically here there is an issue
         // stoichiometry is dimensionless
-        SBMLTransforms::mapComponentValues(&m);
-        double value1 = SBMLTransforms::evaluateASTNode(child, &m);
-        SBMLTransforms::clearComponentValues();
+        SBMLTransforms::IdValueMap values;
+        SBMLTransforms::getComponentValuesForModel(&m, values);
+        double value1 = SBMLTransforms::evaluateASTNode(child, values, &m);
         // but it may not be an integer
         if (util_isNaN(value1))
           // we cant check


### PR DESCRIPTION
## Description
- use a local map to store component values inside UnitFormulaFormatter, PowerUnitsCheck instead of using the static map in SBMLTransforms
- now safe to call these functions from multiple threads

## Motivation and Context

partial fix for #232
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here, using the 'fixes #<issue>' syntax. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Change in documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have updated all documentation necessary.
- [ ] I have checked spelling in (new) comments.

## Testing
- [X] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested -->

