### PR TITLE
Make various 'get' functions const for annotations.

### DIFF
--- a/src/sbml/annotation/Date.h
+++ b/src/sbml/annotation/Date.h
@@ -316,7 +316,7 @@ public:
    *
    * @return the year from this Date.
    */
-  unsigned int getYear()    { return mYear;   }
+  unsigned int getYear() const   { return mYear;   }
 
 
   /**
@@ -324,7 +324,7 @@ public:
    *
    * @return the month from this Date.
    */
-  unsigned int getMonth()   { return mMonth;  }
+  unsigned int getMonth() const { return mMonth;  }
 
 
   /**
@@ -332,7 +332,7 @@ public:
    *
    * @return the day from this Date.
    */
-  unsigned int getDay()     { return mDay;    }
+  unsigned int getDay() const { return mDay;    }
 
 
   /**
@@ -340,7 +340,7 @@ public:
    *
    * @return the hour from this Date.
    */
-  unsigned int getHour()    { return mHour;   }
+  unsigned int getHour() const { return mHour;   }
 
 
   /**
@@ -348,7 +348,7 @@ public:
    *
    * @return the minute from this Date.
    */
-  unsigned int getMinute()  { return mMinute; }
+  unsigned int getMinute() const { return mMinute; }
 
 
   /**
@@ -356,7 +356,7 @@ public:
    *
    * @return the seconds from this Date.
    */
-  unsigned int getSecond()  { return mSecond; }
+  unsigned int getSecond() const { return mSecond; }
   
 
   /**
@@ -364,7 +364,7 @@ public:
    *
    * @return the sign of the offset from this Date.
    */
-  unsigned int getSignOffset()    { return mSignOffset;   }
+  unsigned int getSignOffset() const { return mSignOffset;   }
  
 
   /**
@@ -372,7 +372,7 @@ public:
    *
    * @return the hours of the offset from this Date.
    */
-  unsigned int getHoursOffset()   { return mHoursOffset;  }
+  unsigned int getHoursOffset() const { return mHoursOffset;  }
 
   
   /**
@@ -380,7 +380,7 @@ public:
    *
    * @return the minutes of the offset from this Date.
    */
-   unsigned int getMinutesOffset() { return mMinutesOffset;}
+   unsigned int getMinutesOffset() const { return mMinutesOffset;}
 
    
   /**
@@ -394,7 +394,7 @@ public:
    *
    * @return the date as a string.
    */
-  const std::string& getDateAsString() { return mDate; }
+  const std::string& getDateAsString() const { return mDate; }
 
 
   /**

--- a/src/sbml/annotation/ModelHistory.cpp
+++ b/src/sbml/annotation/ModelHistory.cpp
@@ -326,7 +326,7 @@ ModelHistory::getModifiedDate(unsigned int n)
  * @return number in List of Creator
  */
 unsigned int 
-ModelHistory::getNumCreators()
+ModelHistory::getNumCreators() const
 {
   return mCreators != NULL ? mCreators->getSize() : 0;
 }
@@ -336,7 +336,7 @@ ModelHistory::getNumCreators()
  * @return number in List of modified dates
  */
 unsigned int 
-ModelHistory::getNumModifiedDates()
+ModelHistory::getNumModifiedDates() const
 {
   return mModifiedDates->getSize();
 }
@@ -356,7 +356,7 @@ ModelHistory::getCreator(unsigned int n)
  * otherwise.
  */
 bool 
-ModelHistory::isSetCreatedDate()
+ModelHistory::isSetCreatedDate() const
 {
   return mCreatedDate != NULL;
 }
@@ -367,7 +367,7 @@ ModelHistory::isSetCreatedDate()
  * otherwise.
  */
 bool 
-ModelHistory::isSetModifiedDate()
+ModelHistory::isSetModifiedDate() const
 {
   return (getNumModifiedDates() != 0);
 }

--- a/src/sbml/annotation/ModelHistory.h
+++ b/src/sbml/annotation/ModelHistory.h
@@ -206,7 +206,7 @@ public:
    * @return @c true if the creation date value of this ModelHistory is
    * set, @c false otherwise.
    */
-  bool isSetCreatedDate();
+  bool isSetCreatedDate() const;
 
   
   /**
@@ -216,7 +216,7 @@ public:
    * @return @c true if the modification date value of this ModelHistory
    * object is set, @c false otherwise.
    */
-  bool isSetModifiedDate();
+  bool isSetModifiedDate() const;
 
   
   /**
@@ -302,7 +302,7 @@ public:
    * 
    * @return the number of ModifiedDates in this ModelHistory.
    */
-  unsigned int getNumModifiedDates();
+  unsigned int getNumModifiedDates() const;
 
   
   /**
@@ -358,7 +358,7 @@ public:
    * 
    * @return the number of ModelCreators objects.
    */
-  unsigned int getNumCreators();
+  unsigned int getNumCreators() const;
 
 
   /**


### PR DESCRIPTION
I was trying to 'getYear' on a const Date, and couldn't.

'ModelCreator' get functions were already const.
