### PR TITLE
Add `SBMLNamespaces_addPackageNamespace{,s}` functions to C API

### DIFF
--- a/src/sbml/SBMLNamespaces.cpp
+++ b/src/sbml/SBMLNamespaces.cpp
@@ -889,6 +889,30 @@ SBMLNamespaces_getSupportedNamespaces(int *length)
   SBMLNamespaces::freeSBMLNamespaces(const_cast<List*>(supported));
   return result;
 }
+
+LIBSBML_EXTERN
+int
+SBMLNamespaces_addPackageNamespace(SBMLNamespaces_t *sbmlns,
+                                   const char *pkgName,
+                                   unsigned int pkgVersion,
+                                   const char *prefix)
+{
+  if (sbmlns != NULL)
+    return sbmlns->addPackageNamespace(pkgName, pkgVersion, prefix);
+  else
+    return LIBSBML_INVALID_OBJECT;
+}
+
+LIBSBML_EXTERN
+int
+SBMLNamespaces_addPackageNamespaces(SBMLNamespaces_t *sbmlns,
+                                    const XMLNamespaces_t * xmlns)
+{
+  if (sbmlns != NULL)
+    return sbmlns->addPackageNamespaces(xmlns);
+  else
+    return LIBSBML_INVALID_OBJECT;
+}
 /** @endcond */
 
 LIBSBML_CPP_NAMESPACE_END

--- a/src/sbml/SBMLNamespaces.h
+++ b/src/sbml/SBMLNamespaces.h
@@ -778,6 +778,56 @@ LIBSBML_EXTERN
 SBMLNamespaces_t **
 SBMLNamespaces_getSupportedNamespaces(int *length);
 
+/**
+ * Add an XML namespace (a pair of URI and prefix) of a package extension
+ * to the set of namespaces within this SBMLNamespaces object.
+ *
+ * The SBML Level and SBML Version of this object is used.
+ *
+ * @param sbmlns the SBMLNamespaces_t structure to add to.
+ * @param pkgName the string of package name (e.g. "layout", "multi").
+ * @param pkgVersion the package version.
+ * @param prefix the prefix of the package namespace to be added.
+ *        The package's name will be used if the given string is empty (default).
+ *
+ * @copydetails doc_returns_success_code
+ * @li @sbmlconstant{LIBSBML_OPERATION_SUCCESS, OperationReturnValues_t}
+ * @li @sbmlconstant{LIBSBML_INVALID_ATTRIBUTE_VALUE, OperationReturnValues_t}
+ *
+ * @note An XML namespace of a non-registered package extension can't be
+ * added by this function (@sbmlconstant{LIBSBML_INVALID_ATTRIBUTE_VALUE, OperationReturnValues_t}
+ * will be returned).
+ *
+ * @see addNamespace(@if java String, String@endif)
+ */
+LIBSBML_EXTERN
+int
+SBMLNamespaces_addPackageNamespace(SBMLNamespaces_t *sbmlns,
+                                   const char *pkgName,
+                                   unsigned int pkgVersion,
+                                   const char *prefix);
+
+/**
+ * Add the XML namespaces of package extensions in the given XMLNamespace
+ * object to the set of namespaces within this SBMLNamespaces object
+ * (Non-package XML namespaces are not added by this function).
+ *
+ * @param sbmlns the SBMLNamespaces_t structure to add to.
+ * @param xmlns the XML namespaces to be added.
+ *
+ * @copydetails doc_returns_success_code
+ * @li @sbmlconstant{LIBSBML_OPERATION_SUCCESS, OperationReturnValues_t}
+ * @li @sbmlconstant{LIBSBML_INVALID_ATTRIBUTE_VALUE, OperationReturnValues_t}
+ *
+ * @note XML namespaces of a non-registered package extensions are not
+ * added (just ignored) by this function. @sbmlconstant{LIBSBML_INVALID_ATTRIBUTE_VALUE, OperationReturnValues_t} will be returned if the given
+ * xmlns is @c NULL.
+ */
+LIBSBML_EXTERN
+int
+SBMLNamespaces_addPackageNamespaces(SBMLNamespaces_t *sbmlns,
+                                    const XMLNamespaces_t * xmlns);
+
 END_C_DECLS
 LIBSBML_CPP_NAMESPACE_END
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Motivation and Context

Functions `SBMLNamespaces::addPackageNamespace` and `SBMLNamespaces::addPackageNamespaces` don't currently have counterparts in the C API.  With this patch I was able to create an `SBMLDocument_t` with fbc package in [`SBML.jl`](https://github.com/LCSB-BioCore/SBML.jl) (which only uses the C API).

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Change in documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have updated all documentation necessary.
- [ ] I have checked spelling in (new) comments.

## Testing
- [X] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested -->

