### PR TITLE
Fix signature of `SBase_getNumPlugins` in prototype

### DIFF
--- a/src/sbml/SBase.h
+++ b/src/sbml/SBase.h
@@ -5074,7 +5074,7 @@ SBase_hasValidLevelVersionNamespaceCombination(SBase_t *sb);
  */
 LIBSBML_EXTERN
 int
-SBase_getNumPlugins(SBase_t *sb);
+SBase_getNumPlugins(const SBase_t *sb);
 
 /**
  * Returns a plug-in structure (extension interface) for an SBML Level&nbsp;3


### PR DESCRIPTION
This was different from signature in implementation, leading to the
implementation not being C-exported correctly, and having C++ name mangling:

```console
% nm libsbml.so | grep SBase_getNumPlugins
00000000008f5240 T _Z19SBase_getNumPluginsPK5SBase
```

Similar to #189.  Spotted in https://github.com/JuliaPackaging/Yggdrasil/pull/5059.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here, using the 'fixes #<issue>' syntax. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Change in documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have updated all documentation necessary.
- [x] I have checked spelling in (new) comments.

## Testing
- [X] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested -->

