### PR TITLE
fix Java Testrunner

### DIFF
--- a/src/bindings/java/AutoTestRunner.java
+++ b/src/bindings/java/AutoTestRunner.java
@@ -45,7 +45,10 @@ import java.util.regex.Pattern;
 import java.util.regex.Matcher;
 import java.lang.reflect.*;
 
-import org.sbml.libsbml.test.*;
+import org.sbml.libsbml.test.annotation.*;
+import org.sbml.libsbml.test.math.*;
+import org.sbml.libsbml.test.sbml.*;
+import org.sbml.libsbml.test.xml.*;
 import org.sbml.libsbml.*;
 
 public class AutoTestRunner


### PR DESCRIPTION

## Description
This commit changes the auto test runner to include tests from sub directories, rather than just test. While previous javac versions compiled the old version without issue, newer javac compilers raise an issue. it was originally submitted by @pgrt 

## Motivation and Context
The change is needed, to get the java bindings built with newer javac, as it otherwise will fail when compiling the tests. 
the change still works for older javac versions as well. 

fixes #281 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Change in documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have updated all documentation necessary.
- [ ] I have checked spelling in (new) comments.

## Testing
this will be tested on a run of the extensive checks. 
- [X] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested -->

