### PR TITLE
 - add compile option for mxArrayToString

### DIFF
--- a/src/bindings/matlab/CMakeLists.txt
+++ b/src/bindings/matlab/CMakeLists.txt
@@ -54,6 +54,12 @@ find_package(Matlab)
 option(WITH_MATLAB_UTF8STRING
   "Generate Matlab bindings using mxArrayToUTF8String." ON )
 
+# allow using undefined lookup for matlab libraries
+if (NOT WIN32)  
+  option(WITH_MATLAB_UNDEFINED_LOOKUP
+    "Allow undefined lookup for matlab libraries." OFF )
+endif()
+
 #
 # Determine the matlab installation directory
 #
@@ -115,7 +121,14 @@ foreach(matlab_source_file "TranslateSBML" "OutputSBML")
     set_target_properties(matlab_binding_${matlab_source_file} PROPERTIES LINK_FLAGS "/export:mexFunction")
   endif()
 
-  target_link_libraries(matlab_binding_${matlab_source_file} ${MATLAB_LIBRARIES} ${LIBSBML_LIBRARY}-static)
+  if (WITH_MATLAB_UNDEFINED_LOOKUP)
+    if (APPLE)
+      set_target_properties(matlab_binding_${matlab_source_file} PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
+    endif()
+    target_link_libraries(matlab_binding_${matlab_source_file} ${LIBSBML_LIBRARY}-static)
+  else()
+    target_link_libraries(matlab_binding_${matlab_source_file} ${MATLAB_LIBRARIES} ${LIBSBML_LIBRARY}-static)
+  endif()
   install(TARGETS matlab_binding_${matlab_source_file} DESTINATION ${MATLAB_PACKAGE_INSTALL_DIR} )
 endforeach()
 

--- a/src/bindings/matlab/CMakeLists.txt
+++ b/src/bindings/matlab/CMakeLists.txt
@@ -12,17 +12,17 @@
 #     2. EMBL European Bioinformatics Institute (EMBL-EBI), Hinxton, UK
 #     3. University of Heidelberg, Heidelberg, Germany
 #
-# Copyright (C) 2009-2013 jointly by the following organizations: 
+# Copyright (C) 2009-2013 jointly by the following organizations:
 #     1. California Institute of Technology, Pasadena, CA, USA
 #     2. EMBL European Bioinformatics Institute (EMBL-EBI), Hinxton, UK
-#  
+#
 # Copyright (C) 2006-2008 by the California Institute of Technology,
-#     Pasadena, CA, USA 
-#  
-# Copyright (C) 2002-2005 jointly by the following organizations: 
+#     Pasadena, CA, USA
+#
+# Copyright (C) 2002-2005 jointly by the following organizations:
 #     1. California Institute of Technology, Pasadena, CA, USA
 #     2. Japan Science and Technology Agency, Japan
-# 
+#
 # This library is free software; you can redistribute it and/or modify it
 # under the terms of the GNU Lesser General Public License as published by
 # the Free Software Foundation.  A copy of the license agreement is provided
@@ -32,13 +32,13 @@
 ###############################################################################
 
 if(WITH_MATLAB)
-SET(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}" ${CMAKE_MODULE_PATH}) 
+SET(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}" ${CMAKE_MODULE_PATH})
 
 if (NOT MATLAB_ROOT_PATH)
   # try and find matlab in path
   find_program(MATLAB_COMMAND NAMES matlab matlab.exe)
   if (MATLAB_COMMAND)
-    # if we have it in the path, it will be of form <matlab_version>/bin/matlab, 
+    # if we have it in the path, it will be of form <matlab_version>/bin/matlab,
     # so take the DIRECTORY component twice
     get_filename_component(MATLAB_BIN_PATH ${MATLAB_COMMAND} DIRECTORY)
     get_filename_component(MATLAB_ROOT ${MATLAB_BIN_PATH} DIRECTORY)
@@ -48,87 +48,76 @@ endif()
 
 find_package(Matlab)
 
-# on windows let us build the library using MSVC, on Linux and OS X we choose
-# to build with the buildSBML script by default
-#set(MATLAB_MEX_DEFAULT)
-#set(WITH_MATLAB_BUILDSBML_DEFAULT)
-#if (UNIX)
-#   set(WITH_MATLAB_BUILDSBML_DEFAULT ON)
-#   set(MATLAB_MEX_DEFAULT OFF)
-#else()
-#   set(WITH_MATLAB_BUILDSBML_DEFAULT OFF)
-#   set(MATLAB_MEX_DEFAULT OFF)
-#endif()
+# by default we build matlab bindings using mxArrayToUTF8String this is only 
+# available for later versions of matlab, so the following flag allows us to 
+# compile for them. 
+option(WITH_MATLAB_UTF8STRING
+  "Generate Matlab bindings using mxArrayToUTF8String." ON )
+
 #
-#option(WITH_MATLAB_BUILDSBML   
-#      "Generate Matlab bindings using the buildsbml script from matlab."     ${WITH_MATLAB_BUILDSBML_DEFAULT} )
-#option(WITH_MATLAB_MEX   
-#      "Generate Matlab bindings using MEX compiler "     ${MATLAB_MEX_DEFAULT} )
-
-
-# 
 # Determine the matlab installation directory
 #
 set(MATLAB_PACKAGE_INSTALL_DIR)
-if (UNIX OR CYGWIN) 
+if (UNIX OR CYGWIN)
   set(MATLAB_PACKAGE_INSTALL_DIR ${CMAKE_INSTALL_LIBDIR})
 else()
   set(MATLAB_PACKAGE_INSTALL_DIR ${MISC_PREFIX}bindings/matlab)
 endif()
 
 
-	if (MSVC)
-	###############################################################################
-	#
-	# this is a directory level operation!
-	#
-	if (WITH_STATIC_RUNTIME)
-		foreach(flag_var
-			CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE
-			CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO
-			CMAKE_C_FLAGS CMAKE_C_FLAGS_DEBUG CMAKE_C_FLAGS_RELEASE
-			CMAKE_C_FLAGS_MINSIZEREL CMAKE_C_FLAGS_RELWITHDEBINFO)
-	
-			if(${flag_var} MATCHES "/MD")
-				string(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
-			endif(${flag_var} MATCHES "/MD")
-			
-			
-		endforeach(flag_var)
-		add_definitions( -D_MT)
-	endif(WITH_STATIC_RUNTIME)
-	endif()
-	
-	include_directories(${MATLAB_INCLUDE_DIR})
-	include_directories(BEFORE ${LIBSBML_ROOT_BINARY_DIR}/src)
+if (MSVC)
+###############################################################################
+#
+# this is a directory level operation!
+#
+if (WITH_STATIC_RUNTIME)
+  foreach(flag_var
+    CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE
+    CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO
+    CMAKE_C_FLAGS CMAKE_C_FLAGS_DEBUG CMAKE_C_FLAGS_RELEASE
+    CMAKE_C_FLAGS_MINSIZEREL CMAKE_C_FLAGS_RELWITHDEBINFO)
 
-	if (EXTRA_INCLUDE_DIRS) 
-	  include_directories(${EXTRA_INCLUDE_DIRS})
-	endif(EXTRA_INCLUDE_DIRS)
+    if(${flag_var} MATCHES "/MD")
+      string(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
+    endif(${flag_var} MATCHES "/MD")
 
-	SET(COMMON_FILES
-		"${CMAKE_CURRENT_SOURCE_DIR}/ModelDetails.cpp"
-		"${CMAKE_CURRENT_SOURCE_DIR}/StructureFields.cpp"
-		"${CMAKE_CURRENT_SOURCE_DIR}/CommonFunctions.cpp"
-		"${CMAKE_CURRENT_SOURCE_DIR}/Filenames.cpp"
-		"${CMAKE_CURRENT_SOURCE_DIR}/InputOutput.cpp"	)
-	
-	foreach(matlab_source_file "TranslateSBML" "OutputSBML")
-	
-		add_library(matlab_binding_${matlab_source_file} SHARED "${CMAKE_CURRENT_SOURCE_DIR}/${matlab_source_file}.cpp" ${COMMON_FILES})
-		set_target_properties(matlab_binding_${matlab_source_file} PROPERTIES OUTPUT_NAME "${matlab_source_file}")
-		set_target_properties(matlab_binding_${matlab_source_file} PROPERTIES SUFFIX ".${MATLAB_MEX_EXT}")
-                set_target_properties(matlab_binding_${matlab_source_file} PROPERTIES  PREFIX "")
-		if (MSVC)
-		set_target_properties(matlab_binding_${matlab_source_file} PROPERTIES LINK_FLAGS "/export:mexFunction") 
-		endif()
-		target_link_libraries(matlab_binding_${matlab_source_file} ${MATLAB_LIBRARIES} ${LIBSBML_LIBRARY}-static)				
-		install(TARGETS matlab_binding_${matlab_source_file} DESTINATION ${MATLAB_PACKAGE_INSTALL_DIR} )
 
-	endforeach()
-	
-	
-#endif(WITH_MATLAB_BUILDSBML)
+  endforeach(flag_var)
+  add_definitions( -D_MT)
+endif(WITH_STATIC_RUNTIME)
+endif()
+
+include_directories(${MATLAB_INCLUDE_DIR})
+include_directories(BEFORE ${LIBSBML_ROOT_BINARY_DIR}/src)
+if (EXTRA_INCLUDE_DIRS)
+  include_directories(${EXTRA_INCLUDE_DIRS})
+endif(EXTRA_INCLUDE_DIRS)
+
+SET(COMMON_FILES
+  "${CMAKE_CURRENT_SOURCE_DIR}/ModelDetails.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/StructureFields.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/CommonFunctions.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/Filenames.cpp"
+  "${CMAKE_CURRENT_SOURCE_DIR}/InputOutput.cpp"  )
+
+foreach(matlab_source_file "TranslateSBML" "OutputSBML")
+
+  add_library(matlab_binding_${matlab_source_file} SHARED "${CMAKE_CURRENT_SOURCE_DIR}/${matlab_source_file}.cpp" ${COMMON_FILES})
+  set_target_properties(matlab_binding_${matlab_source_file} PROPERTIES OUTPUT_NAME "${matlab_source_file}")
+  set_target_properties(matlab_binding_${matlab_source_file} PROPERTIES SUFFIX ".${MATLAB_MEX_EXT}")
+  set_target_properties(matlab_binding_${matlab_source_file} PROPERTIES  PREFIX "")
+
+  if (WITH_MATLAB_UTF8STRING)
+    target_compile_options(matlab_binding_${matlab_source_file} PRIVATE -DUSE_UTF8STRING)
+  endif()
+
+  if (MSVC)
+    set_target_properties(matlab_binding_${matlab_source_file} PROPERTIES LINK_FLAGS "/export:mexFunction")
+  endif()
+
+  target_link_libraries(matlab_binding_${matlab_source_file} ${MATLAB_LIBRARIES} ${LIBSBML_LIBRARY}-static)
+  install(TARGETS matlab_binding_${matlab_source_file} DESTINATION ${MATLAB_PACKAGE_INSTALL_DIR} )
+endforeach()
 
 
 # mark files for installation
@@ -137,7 +126,7 @@ file(GLOB matlab_scripts "${CMAKE_CURRENT_SOURCE_DIR}/../matlab/*.m"
 install(FILES ${matlab_scripts} DESTINATION ${MATLAB_PACKAGE_INSTALL_DIR})
 
 # add test cases
-add_subdirectory(test)	
+add_subdirectory(test)
 
 endif()
 

--- a/src/bindings/matlab/StructureFields.cpp
+++ b/src/bindings/matlab/StructureFields.cpp
@@ -539,10 +539,10 @@ StructureFields::getNamespacesStructure()
     * a string that is NULL
     */
     if (pacPrefix == NULL) {
-      pacPrefix = "";
+      pacPrefix = safe_strdup("");
     }
     if (pacURI == NULL) {
-      pacURI = "";
+      pacURI = safe_strdup("");
     }
 
     mxSetField(mxNSReturn, i, "prefix", mxCreateString(pacPrefix)); 

--- a/src/bindings/matlab/StructureFields.cpp
+++ b/src/bindings/matlab/StructureFields.cpp
@@ -1770,7 +1770,7 @@ StructureFields::readString(const std::string& name, unsigned int index, unsigne
   mxField = mxGetField(mxStructure, index, name.c_str());
   if (mxField != NULL)
   {
-#ifndef USE_OCTAVE
+#ifdef USE_UTF8STRING
     value = mxArrayToUTF8String(mxField);
 #else
     value = mxArrayToString(mxField);


### PR DESCRIPTION
## Description
To support older matlab versions, it would be good to be able to switch between the use of 
mxArrayToString and mxArrayToUTF8String. This PR adds a configuration option
`WITH_MATLAB_UTF8STRING` that is on by default. 

## Motivation and Context
compile on older matlab 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Change in documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have updated all documentation necessary.
- [ ] I have checked spelling in (new) comments.

## Testing
- [X] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested -->

