### PR TITLE
 - return integral value rather than ptr-type

### DIFF
--- a/src/sbml/SBase.cpp
+++ b/src/sbml/SBase.cpp
@@ -1087,7 +1087,7 @@ SBase::getModifiedDate(unsigned int n)
 unsigned int
 SBase::getNumModifiedDates()
 {
-  return (mHistory != NULL) ? mHistory->getNumModifiedDates() : NULL;
+  return (mHistory != NULL) ? mHistory->getNumModifiedDates() : 0;
 }
 
 


### PR DESCRIPTION
## Description
a getNum function returned NULL rather than a value in case of an invalid object.

## Motivation and Context
fixes #348 

This gets rid of a warning only. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Change in documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have updated all documentation necessary.
- [ ] I have checked spelling in (new) comments.

## Testing
- [X] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested -->

