### PR TITLE
Improve IdList support in bindings

### DIFF
--- a/src/bindings/python/local-contrib.i
+++ b/src/bindings/python/local-contrib.i
@@ -376,3 +376,19 @@ class AutoProperty(type):
         __metaclass__ = AutoProperty
     }
 }
+
+%extend IdList
+{
+    %pythoncode
+    {
+        def __len__(self):
+           return self.size()
+        
+        def __getitem__(self, index):
+            return self.at(index)
+
+        def __iter__(self):
+            for i in range(self.size()):
+                yield self.at(i)        
+    }
+}

--- a/src/bindings/swig/libsbml.i
+++ b/src/bindings/swig/libsbml.i
@@ -779,6 +779,7 @@ as a comment in the output stream.
 %include sbml/common/common-documentation.h
 %include sbml/common/common-sbmlerror-codes.h
 
+%catches(std::exception, ...) IdList::at;
 %include <sbml/util/IdList.h>
 %include <sbml/util/IdentifierTransformer.h>
 %include <sbml/util/ElementFilter.h>


### PR DESCRIPTION
## Description
This PR, ensures that calling `IdList::at` out of bounds throws an exception instead of crashing runtimes. It also adds some convenience wrappers for python to IdList:  `__len__`, `__iter__ and `__getitem__`

## Motivation and Context
fixes #306 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Change in documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have updated all documentation necessary.
- [ ] I have checked spelling in (new) comments.

## Testing
- [X] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested -->

