### PR TITLE
Fix crash when infering units

### DIFF
--- a/src/sbml/conversion/test/TestInferUnitsConverter.cpp
+++ b/src/sbml/conversion/test/TestInferUnitsConverter.cpp
@@ -392,6 +392,31 @@ START_TEST (test_infer_localParam_fromReaction)
 END_TEST
 
 
+START_TEST (test_infer_reaction_with_4_params_func_call)
+{
+  string filename(TestDataDirectory);
+  filename += "inferUnits-4.xml";
+
+  SBMLDocument* d = readSBMLFromFile(filename.c_str());
+
+  fail_unless(d != NULL);
+
+  SBMLInferUnitsConverter * units = new SBMLInferUnitsConverter();
+
+  units->setDocument(d);
+
+  fail_unless (units->convert() == LIBSBML_OPERATION_SUCCESS);
+
+  // TO DO infer units using the function formula
+  // fail_unless(d->getModel()->getParameter("k1")->isSetUnits() == true);
+  // fail_unless(d->getModel()->getParameter("k1")->getUnits() == "unitSid_0");
+
+  delete units;
+  delete d;
+}
+END_TEST
+
+
 Suite *
 create_suite_TestInferUnitsConverter (void)
 { 
@@ -409,6 +434,7 @@ create_suite_TestInferUnitsConverter (void)
   tcase_add_test(tcase, test_infer_baseUnit_fromMath);
   tcase_add_test(tcase, test_infer_fromReaction);
   tcase_add_test(tcase, test_infer_localParam_fromReaction);
+  tcase_add_test(tcase, test_infer_reaction_with_4_params_func_call);
 
   suite_add_tcase(suite, tcase);
 

--- a/src/sbml/conversion/test/test-data/inferUnits-4.xml
+++ b/src/sbml/conversion/test/test-data/inferUnits-4.xml
@@ -1,0 +1,82 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<sbml xmlns="http://www.sbml.org/sbml/level2/version4" level="2" metaid="ea71b239_15b6_4fa3_a76f_dd6c414eede6" version="4">
+  <model id="MODEL1212210000" metaid="f4425bc4_80db_4c1c_b889_aae600e0ce20" name="Smith2013 - Regulation of Insulin Signalling by Oxidative Stress">
+    <listOfFunctionDefinitions>
+      <functionDefinition id="function_1" metaid="_0b927bb6_7666_4bab_9a62_1bb488a2950b" name="Function for R1f_1">
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <lambda>
+            <bvar>
+              <ci> InR </ci>
+            </bvar>
+            <bvar>
+              <ci> Ins </ci>
+            </bvar>
+            <bvar>
+              <ci> cellsurface </ci>
+            </bvar>
+            <bvar>
+              <ci> extracellular </ci>
+            </bvar>
+            <bvar>
+              <ci> k1 </ci>
+            </bvar>
+            <apply>
+              <times/>
+              <ci> k1 </ci>
+              <ci> Ins </ci>
+              <ci> extracellular </ci>
+              <ci> InR </ci>
+              <ci> cellsurface </ci>
+            </apply>
+          </lambda>
+        </math>
+      </functionDefinition>
+    </listOfFunctionDefinitions>
+    <listOfCompartments>
+      <compartment constant="true" id="extracellular" metaid="_33c764a6_3a3f_4ef0_8617_010e61aaadc6" name="extracellular" sboTerm="SBO:0000290" size="8.3E-12" spatialDimensions="3">
+      </compartment>
+      <compartment constant="true" id="cellsurface" metaid="_3998f93a_7adc_4437_90cb_86503740c79e" name="cellsurface" outside="extracellular" sboTerm="SBO:0000290" size="6.4E-14" spatialDimensions="3">
+      </compartment>
+      <compartment constant="true" id="cytoplasm" metaid="_546b89ee_5e8b_4791_875c_73de58897f5e" name="cytoplasm" outside="cellsurface" sboTerm="SBO:0000290" size="1.65E-11" spatialDimensions="3">
+      </compartment>
+    </listOfCompartments>
+    <listOfSpecies>
+      <species boundaryCondition="true" compartment="extracellular" constant="true" hasOnlySubstanceUnits="false" id="Ins" initialAmount="0" metaid="_820723ff_e05b_49d4_b9bd_b025befd02dc" name="Ins">
+      </species>
+      <species boundaryCondition="false" compartment="cellsurface" constant="false" hasOnlySubstanceUnits="false" id="InR" initialAmount="90000" metaid="d8602ba9_77a8_4307_ab2d_280bbcc14b67" name="InR">
+      </species>
+      <species boundaryCondition="false" compartment="cellsurface" constant="false" hasOnlySubstanceUnits="false" id="Ins_InR" initialAmount="0" metaid="_9672349d_f3af_4c17_8def_526d82171d04" name="Ins_InR">
+      </species>
+    </listOfSpecies>
+    <listOfParameters>
+      <parameter constant="true" id="k1" metaid="_2ad1244a_ce86_42ed_9222_df283a1c56a5" name="k1" value="2E-5"/>
+    </listOfParameters>
+    <listOfReactions>
+      <reaction id="R1f" metaid="b644817b_aa91_4732_9b17_f83803035b63" name="R1f" reversible="false">
+        <listOfReactants>
+          <speciesReference metaid="_652747b2_354c_407c_9dee_9680991fa150" species="Ins" stoichiometry="1"/>
+          <speciesReference metaid="_725a5142_9442_4c37_908f_aeea73cdae7d" species="InR" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="cc7fe296_cb4a_401f_ac8c_64cedf7f36d2" species="Ins_InR" stoichiometry="1"/>
+        </listOfProducts>
+        <listOfModifiers>
+          <modifierSpeciesReference metaid="_0d4998c7_4bc9_4fa7_85b8_9fa7250d6151" species="InR"/>
+          <modifierSpeciesReference metaid="a8a2b586_05fe_478f_a9e7_66a5ff911afe" species="Ins"/>
+        </listOfModifiers>
+        <kineticLaw metaid="_1d9b134e_3620_4ad0_8872_400169c862ca">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">
+            <apply>
+              <ci> function_1 </ci>
+              <ci> InR </ci>
+              <ci> Ins </ci>
+              <ci> cellsurface </ci>
+              <ci> extracellular </ci>
+              <ci> k1 </ci>
+            </apply>
+          </math>
+        </kineticLaw>
+      </reaction>
+    </listOfReactions>
+  </model>
+</sbml>

--- a/src/sbml/units/UnitFormulaFormatter.cpp
+++ b/src/sbml/units/UnitFormulaFormatter.cpp
@@ -377,7 +377,10 @@ UnitFormulaFormatter::getUnitDefinitionFromFunction(const ASTNode * node,
 
   if(node->getType() == AST_FUNCTION)
   {
-    const FunctionDefinition *fd = 
+    // The function name get lost by ASTNode::reduceToBinary when it has more
+    // than one parameter. So we need to check we have a name before calling
+    // model->getFunctionDefinition to avoid crashing.
+    const FunctionDefinition *fd = node->getName() == NULL ? NULL :
                                model->getFunctionDefinition(node->getName());
     if (fd && fd->isSetMath())
     {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
When trying to infer units of the added `inferUnits-4.xml` file, libsbml crashes.
My change only fixes the crash but does not make libsbml able to infer the units.

The reason why libsbml crashes (or is not able to infer the units) is that the file contains a `function_1` with more than 2 arguments.  
`UnitFormulaFormatter::inferUnitDefinition` then tries to reduce the kinetic law's math node to a binary tree but fails to do that properly because of the `function_1` call.
Maybe a full fix would be to fix `ASTNode::reduceToBinary()` to detect that there is a call to a function of more than 2 params and build a binary tree of the function first.
For now, avoiding a crash seems like a quick win.

Note that replacing `<ci> function_1 </ci>` by `<time />` in the input file avoids the crash and let libsbml infer units correctly.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here, using the 'fixes #<issue>' syntax. -->
Avoid crashing when infering units.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Change in documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have updated all documentation necessary.
- [ ] I have checked spelling in (new) comments.

## Testing
- [X] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested -->

