### PR TITLE
 #232: allow to store maps for each model

### DIFF
--- a/src/sbml/SBMLDocument.cpp
+++ b/src/sbml/SBMLDocument.cpp
@@ -235,7 +235,11 @@ SBMLDocument::~SBMLDocument ()
   if (mInternalValidator != NULL)
     delete mInternalValidator;
   if (mModel != NULL)
+  {
+    // remove from static map, since this object is being deleted
+		SBMLTransforms::clearComponentValues(mModel);
     delete mModel;
+  }
   clearValidators();
 }
 

--- a/src/sbml/SBMLTransforms.cpp
+++ b/src/sbml/SBMLTransforms.cpp
@@ -291,7 +291,8 @@ SBMLTransforms::mapComponentValues(const Model * m)
 {
 	IdValueMap values;
   IdList result = getComponentValuesForModel(m, values);
-  mModelValues[m] = values;
+  mModelValues.erase(m);
+  mModelValues.insert(std::make_pair(m, values));
   return result;
 }
 

--- a/src/sbml/SBMLTransforms.h
+++ b/src/sbml/SBMLTransforms.h
@@ -89,6 +89,7 @@ public:
   typedef std::pair<double, bool>   ValueSet;
   typedef std::map<const std::string, ValueSet> IdValueMap;
   typedef IdValueMap::iterator                  IdValueIter;
+  typedef std::map<const Model*, IdValueMap> ModelValuesMap;
 #endif
 
   /**
@@ -136,24 +137,119 @@ public:
                         const IdList* idsToExclude = NULL);
 
 
+  /**
+   * Expands the initial assignments in the given model
+   * 
+   * @param m the model to expand the initial assignments in
+   * 
+   * @return true if the model was changed, false otherwise
+   */
   static bool expandInitialAssignments(Model * m);
 
-
+  /**
+   * Evaluates the given AST node for the specified model 
+   * 
+   * @param node the AST node to evaluate
+   * @param m the model to evaluate the AST node for (if not NULL, all 
+   *        component values will be added to the map of values)
+   * 
+   * @return the result of the evaluation
+   */
   static double evaluateASTNode(const ASTNode * node, const Model * m = NULL);
 
+  /**
+   * Expands the initial assignments in the given L3V2 model
+   *
+   * @param m the model to expand the initial assignments in
+   *
+   * @return true if the model was changed, false otherwise
+   */
   static bool expandL3V2InitialAssignments(Model * m);
 
 
 #ifndef SWIG
+
+  /**
+   * Evaluates the given AST node for the specified model and values
+   * 
+   * @param node the AST node to evaluate
+   * @param values the values to use for the evaluation of identifiers
+   * @param m the model to evaluate the AST node for
+   * 
+   * @return the result of the evaluation
+   */
   static double evaluateASTNode(const ASTNode * node, const IdValueMap& values, const Model * m = NULL);
+
+  /**
+   * Evaluates the given AST node for the specified model and values
+   * 
+   * This overload converts the map of values to an IdValueMap first
+   *
+   * @param node the AST node to evaluate
+   * @param values the values to use for the evaluation of identifiers 
+   * @param m the model to evaluate the AST node for
+   *
+   * @return the result of the evaluation
+   */
   static double evaluateASTNode(const ASTNode * node, const std::map<std::string, double>& values, const Model * m = NULL);
+  
+  /**
+   * creates a new component value map for the specified model (without adding it to the static map)
+   * 
+   * @param m the model to create the map for
+   * @param values the values to fill from the model
+   * 
+   * @return a list of all ids in the created map
+   */
   static IdList getComponentValuesForModel(const Model * m, IdValueMap& values);
+
+  /** 
+   * Returns the component values for the specified model 
+   * 
+   * @param m the model to get the component values for
+   * 
+   * @return the component values for the specified model (or empty if not in the static map)
+   */
+  
+  static IdValueMap getComponentValues(const Model* m);
+
+  /**
+   * Creates an IdList of the map of component values for the specified model
+   * 
+   * @param m the model to get the component value ids for
+   * 
+   * @return the list of ids in the map of component values for the specified model
+   */
+  static IdList getComponentIds(const Model* m);
 #endif
   
+  /**
+   * Creates a map of all values of the specified model. 
+   * 
+   * This also adds the created map to the static map of all model values. All 
+   * identifiers that cannot be determined are returned. 
+   * 
+   * @param m the model to create the map for
+   * 
+   * @return a list of all ids of the model that could not be determined
+   */
   static IdList mapComponentValues(const Model * m);
 
-  static void clearComponentValues();
+  /**
+   * Clears the component values for the specified model or all models if NULL
+   * 
+   * @param m the model to clear the component values for or NULL to clear all
+   */
+  static void clearComponentValues(const Model *m = NULL);
 
