### PR TITLE
use . to access convertStringToXMLNode

### DIFF
--- a/examples/python/append_to_note.py
+++ b/examples/python/append_to_note.py
@@ -75,7 +75,7 @@ def addToNotes(doc, id, stringToAdd):
         exit(4)
     print ("Body before change: ")
     print (body.toXMLString())
-    body.addChild(libsbml.XMLNode_convertStringToXMLNode(stringToAdd))
+    body.addChild(libsbml.XMLNode.convertStringToXMLNode(stringToAdd))
     print ("\nBody after change: ")
     print (body.toXMLString())
 


### PR DESCRIPTION
fixes #271

## Description
even before using the newer swig it is possible to use . to access the function, so it is fine to just use that. 

## Motivation and Context
fixes #271 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Change in documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have updated all documentation necessary.
- [ ] I have checked spelling in (new) comments.

## Testing
- [X] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested -->

