### PR TITLE
add `FbcReactionPlugin_createGeneProductAssociation` to C API

### DIFF
--- a/src/sbml/packages/fbc/extension/FbcReactionPlugin.cpp
+++ b/src/sbml/packages/fbc/extension/FbcReactionPlugin.cpp
@@ -995,6 +995,13 @@ FbcReactionPlugin::accept(SBMLVisitor& v) const
 
 
 LIBSBML_EXTERN
+GeneProductAssociation_t *
+FbcReactionPlugin_createGeneProductAssociation(FbcSBasePlugin_t * fbc)
+{
+  return  (fbc != NULL) ? static_cast<FbcReactionPlugin*>(fbc)->createGeneProductAssociation() : NULL;
+}
+
+LIBSBML_EXTERN
 char *
 FbcReactionPlugin_getUpperFluxBound(FbcSBasePlugin_t * fbc)
 {

--- a/src/sbml/packages/fbc/extension/FbcReactionPlugin.h
+++ b/src/sbml/packages/fbc/extension/FbcReactionPlugin.h
@@ -723,6 +723,20 @@ BEGIN_C_DECLS
 
 
 /**
+ * Creates a new GeneProductAssociation_t object and adds it to the FbcReactionPlugin_t object.
+ *
+ * @param fbc the FbcReactionPlugin_t that should have the GeneProductAssociation_t added
+ *
+ * @copydetails doc_note_geneproduct_v2_only
+ *
+ * @return pointer to the newly created GeneProductAssociation_t object.
+ */
+LIBSBML_EXTERN
+GeneProductAssociation_t*
+FbcReactionPlugin_createGeneProductAssociation(FbcSBasePlugin_t * fbc);
+
+
+/**
  * Takes a FbcReactionPlugin_t structure and returns its "upperFluxBound" attribute.
  *
  * @param fbc the FbcReactionPlugin_t whose "upperFluxBound" attribute is sought.


### PR DESCRIPTION
## Description
This simply adds a C wrapper for the C++ method.

## Motivation and Context
We needed the wrappers for making reactions with GPA from SBML.jl.

Closes #246 .

Cc @giordano .

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Change in documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have updated all documentation necessary.
- [x] I have checked spelling in (new) comments.

## Testing
- [ ] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested -->