+  /**
+   * Checks whether the node contains any id in the specified list
+   * 
+   * @param node the node to check
+   * @param ids the list of ids to check for
+   * 
+   * @return true, if the node contains any id in the list, false otherwise
+   */
   static bool nodeContainsId(const ASTNode * node, IdList& ids);
 
 
@@ -183,7 +279,7 @@ protected:
                         const IdList* idsToExclude);
 
 
-  static IdValueMap mValues;
+  static ModelValuesMap mModelValues;
 
 };
 

--- a/src/sbml/conversion/ExpressionAnalyser.cpp
+++ b/src/sbml/conversion/ExpressionAnalyser.cpp
@@ -106,7 +106,7 @@ ExpressionAnalyser::~ExpressionAnalyser ()
     }
   }
   mODEs.clear();
-  SBMLTransforms::clearComponentValues();
+  SBMLTransforms::clearComponentValues(mModel);
 }
 
 /*
@@ -126,6 +126,7 @@ ExpressionAnalyser::setODEPairs(std::vector< std::pair< std::string, ASTNode*> >
 int
 ExpressionAnalyser::setModel(Model* model)
 {
+  SBMLTransforms::clearComponentValues(mModel);
   mModel = model;
   SBMLTransforms::mapComponentValues(model);
   return LIBSBML_OPERATION_SUCCESS;

--- a/src/sbml/test/TestSBMLTransforms.cpp
+++ b/src/sbml/test/TestSBMLTransforms.cpp
@@ -976,6 +976,61 @@ START_TEST(test_SBMLTransforms_evaluateAST_L2SpeciesReference)
 }
 END_TEST
 
+
+START_TEST(test_SBMLTransforms_multipleMaps)
+{
+  SBMLDocument d1(3, 1);
+  Model* m1 = d1.createModel();
+  Compartment* c1 = m1->createCompartment();
+  c1->setId("c");
+  c1->setConstant(true);
+  c1->setSize(1.0);
+
+  Species* s1 = m1->createSpecies();
+  s1->setId("s");
+  s1->setCompartment("c");
+  s1->setInitialConcentration(1.0);
+  s1->setHasOnlySubstanceUnits(false);
+
+  // at this point there shouldn't be a map for this model
+  fail_unless(SBMLTransforms::getComponentValues(m1).size() == 0);
+
+  // create a map for this model
+  IdList list1 = SBMLTransforms::mapComponentValues(m1);
+	fail_unless(list1.size() == 0);
+
+  SBMLDocument d2(3, 2);
+	Model* m2 = d2.createModel();
+	c1 = m2->createCompartment();
+	c1->setId("c");
+	c1->setConstant(true);
+	c1->setSize(2.0);
+
+	s1 = m2->createSpecies();
+	s1->setId("s");
+	s1->setCompartment("c");
+	s1->setInitialConcentration(2.0);
+	s1->setHasOnlySubstanceUnits(false);
+
+  fail_unless(SBMLTransforms::getComponentValues(m2).size() == 0);
+
+  IdList list2 = SBMLTransforms::mapComponentValues(m2);
+  fail_unless(list2.size() == 0);
+
+  SBMLTransforms::IdValueMap values1 = SBMLTransforms::getComponentValues(m1);
+  SBMLTransforms::IdValueMap values2 = SBMLTransforms::getComponentValues(m2);
+
+  fail_unless(values1["c"].first == 1);
+  fail_unless(values1["s"].first == 1);
+	fail_unless(values2["c"].first == 2);
+  fail_unless(values2["s"].first == 2);
+
+  SBMLTransforms::clearComponentValues(m1);
+  SBMLTransforms::clearComponentValues(m2);
+  
+}
+END_TEST
+
 Suite *
 create_suite_SBMLTransforms (void)
 {
@@ -994,6 +1049,7 @@ create_suite_SBMLTransforms (void)
   tcase_add_test(tcase, test_SBMLTransforms_evaluateL3V2ASTWithModel);
   tcase_add_test(tcase, test_SBMLTransforms_L3V2AssignmentNoMath);
   tcase_add_test(tcase, test_SBMLTransforms_StoichiometryMath);
+	tcase_add_test(tcase, test_SBMLTransforms_multipleMaps);
 
 
   suite_add_tcase(suite, tcase);


### PR DESCRIPTION
## Description
SBML Transforms so far was only using one set of values. Which caused issues when using multiple models at the same time. 
this pr includes a map allowing values to be stored for multiple models. 

## Motivation and Context
fixes #232 


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Change in documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have updated all documentation necessary.
- [ ] I have checked spelling in (new) comments.

## Testing
- [X] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested -->

