### PR TITLE
Cmake libxml fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -419,7 +419,9 @@ set(LIBSBML_XML_LIBRARY_LIBS)
 
 if(WITH_EXPAT)
   
+    if(NOT TARGET EXPAT::EXPAT)
     find_package(EXPAT REQUIRED)
+    endif()
 
     add_definitions( -DUSE_EXPAT )
     list(APPEND SWIG_EXTRA_ARGS -DUSE_EXPAT)

--- a/CMakeModules/FindLIBXML.cmake
+++ b/CMakeModules/FindLIBXML.cmake
@@ -1,3 +1,5 @@
+include(CheckLibraryExists)
+
 string(TOUPPER ${PROJECT_NAME} _UPPER_PROJECT_NAME)
 set(_PROJECT_DEPENDENCY_DIR ${_UPPER_PROJECT_NAME}_DEPENDENCY_DIR)
 
@@ -23,7 +25,7 @@ find_path(LIBXML_INCLUDE_DIR
     PATHS ${${_PROJECT_DEPENDENCY_DIR}}/include
           ${${_PROJECT_DEPENDENCY_DIR}}/include/libxml2
     NO_DEFAULT_PATH
-)      
+)
 
 
 if (NOT LIBXML_INCLUDE_DIR)
@@ -71,6 +73,13 @@ if (WIN32)
 set(ADDITIONAL_LIBS "ws2_32.lib;${ADDITIONAL_LIBS}")
 endif()
 
+
+CHECK_LIBRARY_EXISTS(m sin "" HAVE_LIB_M)
+
+if (HAVE_LIB_M)
+    set(ADDITIONAL_LIBS ${ADDITIONAL_LIBS} m)
+endif (HAVE_LIB_M)
+
 if(NOT TARGET LIBXML::LIBXML)
   add_library(LIBXML::LIBXML UNKNOWN IMPORTED)
   set_target_properties(LIBXML::LIBXML PROPERTIES
@@ -83,7 +92,7 @@ endif()
 
 # figure out if we need XML_STATIC flag
 if (LIBXML_INCLUDE_DIR AND LIBXML_LIBRARY)
-  
+
   set(LIBXML_LIBXML_CODE
 "
 #include <libxml/xmlversion.h>
@@ -130,10 +139,10 @@ if (LIBXML_LIBXML_TEST2)
     )
 else()
     message(FATAL_ERROR "Unable to compile a test executable against LIBXML
-    
+
     LIBXML_INCLUDE_DIR = ${LIBXML_INCLUDE_DIR}
     LIBXML_LIBRARY     = ${LIBXML_LIBRARY}
-    
+
     ")
 endif()
 
@@ -143,7 +152,7 @@ set(CMAKE_REQUIRED_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES_CACHE})
 set(CMAKE_REQUIRED_INCLUDES ${CMAKE_REQUIRED_INCLUDES_CACHE})
 set(CMAKE_REQUIRED_DEFINITIONS ${CMAKE_REQUIRED_DEFINITIONS_CACHE})
 endif()
-  
+
 include(FindPackageHandleStandardArgs)
 
 find_package_handle_standard_args(


### PR DESCRIPTION
## Description
This fixes the 2nd issue that alan came across, where the compile tests for libxml2 would fail for a static library, because of missing math symbols. 

## Motivation and Context
fixes #240 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Change in documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have updated all documentation necessary.
- [ ] I have checked spelling in (new) comments.

## Testing
- [X] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested -->

