### PR TITLE
FIX: support compilation with libxml2 2.12.0

### DIFF
--- a/src/sbml/xml/LibXMLParser.cpp
+++ b/src/sbml/xml/LibXMLParser.cpp
@@ -424,7 +424,7 @@ LibXMLParser::parseNext ()
 
   if ( xmlParseChunk(mParser, mBuffer, bytes, done) )
   {
-    xmlErrorPtr libxmlError = xmlGetLastError();
+    const xmlError* libxmlError = xmlGetLastError();
 
     // I tried reporting the message from libXML that's available in
     // libxmlError->message, but the thing is bogus: it will say things


### PR DESCRIPTION
## Description
libxml2 2.12.0 now makes xmlGetLastError() return const pointer: 
https://gitlab.gnome.org/GNOME/libxml2/-/commit/45470611b047db78106dcb2fdbd4164163c15ab7

Fix variable type using xmlGetLastError() as such.

Closes #357 .

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here, using the 'fixes #<issue>' syntax. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Change in documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have updated all documentation necessary.
- [ ] I have checked spelling in (new) comments.

## Testing
- [X] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested -->

