### PR TITLE
Two fixes:

### DIFF
--- a/src/sbml/packages/comp/util/CompFlatteningConverter.cpp
+++ b/src/sbml/packages/comp/util/CompFlatteningConverter.cpp
@@ -385,6 +385,8 @@ CompFlatteningConverter::performConversion()
     mDocument->getVersion(),
     "The subsequent errors are from this attempt.");
 
+  unsetExplicitlyListed();
+
   // setup callback that will enable the packages on submodels
   disable_info mainDoc;
   mainDoc.doc = mDocument;
@@ -1253,6 +1255,19 @@ CompFlatteningConverter::restoreNamespaces()
     mDocument->enablePackage((*pkg).first, (*pkg).second, true);
   }
 }
+
+void CompFlatteningConverter::unsetExplicitlyListed()
+{
+    List* elements = mDocument->getAllElements();
+    for (unsigned int el = 0; el < elements->getSize(); el++) {
+        SBase* element = static_cast<SBase*>(elements->get(el));
+        if (element->getTypeCode() == SBML_LIST_OF) {
+            ListOf* lo = static_cast<ListOf*>(element);
+            lo->setExplicitlyListed(false);
+        }
+    }
+}
+
 /** @endcond */
 
 /** @cond doxygenLibsbmlInternal */

--- a/src/sbml/packages/comp/util/CompFlatteningConverter.h
+++ b/src/sbml/packages/comp/util/CompFlatteningConverter.h
@@ -656,6 +656,8 @@ private:
 
   void restoreNamespaces();
 
+  void unsetExplicitlyListed();
+
   std::set<std::pair<std::string, std::string> > mDisabledPackages;
 
 #ifndef SWIG

--- a/src/sbml/util/ElementFilter.h
+++ b/src/sbml/util/ElementFilter.h
@@ -87,6 +87,10 @@ LIBSBML_CPP_NAMESPACE_BEGIN
     pResult->transferFrom(pSublist);\
     delete pSublist;\
   }\
+  else {\
+    if ((pFilter == NULL || pFilter->filter(&list)) && list.getLevel() >= 3 && list.getVersion() >= 2 && list.isExplicitlyListed())\
+    pResult->add(&list);\
+  }\
 }
 
 #define ADD_FILTERED_PLIST(pResult,pSublist,pList,pFilter)\


### PR DESCRIPTION
* Add ListOf elements to getAllElements when explicitly listed is 'true'.
* Use this to clear the explicitlyListed flag when flattening comp models, so deleted elements won't leave empty lists behind for l3v2.

Fix for #319