### PR TITLE
allow model history without creator

### DIFF
--- a/src/sbml/SBase.cpp
+++ b/src/sbml/SBase.cpp
@@ -2361,11 +2361,8 @@ SBase::setCreatedDate(Date* date)
   }
   else
   {
-    ModelHistory* mh = new ModelHistory();
-    // we want to set it regardless of content
-    mHistory = static_cast<ModelHistory*>(mh->clone());
+    mHistory = new ModelHistory();
     mHistoryChanged = true;
-    delete mh;
 
     return mHistory->setCreatedDate(date);
 
@@ -2381,11 +2378,8 @@ SBase::addModifiedDate(Date* date)
   }
   else
   {
-    ModelHistory* mh = new ModelHistory();
-    // we want to set it regardless of content
-    mHistory = static_cast<ModelHistory*>(mh->clone());
+    mHistory = new ModelHistory();
     mHistoryChanged = true;
-    delete mh;
 
     return mHistory->addModifiedDate(date);
 

--- a/src/sbml/SBase.cpp
+++ b/src/sbml/SBase.cpp
@@ -1064,6 +1064,31 @@ SBase::getModelHistory()
   return mHistory;
 }
 
+Date*
+SBase::getCreatedDate() const
+{
+  return (mHistory != NULL)  ? mHistory->getCreatedDate() : NULL;
+}
+
+Date*
+SBase::getCreatedDate()
+{
+  return (mHistory != NULL) ? mHistory->getCreatedDate() : NULL;
+}
+
+
+Date*
+SBase::getModifiedDate(unsigned int n)
+{
+  return (mHistory != NULL) ? mHistory->getModifiedDate(n) : NULL;
+}
+
+unsigned int
+SBase::getNumModifiedDates()
+{
+  return (mHistory != NULL) ? mHistory->getNumModifiedDates() : NULL;
+}
+
 
 /*
  * @return @c true if the metaid of this SBML object is set, false
@@ -1148,6 +1173,22 @@ SBase::isSetModelHistory() const
 {
   return (mHistory != NULL);
 }
+
+
+bool
+SBase::isSetCreatedDate() const
+{
+  return (mHistory == NULL) ? false : mHistory->isSetCreatedDate();
+}
+
+
+
+bool
+SBase::isSetModifiedDate() const
+{
+  return (mHistory == NULL) ? false : mHistory->isSetModifiedDate();
+}
+
 
 
 /*
@@ -2310,6 +2351,45 @@ SBase::setModelHistory(ModelHistory * history)
   return status;
 }
 
+int 
+SBase::setCreatedDate(Date* date)
+{
+  if (mHistory != NULL)
+  {
+    return mHistory->setCreatedDate(date);
+  }
+  else
+  {
+    ModelHistory* mh = new ModelHistory();
+    // we want to set it regardless of content
+    mHistory = static_cast<ModelHistory*>(mh->clone());
+    mHistoryChanged = true;
+    delete mh;
+
+    return mHistory->setCreatedDate(date);
+
+  }
+}
+
+int
+SBase::addModifiedDate(Date* date)
+{
+  if (mHistory != NULL)
+  {
+    return mHistory->addModifiedDate(date);
+  }
+  else
+  {
+    ModelHistory* mh = new ModelHistory();
+    // we want to set it regardless of content
+    mHistory = static_cast<ModelHistory*>(mh->clone());
+    mHistoryChanged = true;
+    delete mh;
+
+    return mHistory->addModifiedDate(date);
+
+  }
+}
 
 /** @cond doxygenLibsbmlInternal */
 /*

--- a/src/sbml/SBase.cpp
+++ b/src/sbml/SBase.cpp
@@ -51,6 +51,7 @@
 #include <sbml/util/util.h>
 
 #include <sbml/annotation/RDFAnnotation.h>
+#include <sbml/annotation/Date.h>
 
 #include <sbml/KineticLaw.h>
 #include <sbml/SBMLError.h>
@@ -2962,6 +2963,74 @@ SBase::unsetModelHistory()
   }
 
   if (mHistory != NULL)
+  {
+    return LIBSBML_OPERATION_FAILED;
+  }
+  else
+  {
+    return LIBSBML_OPERATION_SUCCESS;
+  }
+}
+
+
+int
+SBase::unsetCreatedDate()
+{
+  if (mHistory != NULL && mHistory->isSetCreatedDate())
+  {
+    mHistoryChanged = true;
+  }
+  else
+  {
+    return LIBSBML_UNEXPECTED_ATTRIBUTE;
+  }
+
+  /* ModelHistory is only allowed on Model in L2
+  * but on any element in L3
+  */
+  if (getLevel() < 3 && getTypeCode() != SBML_MODEL)
+  {
+    return LIBSBML_UNEXPECTED_ATTRIBUTE;
+  }
+
+  Date* created = mHistory->getCreatedDate();
+  delete created;
+  mHistory->mCreatedDate = NULL;
+
+  if (mHistory->isSetCreatedDate() == true)
+  {
+    return LIBSBML_OPERATION_FAILED;
+  }
+  else
+  {
+    return LIBSBML_OPERATION_SUCCESS;
+  }
+}
+
+
+int
+SBase::unsetModifiedDates()
+{
+  if (mHistory != NULL && mHistory->isSetModifiedDate())
+  {
+    mHistoryChanged = true;
+  }
+  else
+  {
+    return LIBSBML_UNEXPECTED_ATTRIBUTE;
+  }
+
+  /* ModelHistory is only allowed on Model in L2
+  * but on any element in L3
+  */
+  if (getLevel() < 3 && getTypeCode() != SBML_MODEL)
+  {
+    return LIBSBML_UNEXPECTED_ATTRIBUTE;
+  }
+
+  List_freeItems(mHistory->getListModifiedDates(), Date_free, Date_t);
+
+  if (mHistory->getNumModifiedDates() > 0)
   {
     return LIBSBML_OPERATION_FAILED;
   }

--- a/src/sbml/SBase.h
+++ b/src/sbml/SBase.h
@@ -2122,6 +2122,36 @@ s.setNotes("<body xmlns='http://www.w3.org/1999/xhtml'><p>here is my note</p></b
 
 
   /**
+  * Unsets the created date of the ModelHistory object attached to this object.
+  *
+  * @copydetails doc_returns_success_code
+  * @li @sbmlconstant{LIBSBML_OPERATION_SUCCESS, OperationReturnValues_t}
+  * @li @sbmlconstant{LIBSBML_UNEXPECTED_ATTRIBUTE, OperationReturnValues_t}
+  * @li @sbmlconstant{LIBSBML_OPERATION_FAILED, OperationReturnValues_t}
+  *
+  * @note In SBML Level&nbsp;2, model history annotations were only
+  * permitted on the Model element.  In SBML Level&nbsp;3, they are
+  * permitted on all SBML components derived from SBase.
+  */
+  int unsetCreatedDate();
+
+
+  /**
+  * Unsets the modified dates of the ModelHistory object attached to this object.
+  *
+  * @copydetails doc_returns_success_code
+  * @li @sbmlconstant{LIBSBML_OPERATION_SUCCESS, OperationReturnValues_t}
+  * @li @sbmlconstant{LIBSBML_UNEXPECTED_ATTRIBUTE, OperationReturnValues_t}
+  * @li @sbmlconstant{LIBSBML_OPERATION_FAILED, OperationReturnValues_t}
+  *
+  * @note In SBML Level&nbsp;2, model history annotations were only
+  * permitted on the Model element.  In SBML Level&nbsp;3, they are
+  * permitted on all SBML components derived from SBase.
+  */
+  int unsetModifiedDates();
+
+
+  /**
    * Returns the MIRIAM <em>biological qualifier</em> associated with the
    * given resource.
    *

--- a/src/sbml/SBase.h
+++ b/src/sbml/SBase.h
@@ -976,6 +976,19 @@ public:
 
 
   /**
+  * Returns the "creation date" portion of the ModelHistory of this object.
+  *
+  * @return a Date object representing the creation date stored in
+  * this ModelHistory object.
+  *
+  * @note In SBML Level&nbsp;2, model history annotations were only
+  * permitted on the Model element.  In SBML Level&nbsp;3, they are
+  * permitted on all SBML components derived from SBase.
+  */
+  Date * getCreatedDate() const;
+
+
+  /**
    * Returns the ModelHistory object, if any, attached to this object.
    * 
    * @return the ModelHistory object attached to this object, or @c NULL if
@@ -986,6 +999,46 @@ public:
    * permitted on all SBML components derived from SBase.
    */
   ModelHistory* getModelHistory();
+
+
+  /**
+  * Returns the "creation date" portion of the ModelHistory of this object.
+  *
+  * @return a Date object representing the creation date stored in
+  * this ModelHistory object.
+  *
+  * @note In SBML Level&nbsp;2, model history annotations were only
+  * permitted on the Model element.  In SBML Level&nbsp;3, they are
+  * permitted on all SBML components derived from SBase.
+  */
+  Date * getCreatedDate();
+
+
+  /**
+  * Get the nth Date object in the list of "modified date" values stored
+  * in the ModelHistory of this object.
+  *
+  * In the MIRIAM format for annotations, there can be multiple
+  * modification dates.  The libSBML ModelHistory class supports this by
+  * storing a list of "modified date" values.
+  *
+  * @return the nth Date in the list of ModifiedDates of this
+  * ModelHistory or @c NULL if no such object exists.
+  */
+  Date* getModifiedDate(unsigned int n);
+
+
+  /**
+  * Get the number of Date objects in the ModelHistory of this Iobject's list of
+  * "modified dates".
+  *
+  * In the MIRIAM format for annotations, there can be multiple
+  * modification dates.  The libSBML ModelHistory class supports this by
+  * storing a list of "modified date" values.
+  *
+  * @return the number of ModifiedDates in this ModelHistory.
+  */
+  unsigned int getNumModifiedDates();
 
 
   /**
@@ -1161,6 +1214,30 @@ public:
    * permitted on all SBML components derived from SBase.
    */
   bool isSetModelHistory() const;
+
+
+  /**
+  * Predicate returning @c true if this
+  * object has a ModelHistory object attached to it and the created date is set
+  *
+  * @return @c true if the CreatedDate of the ModelHistory of this object is set,
+  * @c false otherwise.
+  *
+  * @note In SBML Level&nbsp;2, model history annotations were only
+  * permitted on the Model element.  In SBML Level&nbsp;3, they are
+  * permitted on all SBML components derived from SBase.
+  */
+  bool isSetCreatedDate() const;
+
+
+  /**
+  * Predicate returning @c true or @c false depending on whether the
+  * ModelHistory's "modified date" of this object is set.
+  *
+  * @return @c true if the modification date value of this ModelHistory
+  * object is set, @c false otherwise.
+  */
+  bool isSetModifiedDate() const;
 
 
   /**
@@ -1695,6 +1772,32 @@ s.setNotes("<body xmlns='http://www.w3.org/1999/xhtml'><p>here is my note</p></b
    * permitted on all SBML components derived from SBase.
    */
   int setModelHistory(ModelHistory * history);
+
+
+  /**
+  * Sets the creation date of the ModelHistory of this object.
+  *
+  * @param date a Date object representing the date to which the "created
+  * date" portion of this ModelHistory should be set.
+  *
+  * @copydetails doc_returns_success_code
+  * @li @sbmlconstant{LIBSBML_OPERATION_SUCCESS, OperationReturnValues_t}
+  * @li @sbmlconstant{LIBSBML_UNEXPECTED_ATTRIBUTE, OperationReturnValues_t}
+  */
+  int setCreatedDate(Date* date);
+
+
+  /**
+  * Adds a modified date to the ModelHistory of this object.
+  *
+  * @param date a Date object representing the date to which the "modified
+  * date" portion of this ModelHistory should be set.
+  *
+  * @copydetails doc_returns_success_code
+  * @li @sbmlconstant{LIBSBML_OPERATION_SUCCESS, OperationReturnValues_t}
+  * @li @sbmlconstant{LIBSBML_UNEXPECTED_ATTRIBUTE, OperationReturnValues_t}
+  */
+  int addModifiedDate(Date* date);
 
 
   /** @cond doxygenLibsbmlInternal */

--- a/src/sbml/annotation/RDFAnnotationParser.cpp
+++ b/src/sbml/annotation/RDFAnnotationParser.cpp
@@ -960,133 +960,135 @@ RDFAnnotationParser::createRDFDescriptionWithHistory(const SBase * object)
 
   /* now add the data from the ModelHistory */
 
-  for (unsigned int n = 0; n < history->getNumCreators(); n++)
+  if (history->getNumCreators() > 0)
   {
-    XMLNode * N     = 0;
-    XMLNode * Email = 0;
-    XMLNode * Org   = 0;
-
-    ModelCreator* c = history->getCreator(n);
-    if (c->usingFNVcard4())
+    for (unsigned int n = 0; n < history->getNumCreators(); n++)
     {
-      if (c->usingSingleName())
+      XMLNode * N = 0;
+      XMLNode * Email = 0;
+      XMLNode * Org = 0;
+
+      ModelCreator* c = history->getCreator(n);
+      if (c->usingFNVcard4())
       {
-        // we want to a single name but we have entered it as two
-        std::string name = c->getName();
-        if (name != c->getGivenName())
+        if (c->usingSingleName())
         {
-          name = c->getGivenName() + " " + c->getFamilyName();
+          // we want to a single name but we have entered it as two
+          std::string name = c->getName();
+          if (name != c->getGivenName())
+          {
+            name = c->getGivenName() + " " + c->getFamilyName();
+          }
+          XMLNode empty(empty_token);
+          empty.append(name);
+
+          XMLNode Text(Text_token);
+          Text.addChild(empty);
+
+          N = new XMLNode(Fn_token);
+          N->addChild(Text);
         }
-        XMLNode empty(empty_token);
-        empty.append(name);
-
-        XMLNode Text(Text_token);
-        Text.addChild(empty);
-
-        N = new XMLNode(Fn_token);
-        N->addChild(Text);
-      }
-    }
-    else
-    {
-      std::string name = c->getName();
-      std::string fname, gname;
-      // we have entered one name but want to display it as 2
-      if (name == c->getGivenName())
-      {
-        std::size_t found = name.find(" ");
-        gname = name.substr(0, found);
-        fname = name.substr(found + 1);
-        c->setFamilyName(fname);
-        c->setGivenName(gname);
-      }
-      if (c->isSetFamilyName())
-      {
-        XMLNode empty(empty_token);
-        empty.append(c->getFamilyName());
-
-        XMLNode Family(Family_token);
-        Family.addChild(empty);
-
-        N = new XMLNode(N_token);
-        N->addChild(Family);
-      }
-
-      if (c->isSetGivenName())
-      {
-        XMLNode empty(empty_token);
-        empty.append(c->getGivenName());
-
-        XMLNode Given(Given_token);
-        Given.addChild(empty);
-
-        if (N == NULL)
-        {
-          N = new XMLNode(N_token);
-        }
-        N->addChild(Given);
-      }
-    }
-
-    if (c->isSetEmail())
-    {
-      XMLNode empty(empty_token);
-      empty.append(c->getEmail());
-
-      Email = new XMLNode(Email_token);
-      Email->addChild(empty);
-    }
-
-    if (c->isSetOrganisation())
-    {
-      if (use_vcard3)
-      {
-        XMLNode empty(empty_token);
-        empty.append(c->getOrganisation());
-        XMLNode Orgname(Orgname_token);
-        Orgname.addChild(empty);
-
-        Org = new XMLNode(Org_token);
-        Org->addChild(Orgname);
       }
       else
       {
-        XMLNode empty(empty_token);
-        empty.append(c->getOrganisation());
+        std::string name = c->getName();
+        std::string fname, gname;
+        // we have entered one name but want to display it as 2
+        if (name == c->getGivenName())
+        {
+          std::size_t found = name.find(" ");
+          gname = name.substr(0, found);
+          fname = name.substr(found + 1);
+          c->setFamilyName(fname);
+          c->setGivenName(gname);
+        }
+        if (c->isSetFamilyName())
+        {
+          XMLNode empty(empty_token);
+          empty.append(c->getFamilyName());
 
-        Org = new XMLNode(Org_token);
-        Org->addChild(empty);
+          XMLNode Family(Family_token);
+          Family.addChild(empty);
+
+          N = new XMLNode(N_token);
+          N->addChild(Family);
+        }
+
+        if (c->isSetGivenName())
+        {
+          XMLNode empty(empty_token);
+          empty.append(c->getGivenName());
+
+          XMLNode Given(Given_token);
+          Given.addChild(empty);
+
+          if (N == NULL)
+          {
+            N = new XMLNode(N_token);
+          }
+          N->addChild(Given);
+        }
       }
+
+      if (c->isSetEmail())
+      {
+        XMLNode empty(empty_token);
+        empty.append(c->getEmail());
+
+        Email = new XMLNode(Email_token);
+        Email->addChild(empty);
+      }
+
+      if (c->isSetOrganisation())
+      {
+        if (use_vcard3)
+        {
+          XMLNode empty(empty_token);
+          empty.append(c->getOrganisation());
+          XMLNode Orgname(Orgname_token);
+          Orgname.addChild(empty);
+
+          Org = new XMLNode(Org_token);
+          Org->addChild(Orgname);
+        }
+        else
+        {
+          XMLNode empty(empty_token);
+          empty.append(c->getOrganisation());
+
+          Org = new XMLNode(Org_token);
+          Org->addChild(empty);
+        }
+      }
+
+      XMLNode li(li_token);
+      if (N != NULL)
+      {
+        li.addChild(*N);
+        delete N;
+      }
+      if (Email != NULL)
+      {
+        li.addChild(*Email);
+        delete Email;
+      }
+      if (Org != NULL)
+      {
+        li.addChild(*Org);
+        delete Org;
+      }
+      if (c->getAdditionalRDF() != NULL)
+      {
+        li.addChild(*(c->getAdditionalRDF()));
+      }
+
+      bag.addChild(li);
     }
 
-    XMLNode li(li_token);
-    if (N != NULL)
-    {
-      li.addChild(*N);
-      delete N;
-    }
-    if (Email != NULL)
-    {
-      li.addChild(*Email);
-      delete Email;
-    }
-    if (Org != NULL)
-    {
-      li.addChild(*Org);
-      delete Org;
-    }
-    if (c->getAdditionalRDF() != NULL)
-    {
-      li.addChild(*(c->getAdditionalRDF()));
-    }
-
-    bag.addChild(li);
+    XMLNode creator(creator_token);
+    creator.addChild(bag);
+    description->addChild(creator);
   }
-
-  XMLNode creator(creator_token);
-  creator.addChild(bag);
-  description->addChild(creator);
-  
   /* created date */
   if (history->isSetCreatedDate())
   {

--- a/src/sbml/annotation/test/TestUnusualRDFAnnotation.cpp
+++ b/src/sbml/annotation/test/TestUnusualRDFAnnotation.cpp
@@ -383,6 +383,31 @@ START_TEST(test_set_dates)
 END_TEST
 
 
+START_TEST(test_unset_dates)
+{
+  Compartment *c = m1->getCompartment(0);
+
+  fail_unless(c->isSetModelHistory() == true);
+  fail_unless(c->isSetCreatedDate() == true);
+  fail_unless(c->isSetModifiedDate() == true);
+  fail_unless(c->getNumModifiedDates() == 1);
+  Date_t *date1 = Date_createFromString("2006-05-30T10:46:02");
+  fail_unless(c->addModifiedDate(date1) == LIBSBML_OPERATION_SUCCESS);
+  fail_unless(c->getNumModifiedDates() == 2);
+
+  fail_unless(c->unsetCreatedDate() == LIBSBML_OPERATION_SUCCESS);
+  fail_unless(c->isSetCreatedDate() == false);
+
+  fail_unless(c->unsetModifiedDates() == LIBSBML_OPERATION_SUCCESS);
+  fail_unless(c->isSetModifiedDate() == false);
+  fail_unless(c->getNumModifiedDates() == 0);
+
+  delete date1;
+}
+END_TEST
+
+
+
 Suite *
 create_suite_UnusualRDFAnnotation (void)
 {
@@ -404,6 +429,7 @@ create_suite_UnusualRDFAnnotation (void)
   tcase_add_test(tcase, test_has_dates);
   tcase_add_test(tcase, test_no_dates);
   tcase_add_test(tcase, test_set_dates);
+  tcase_add_test(tcase, test_unset_dates);
 
 
   suite_add_tcase(suite, tcase);

--- a/src/sbml/annotation/test/test-data/model_history_dates.xml
+++ b/src/sbml/annotation/test/test-data/model_history_dates.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" level="3" version="1">
+  <model metaid="metaid_0000002" id="Model_1">
+    <listOfCompartments>
+      <compartment metaid="metaid_09" id="cytosol" constant="true">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:vCard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#metaid_09">
+              <dcterms:created rdf:parseType="Resource">
+                <dcterms:W3CDTF>2005-02-02T14:56:11Z</dcterms:W3CDTF>
+              </dcterms:created>
+              <dcterms:modified rdf:parseType="Resource">
+                <dcterms:W3CDTF>2006-05-30T10:46:02Z</dcterms:W3CDTF>
+              </dcterms:modified>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </compartment>
+    </listOfCompartments>
+  </model>
+</sbml>

--- a/src/sbml/annotation/test/test-data/set_annot_test.xml
+++ b/src/sbml/annotation/test/test-data/set_annot_test.xml
@@ -2,33 +2,33 @@
 <sbml xmlns="http://www.sbml.org/sbml/level2/version3" metaid="metaid_0000001" level="2" version="3">
   <model metaid="metaid_0000002" id="Model_1">
     <listOfCompartments>
-      <compartment id="cytosol" name="Cytosol" size="1"/>
+      <compartment metaid="metaid_09" id="cytosol" name="Cytosol" size="1"/>
     </listOfCompartments>
     <listOfSpecies>
-<species metaid="metaid_0000036" id="SAM" compartment="cytosol" initialConcentration="0.01">
-  <annotation>
-    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vcard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
-      <rdf:Description rdf:about="#metaid_0000036">
-        <bqbiol:is>
-          <rdf:Bag>
-            <rdf:li rdf:resource="http://identifiers.org/chebi/CHEBI:59789"/>
-            <bqbiol:hasProperty>
-              <rdf:Bag>
-                <rdf:li rdf:resource="http://amas/match_score/by_name/1.0"/>
-              </rdf:Bag>
-            </bqbiol:hasProperty>
-            <rdf:li rdf:resource="http://identifiers.org/chebi/CHEBI:15414"/>
-            <bqbiol:hasProperty>
-              <rdf:Bag>
-                <rdf:li rdf:resource="http://amas/match_score/by_name/1.0"/>
-              </rdf:Bag>
-            </bqbiol:hasProperty>
-          </rdf:Bag>
-        </bqbiol:is>
-      </rdf:Description>
-    </rdf:RDF>
-  </annotation>
-</species>
+      <species metaid="metaid_0000036" id="SAM" compartment="cytosol" initialConcentration="0.01">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vcard4="http://www.w3.org/2006/vcard/ns#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#metaid_0000036">
+              <bqbiol:is>
+                <rdf:Bag>
+                  <rdf:li rdf:resource="http://identifiers.org/chebi/CHEBI:59789"/>
+                  <bqbiol:hasProperty>
+                    <rdf:Bag>
+                      <rdf:li rdf:resource="http://amas/match_score/by_name/1.0"/>
+                    </rdf:Bag>
+                  </bqbiol:hasProperty>
+                  <rdf:li rdf:resource="http://identifiers.org/chebi/CHEBI:15414"/>
+                  <bqbiol:hasProperty>
+                    <rdf:Bag>
+                      <rdf:li rdf:resource="http://amas/match_score/by_name/1.0"/>
+                    </rdf:Bag>
+                  </bqbiol:hasProperty>
+                </rdf:Bag>
+              </bqbiol:is>
+            </rdf:Description>
+          </rdf:RDF>
+        </annotation>
+      </species>
     </listOfSpecies>
   </model>
 </sbml>


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
lets a model history withoutcreator be roundtripped

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here, using the 'fixes #<issue>' syntax. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Change in documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have updated all documentation necessary.
- [ ] I have checked spelling in (new) comments.

## Testing
- [X] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested -->

