### PR TITLE
#275: check that spatial dimensions match before running test

### DIFF
--- a/src/sbml/packages/spatial/validator/SpatialSBMLErrorTable.h
+++ b/src/sbml/packages/spatial/validator/SpatialSBMLErrorTable.h
@@ -884,7 +884,7 @@ static const packageErrorTableEntry spatialErrorTable[] =
     LIBSBML_CAT_GENERAL_CONSISTENCY,
     LIBSBML_SEV_WARNING,
     "The attribute 'spatial:unitSize' on a <compartmentMapping> must have a value "
-    "between 0 and 1, inclusive.",
+    "between 0 and 1, inclusive, when the dimensions of the referenced compartments have the same dimensions.",
     { "L3V1 Spatial V1 Section"
     }
   },

--- a/src/sbml/packages/spatial/validator/SpatialSBMLErrorTable.h
+++ b/src/sbml/packages/spatial/validator/SpatialSBMLErrorTable.h
@@ -882,7 +882,7 @@ static const packageErrorTableEntry spatialErrorTable[] =
   { SpatialCompartmentMappingUnitSizeMustBeFraction,
     "The 'unitSize' attribute must be between 0 and 1.",
     LIBSBML_CAT_GENERAL_CONSISTENCY,
-    LIBSBML_SEV_ERROR,
+    LIBSBML_SEV_WARNING,
     "The attribute 'spatial:unitSize' on a <compartmentMapping> must have a value "
     "between 0 and 1, inclusive.",
     { "L3V1 Spatial V1 Section"

--- a/src/sbml/packages/spatial/validator/SpatialSBMLErrorTable.h
+++ b/src/sbml/packages/spatial/validator/SpatialSBMLErrorTable.h
@@ -884,7 +884,7 @@ static const packageErrorTableEntry spatialErrorTable[] =
     LIBSBML_CAT_GENERAL_CONSISTENCY,
     LIBSBML_SEV_WARNING,
     "The attribute 'spatial:unitSize' on a <compartmentMapping> should have a value "
-    "between 0 and 1, inclusive, when the dimensions of the referenced compartments have the same dimensions.",
+    "between 0 and 1, inclusive, when the dimensions of the referenced compartments are the same.",
     { "L3V1 Spatial V1 Section"
     }
   },
@@ -894,7 +894,7 @@ static const packageErrorTableEntry spatialErrorTable[] =
     "The 'unitSize' attributes should sum to 1.",
     LIBSBML_CAT_GENERAL_CONSISTENCY,
     LIBSBML_SEV_WARNING,
-    "The values of the 'spatial:unitSize' attributes of every <compartmentMapping> with the same 'spatial:domainType' should sum to 1.",
+    "The values of the 'spatial:unitSize' attributes of every <compartmentMapping> with the same 'spatial:domainType' should sum to 1, when the dimensions of the referenced compartments are the same.",
     { "L3V1 Spatial V1 Section"
     }
   },

--- a/src/sbml/packages/spatial/validator/SpatialSBMLErrorTable.h
+++ b/src/sbml/packages/spatial/validator/SpatialSBMLErrorTable.h
@@ -883,7 +883,7 @@ static const packageErrorTableEntry spatialErrorTable[] =
     "The 'unitSize' attribute must be between 0 and 1.",
     LIBSBML_CAT_GENERAL_CONSISTENCY,
     LIBSBML_SEV_WARNING,
-    "The attribute 'spatial:unitSize' on a <compartmentMapping> must have a value "
+    "The attribute 'spatial:unitSize' on a <compartmentMapping> should have a value "
     "between 0 and 1, inclusive, when the dimensions of the referenced compartments have the same dimensions.",
     { "L3V1 Spatial V1 Section"
     }

--- a/src/sbml/packages/spatial/validator/constraints/SpatialConsistencyConstraints.cpp
+++ b/src/sbml/packages/spatial/validator/constraints/SpatialConsistencyConstraints.cpp
@@ -664,6 +664,17 @@ END_CONSTRAINT
 // 1221350
 START_CONSTRAINT(SpatialCompartmentMappingUnitSizeMustBeFraction, CompartmentMapping, cmap)
 {
+  SpatialModelPlugin *plug = (SpatialModelPlugin*)(m.getPlugin("spatial"));
+  pre(plug != NULL);
+  const Compartment *pComp = dynamic_cast<const Compartment*>(cmap.getParentSBMLObject());
+  pre(pComp != NULL);
+  pre(plug->isSetGeometry());
+  DomainType* pDomain = plug->getGeometry()->getDomainType(cmap.getDomainType());
+  pre(pDomain != NULL);
+  // this constraint should only apply when 
+  // the domainType has the same dimension as the compartment
+  pre(pComp->getSpatialDimensions() == pDomain->getSpatialDimensions());
+
   bool fail = false;
   if (cmap.isSetUnitSize() && (cmap.getUnitSize() > 1 || cmap.getUnitSize() < 0)) {
     fail = true;

--- a/src/sbml/packages/spatial/validator/constraints/SpatialConsistencyConstraints.cpp
+++ b/src/sbml/packages/spatial/validator/constraints/SpatialConsistencyConstraints.cpp
@@ -669,11 +669,24 @@ START_CONSTRAINT(SpatialCompartmentMappingUnitSizeMustBeFraction, CompartmentMap
   const Compartment *pComp = dynamic_cast<const Compartment*>(cmap.getParentSBMLObject());
   pre(pComp != NULL);
   pre(plug->isSetGeometry());
-  DomainType* pDomain = plug->getGeometry()->getDomainType(cmap.getDomainType());
-  pre(pDomain != NULL);
+  const Compartment* pOtherComp = NULL;
+  for (unsigned int i = 0; i < m.getNumCompartments(); ++i)
+  {
+     const Compartment* comp = m.getCompartment(i); 
+     if (!comp) continue;
+     const SpatialCompartmentPlugin *compPlugin = dynamic_cast<const SpatialCompartmentPlugin *>(comp->getPlugin("spatial"));
+     if (!compPlugin) continue;
+     const CompartmentMapping* otherMapping = compPlugin->getCompartmentMapping();
+     if (!otherMapping) continue;
+     if (otherMapping->getDomainType() != cmap.getDomainType()) continue;
+     pOtherComp = comp;
+     break;    
+  }
+  pre(pOtherComp != NULL);
+  
   // this constraint should only apply when 
-  // the domainType has the same dimension as the compartment
-  pre(pComp->getSpatialDimensions() == pDomain->getSpatialDimensions());
+  // the domainType's compartment has the same dimension as the mapped compartment
+  pre(pComp->getSpatialDimensions() == pOtherComp->getSpatialDimensions());
 
   bool fail = false;
   if (cmap.isSetUnitSize() && (cmap.getUnitSize() > 1 || cmap.getUnitSize() < 0)) {


### PR DESCRIPTION
## Description
before testing whether the unitsize is between 0 and 1, we should check, that the spatial dimensions match first. 

## Motivation and Context
fixes #275

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Change in documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have updated all documentation necessary.
- [ ] I have checked spelling in (new) comments.

## Testing
- [X] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested -->

