### PR TITLE
Fix bug in `SBMLTransforms::replaceFD`

### DIFF
--- a/src/sbml/SBMLTransforms.cpp
+++ b/src/sbml/SBMLTransforms.cpp
@@ -146,59 +146,14 @@ SBMLTransforms::replaceBvars(ASTNode * node, const FunctionDefinition *fd)
     noBvars = fd->getMath()->getNumBvars();
     fdMath = *fd->getBody();
 
-    // get names of all bvars
-    std::vector<std::string> allBVars; 
-    for (unsigned int i = 0; i < noBvars; ++i)
-      allBVars.push_back(fd->getArgument(i)->getName());
-
-		// get all names in the node
-		List* names = node->getListOfNodes((ASTNodePredicate)ASTNode_isName);
-		
-		// convert to std::vector
-    std::vector<std::string> currentChildNames;
-		for (unsigned int j = 0 ; j < names->getSize(); ++j)
-		{
-			ASTNode* name = (ASTNode*)names->get(j);
-			currentChildNames.push_back(name->getName());
-		}
-		delete names;
-
-    // establish order in which to replace bvars, we want to ensure that 
-		// no bvars are replaced before they are used
-		std::vector<unsigned int> replaceOrder;
-    for (unsigned int i = 0; i < noBvars; ++i)
-    {
-			std::string currentArg = fd->getArgument(i)->getName();
-      bool added = false;
-			for (unsigned int j = 0; j < currentChildNames.size(); ++j)
-			{
-				if (currentArg == currentChildNames[j])
-				{
-					replaceOrder.insert(replaceOrder.begin(), i);					
-          added = true;
-					break;
-				}
-			}
-	    if (!added)
-	    {
-		    replaceOrder.push_back(i);
-	    }
+    // get names of bvars and AST node to substitute for each
+    std::vector<std::string> bVars;
+    std::vector<ASTNode*> astNodes;
+    for (unsigned int i = 0; i < noBvars; ++i){
+        bVars.push_back(fd->getArgument(i)->getName());
+        astNodes.push_back(node->getChild(i));
     }
-
-    unsigned int nodeCount = 0;
-
-		// now replace in the order established above
-    std::vector<unsigned int>::iterator it = replaceOrder.begin();
-    for (; it != replaceOrder.end(); ++it)
-    {
-      unsigned int i = *it;
-      if (nodeCount < node->getNumChildren())
-      {
-        fdMath.replaceArgument(fd->getArgument(i)->getName(), 
-          node->getChild(nodeCount));
-      }
-      ++nodeCount;
-    }
+    fdMath.replaceArguments(bVars, astNodes);
     (*node) = fdMath;
   }
 

--- a/src/sbml/math/ASTNode.h
+++ b/src/sbml/math/ASTNode.h
@@ -1796,7 +1796,7 @@ setValue(value, 0);
    * For example, if the formula in this ASTNode is <code>x + y</code>,
    * and the function is called with @c bvar = @c "x" and @c arg = an ASTNode
    * representing the real value @c 3.  This method would substitute @c 3 for
-   * @c x within this ASTNode object, resulting in the forula <code>3 + y</code>.
+   * @c x within this ASTNode object, resulting in the formula <code>3 + y</code>.
    *
    * @param bvar a string representing the variable name to be substituted.
    * @param arg an ASTNode representing the name/value/formula to use as
@@ -1805,8 +1805,22 @@ setValue(value, 0);
   LIBSBML_EXTERN
   void replaceArgument(const std::string& bvar, ASTNode * arg);
 
+  /**
+   * Replaces occurrences of each given name with the corresponding ASTNode.
+   *
+   * For example, if the formula in this ASTNode is <code>x - y</code>,
+   * and the function is called with bvars = {"x", "y"} and args = ASTNodes
+   * representing objects with names {"y", "x"}, the result would be <code>y - x</code>.
+   *
+   * @param bvars a vector of strings representing the variable names to be substituted.
+   * @param args a vector of ASTNodes representing the name/value/formula to use as
+   * a replacement for each variable name
+   */
+  LIBSBML_EXTERN
+  void replaceArguments(const std::vector<std::string>& bvars, std::vector<ASTNode *>& args);
 
-  /** @cond doxygenLibsbmlInternal */
+
+    /** @cond doxygenLibsbmlInternal */
 
   /**
    * Sets the parent SBML object of this node.  Is not recursive, and will not set the parent SBML object of any children of this node.

--- a/src/sbml/test/TestSBMLTransforms.cpp
+++ b/src/sbml/test/TestSBMLTransforms.cpp
@@ -98,9 +98,9 @@ START_TEST (test_SBMLTransforms_replaceFD)
   safe_free(math);
 
   /* https://github.com/sbmlteam/libsbml/issues/299 */
-  /* fd: f_relabelled(p, S1) = p * S1 */
+  /* fd: f_relabelled(p, S1) = p - S1 */
   /* ast: f_relabelled(S1, p) * compartmentOne / t */
-  /* ast after replaceFD: p * S1 * compartmentOne / t */
+  /* ast after replaceFD: (S1 - p) * compartmentOne / t */
   
   // use initial assignment instead of reaction, because the reaction
   // got flagged as having invalid units
@@ -114,7 +114,7 @@ START_TEST (test_SBMLTransforms_replaceFD)
   SBMLTransforms::replaceFD(&ast, fd);
 
   math = SBML_formulaToString(&ast);
-  fail_unless (!strcmp(math, "p * S1 * compartmentOne / t"), NULL);
+  fail_unless (!strcmp(math, "(S1 - p) * compartmentOne / t"), NULL);
   safe_free(math);
 
   /* one function definition - nested */

--- a/src/sbml/test/test-data/multiple-functions.xml
+++ b/src/sbml/test/test-data/multiple-functions.xml
@@ -46,7 +46,7 @@
               <ci> S1 </ci>
             </bvar>
             <apply>
-              <times/>
+              <minus/>
               <ci> p </ci>
               <ci> S1 </ci>
             </apply>


### PR DESCRIPTION
## Description

- add `ASTNode::replaceArguments` which replaces all supplied arguments at the same time
- modify `SBMLTransforms::replaceBvars` to use this instead of replacing arguments sequentially
- refactor shared functionality into `copyNode`
- modify test case from using mul to minus to show some results are still incorrect after #300

## Motivation and Context

`SBMLTransforms::replaceFD` gave incorrect results in some cases.
This was due to `SBMLTransforms::replaceBvars` replacing each bvar sequentially (#299)
This PR instead substitutes all bvars simultaneously to avoid these incorrect results.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Change in documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have updated all documentation necessary.
- [ ] I have checked spelling in (new) comments.

## Testing
- [X] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested -->

