### PR TITLE
Allow FBC objects to be used in both L3v1 and L3v2 core documents.

### DIFF
--- a/src/sbml/packages/fbc/extension/FbcModelPlugin.cpp
+++ b/src/sbml/packages/fbc/extension/FbcModelPlugin.cpp
@@ -656,10 +656,6 @@ int
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != bound->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (getPackageVersion() != bound->getPackageVersion())
   {
     return LIBSBML_PKG_VERSION_MISMATCH;
@@ -907,10 +903,6 @@ FbcModelPlugin::addObjective(const Objective* o)
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != o->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (getPackageVersion() != o->getPackageVersion())
   {
     return LIBSBML_PKG_VERSION_MISMATCH;
@@ -1086,10 +1078,6 @@ FbcModelPlugin::addGeneProduct(const GeneProduct* gp)
   else if (getLevel() != gp->getLevel())
   {
     return LIBSBML_LEVEL_MISMATCH;
-  }
-  else if (getVersion() != gp->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
   }
   else if (getPackageVersion() != gp->getPackageVersion())
   {
@@ -1308,10 +1296,6 @@ int
   else if (getLevel() != association->getLevel())
   {
     return LIBSBML_LEVEL_MISMATCH;
-  }
-  else if (getVersion() != association->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
   }
   else if (getPackageVersion() != association->getPackageVersion())
   {
@@ -1533,10 +1517,6 @@ FbcModelPlugin::addUserDefinedConstraint(const UserDefinedConstraint* udc)
   else if (getLevel() != udc->getLevel())
   {
     return LIBSBML_LEVEL_MISMATCH;
-  }
-  else if (getVersion() != udc->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
   }
   else if (getPackageVersion() != udc->getPackageVersion())
   {

--- a/src/sbml/packages/fbc/extension/FbcReactionPlugin.cpp
+++ b/src/sbml/packages/fbc/extension/FbcReactionPlugin.cpp
@@ -422,10 +422,6 @@ FbcReactionPlugin::setGeneProductAssociation(const GeneProductAssociation* geneP
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != geneProductAssociation->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (getPackageVersion() != geneProductAssociation->getPackageVersion())
   {
     return LIBSBML_PKG_VERSION_MISMATCH;

--- a/src/sbml/packages/fbc/extension/FbcSBasePlugin.cpp
+++ b/src/sbml/packages/fbc/extension/FbcSBasePlugin.cpp
@@ -190,10 +190,6 @@ FbcSBasePlugin::addKeyValuePair(const KeyValuePair* kvp)
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != kvp->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (getPackageVersion() != kvp->getPackageVersion())
   {
     return LIBSBML_PKG_VERSION_MISMATCH;

--- a/src/sbml/packages/fbc/sbml/Association.cpp
+++ b/src/sbml/packages/fbc/sbml/Association.cpp
@@ -620,7 +620,7 @@ Association::readAttributes (const XMLAttributes& attributes,
     logEmptyString(mReference, sbmlLevel, sbmlVersion, "<gene>");
   }
   if (!SyntaxChecker::isValidSBMLSId(mReference)) 
-    logError(InvalidIdSyntax, getLevel(), getVersion(), 
+    logError(InvalidIdSyntax, sbmlLevel, sbmlVersion,
     "The syntax of the attribute reference='" + mReference + "' does not conform.");
 
 }

--- a/src/sbml/packages/fbc/sbml/FbcAnd.cpp
+++ b/src/sbml/packages/fbc/sbml/FbcAnd.cpp
@@ -242,10 +242,6 @@ FbcAnd::addAssociation(const FbcAssociation* fa)
   {
     return LIBSBML_PKG_VERSION_MISMATCH;
   }
-  else if (getVersion() != fa->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (matchesRequiredSBMLNamespacesForAddition(static_cast<const SBase *>(fa)) == false)
   {
     return LIBSBML_NAMESPACES_MISMATCH;

--- a/src/sbml/packages/fbc/sbml/FbcAssociation.cpp
+++ b/src/sbml/packages/fbc/sbml/FbcAssociation.cpp
@@ -912,10 +912,6 @@ ListOfFbcAssociations::addFbcAssociation(const FbcAssociation* fa)
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != fa->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (matchesRequiredSBMLNamespacesForAddition(static_cast<const SBase *>(fa)) == false)
   {
     return LIBSBML_NAMESPACES_MISMATCH;

--- a/src/sbml/packages/fbc/sbml/FbcOr.cpp
+++ b/src/sbml/packages/fbc/sbml/FbcOr.cpp
@@ -249,10 +249,6 @@ FbcOr::addAssociation(const FbcAssociation* fa)
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != fa->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (getPackageVersion() != fa->getPackageVersion())
   {
     return LIBSBML_PKG_VERSION_MISMATCH;

--- a/src/sbml/packages/fbc/sbml/FluxObjective.cpp
+++ b/src/sbml/packages/fbc/sbml/FluxObjective.cpp
@@ -343,11 +343,9 @@ FluxObjective::setCoefficient(double coefficient)
 int
 FluxObjective::setVariableType(const FbcVariableType_t variableType)
 {
-  unsigned int coreLevel = getLevel();
-  unsigned int coreVersion = getVersion();
   unsigned int pkgVersion = getPackageVersion();
 
-  if (coreLevel == 3 && coreVersion == 1 && pkgVersion == 3)
+  if (pkgVersion >= 3)
   {
     if (FbcVariableType_isValid(variableType) == 0)
     {
@@ -373,11 +371,9 @@ FluxObjective::setVariableType(const FbcVariableType_t variableType)
 int
 FluxObjective::setVariableType(const std::string& variableType)
 {
-  unsigned int coreLevel = getLevel();
-  unsigned int coreVersion = getVersion();
   unsigned int pkgVersion = getPackageVersion();
 
-  if (coreLevel == 3 && coreVersion == 1 && pkgVersion == 3)
+  if (pkgVersion >= 3)
   {
     mVariableType = FbcVariableType_fromString(variableType.c_str());
 
@@ -550,8 +546,6 @@ FluxObjective::hasRequiredAttributes () const
 {
   bool allPresent = true;
 
-  unsigned int level = getLevel();
-  unsigned int version = getVersion();
   unsigned int pkgVersion = getPackageVersion();
 
   if (isSetReaction() == false)
@@ -560,7 +554,7 @@ FluxObjective::hasRequiredAttributes () const
   if (isSetCoefficient() == false)
     allPresent = false;
 
-  if (level == 3 && version == 1 && pkgVersion == 3)
+  if (pkgVersion >= 3)
   {
     if (isSetVariableType() == false)
     {
@@ -974,8 +968,6 @@ FluxObjective::addExpectedAttributes(ExpectedAttributes& attributes)
 {
   SBase::addExpectedAttributes(attributes);
 
-  unsigned int level = getLevel();
-  unsigned int coreVersion = getVersion();
   unsigned int pkgVersion = getPackageVersion();
 
   attributes.add("id");
@@ -983,7 +975,7 @@ FluxObjective::addExpectedAttributes(ExpectedAttributes& attributes)
   attributes.add("reaction");
   attributes.add("coefficient");
 
-  if (level == 3 && coreVersion == 1 && pkgVersion == 3)
+  if (pkgVersion >= 3)
   {
     attributes.add("variableType");
     attributes.add("reaction2");
@@ -1162,7 +1154,7 @@ FluxObjective::readAttributes (const XMLAttributes& attributes,
   // 
 
   std::string variableType;
-  if (pkgVersion == 3)
+  if (pkgVersion >= 3)
   {
     assigned = attributes.readInto("variableType", variableType);
 
@@ -1351,10 +1343,6 @@ ListOfFluxObjectives::addFluxObjective(const FluxObjective* fo)
   else if (getLevel() != fo->getLevel())
   {
     return LIBSBML_LEVEL_MISMATCH;
-  }
-  else if (getVersion() != fo->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
   }
   else if (matchesRequiredSBMLNamespacesForAddition(static_cast<const SBase *>(fo)) == false)
   {

--- a/src/sbml/packages/fbc/sbml/GeneAssociation.cpp
+++ b/src/sbml/packages/fbc/sbml/GeneAssociation.cpp
@@ -391,10 +391,6 @@ int
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != association->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else
   {
     if (mAssociation != NULL)

--- a/src/sbml/packages/fbc/sbml/GeneProduct.cpp
+++ b/src/sbml/packages/fbc/sbml/GeneProduct.cpp
@@ -1071,10 +1071,6 @@ ListOfGeneProducts::addGeneProduct(const GeneProduct* gp)
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != gp->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (matchesRequiredSBMLNamespacesForAddition(static_cast<const SBase *>(gp)) == false)
   {
     return LIBSBML_NAMESPACES_MISMATCH;

--- a/src/sbml/packages/fbc/sbml/KeyValuePair.cpp
+++ b/src/sbml/packages/fbc/sbml/KeyValuePair.cpp
@@ -235,10 +235,9 @@ KeyValuePair::isSetUri() const
 int
 KeyValuePair::setId(const std::string& id)
 {
-  unsigned int coreLevel = getLevel();
   unsigned int pkgVersion = getPackageVersion();
 
-  if (coreLevel == 3 && pkgVersion == 3)
+  if (pkgVersion >= 3)
   {
     return SyntaxChecker::checkAndSetSId(id, mId);
   }
@@ -255,10 +254,9 @@ KeyValuePair::setId(const std::string& id)
 int
 KeyValuePair::setName(const std::string& name)
 {
-  unsigned int coreLevel = getLevel();
   unsigned int pkgVersion = getPackageVersion();
 
-  if (coreLevel == 3 && pkgVersion == 3)
+  if (pkgVersion >= 3)
   {
     mName = name;
     return LIBSBML_OPERATION_SUCCESS;
@@ -276,10 +274,9 @@ KeyValuePair::setName(const std::string& name)
 int
 KeyValuePair::setKey(const std::string& key)
 {
-  unsigned int coreLevel = getLevel();
   unsigned int pkgVersion = getPackageVersion();
 
-  if (coreLevel == 3 && pkgVersion == 3)
+  if (pkgVersion >= 3)
   {
     mKey = key;
     return LIBSBML_OPERATION_SUCCESS;
@@ -297,10 +294,9 @@ KeyValuePair::setKey(const std::string& key)
 int
 KeyValuePair::setValue(const std::string& value)
 {
-  unsigned int coreLevel = getLevel();
   unsigned int pkgVersion = getPackageVersion();
 
-  if (coreLevel == 3 && pkgVersion == 3)
+  if (pkgVersion >= 3)
   {
     mValue = value;
     return LIBSBML_OPERATION_SUCCESS;
@@ -318,10 +314,9 @@ KeyValuePair::setValue(const std::string& value)
 int
 KeyValuePair::setUri(const std::string& uri)
 {
-  unsigned int coreLevel = getLevel();
   unsigned int pkgVersion = getPackageVersion();
 
-  if (coreLevel == 3 && pkgVersion == 3)
+  if (pkgVersion >= 3)
   {
     mUri = uri;
     return LIBSBML_OPERATION_SUCCESS;
@@ -458,11 +453,9 @@ KeyValuePair::hasRequiredAttributes() const
 {
   bool allPresent = true;
 
-  unsigned int level = getLevel();
-  unsigned int version = getVersion();
   unsigned int pkgVersion = getPackageVersion();
 
-  if (level == 3 && version == 1 && pkgVersion == 3)
+  if (pkgVersion >= 3)
   {
     if (isSetKey() == false)
     {
@@ -854,10 +847,9 @@ KeyValuePair::addExpectedAttributes(ExpectedAttributes& attributes)
 {
   SBase::addExpectedAttributes(attributes);
 
-  unsigned int level = getLevel();
   unsigned int pkgVersion = getPackageVersion();
 
-  if (level == 3 && pkgVersion == 3)
+  if (pkgVersion >= 3)
   {
     attributes.add("id");
     attributes.add("name");
@@ -936,7 +928,7 @@ KeyValuePair::readAttributes(const XMLAttributes& attributes,
     }
   }
 
-  if (level == 3 && version == 1 && pkgVersion == 3)
+  if (pkgVersion >= 3)
   {
     readL3V1V3Attributes(attributes);
   }
@@ -1063,11 +1055,9 @@ KeyValuePair::writeAttributes(XMLOutputStream& stream) const
 {
   SBase::writeAttributes(stream);
 
-  unsigned int level = getLevel();
-  unsigned int version = getVersion();
   unsigned int pkgVersion = getPackageVersion();
 
-  if (level == 3 && pkgVersion == 3)
+  if (pkgVersion >= 3)
   {
     writeL3V1V3Attributes(stream);
   }

--- a/src/sbml/packages/fbc/sbml/ListOfKeyValuePairs.cpp
+++ b/src/sbml/packages/fbc/sbml/ListOfKeyValuePairs.cpp
@@ -156,11 +156,9 @@ ListOfKeyValuePairs::setXmlns(const XMLNamespaces* xmlns, const std::string& pre
 int
 ListOfKeyValuePairs::setXmlns(const std::string& xmlns)
 {
-  unsigned int coreLevel = getLevel();
-  unsigned int coreVersion = getVersion();
   unsigned int pkgVersion = getPackageVersion();
 
-  if (coreLevel == 3 && pkgVersion == 3)
+  if (pkgVersion >= 3)
   {
     mXmlns = xmlns;
     return LIBSBML_OPERATION_SUCCESS;
@@ -286,10 +284,6 @@ ListOfKeyValuePairs::addKeyValuePair(const KeyValuePair* kvp)
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != kvp->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (matchesRequiredSBMLNamespacesForAddition(static_cast<const
     SBase*>(kvp)) == false)
   {
@@ -382,11 +376,9 @@ ListOfKeyValuePairs::hasRequiredAttributes() const
 {
   bool allPresent = true;
 
-  unsigned int level = getLevel();
-  unsigned int version = getVersion();
   unsigned int pkgVersion = getPackageVersion();
 
-  if (level == 3 && pkgVersion == 3)
+  if (pkgVersion >= 3)
   {
     if (isSetXmlns() == false)
     {
@@ -483,7 +475,7 @@ ListOfKeyValuePairs::readAttributes(const XMLAttributes& attributes,
     }
   }
 
-  if (level == 3 && pkgVersion == 3)
+  if (pkgVersion >= 3)
   {
     readL3V1V3Attributes(attributes);
   }
@@ -550,11 +542,9 @@ ListOfKeyValuePairs::writeAttributes(XMLOutputStream& stream) const
 {
   ListOf::writeAttributes(stream);
 
-  unsigned int level = getLevel();
-  unsigned int version = getVersion();
   unsigned int pkgVersion = getPackageVersion();
 
-  if (level == 3 && pkgVersion == 3)
+  if (pkgVersion >= 3)
   {
     writeL3V1V3Attributes(stream);
   }

--- a/src/sbml/packages/fbc/sbml/ListOfUserDefinedConstraintComponents.cpp
+++ b/src/sbml/packages/fbc/sbml/ListOfUserDefinedConstraintComponents.cpp
@@ -231,10 +231,6 @@ ListOfUserDefinedConstraintComponents::addUserDefinedConstraintComponent(const
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != udcc->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (matchesRequiredSBMLNamespacesForAddition(static_cast<const
     SBase*>(udcc)) == false)
   {

--- a/src/sbml/packages/fbc/sbml/ListOfUserDefinedConstraints.cpp
+++ b/src/sbml/packages/fbc/sbml/ListOfUserDefinedConstraints.cpp
@@ -222,10 +222,6 @@ ListOfUserDefinedConstraints::addUserDefinedConstraint(const
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != udc->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (matchesRequiredSBMLNamespacesForAddition(static_cast<const
     SBase*>(udc)) == false)
   {

--- a/src/sbml/packages/fbc/sbml/Objective.cpp
+++ b/src/sbml/packages/fbc/sbml/Objective.cpp
@@ -432,10 +432,6 @@ Objective::addFluxObjective(const FluxObjective* fo)
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != fo->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (matchesRequiredSBMLNamespacesForAddition(static_cast<const SBase *>(fo)) == false)
   {
     return LIBSBML_NAMESPACES_MISMATCH;
@@ -1398,10 +1394,6 @@ ListOfObjectives::addObjective(const Objective* o)
   else if (getLevel() != o->getLevel())
   {
     return LIBSBML_LEVEL_MISMATCH;
-  }
-  else if (getVersion() != o->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
   }
   else if (matchesRequiredSBMLNamespacesForAddition(static_cast<const SBase *>(o)) == false)
   {

--- a/src/sbml/packages/fbc/sbml/UserDefinedConstraint.cpp
+++ b/src/sbml/packages/fbc/sbml/UserDefinedConstraint.cpp
@@ -226,11 +226,9 @@ UserDefinedConstraint::isSetUpperBound() const
 int
 UserDefinedConstraint::setId(const std::string& id)
 {
-  unsigned int coreLevel = getLevel();
-  unsigned int coreVersion = getVersion();
   unsigned int pkgVersion = getPackageVersion();
 
-  if (coreLevel == 3 && coreVersion == 1 && pkgVersion == 3)
+  if (pkgVersion >= 3)
   {
     return SyntaxChecker::checkAndSetSId(id, mId);
   }
@@ -247,11 +245,9 @@ UserDefinedConstraint::setId(const std::string& id)
 int
 UserDefinedConstraint::setName(const std::string& name)
 {
-  unsigned int coreLevel = getLevel();
-  unsigned int coreVersion = getVersion();
   unsigned int pkgVersion = getPackageVersion();
 
-  if (coreLevel == 3 && coreVersion == 1 && pkgVersion == 3)
+  if (pkgVersion >= 3)
   {
     mName = name;
     return LIBSBML_OPERATION_SUCCESS;
@@ -269,11 +265,9 @@ UserDefinedConstraint::setName(const std::string& name)
 int
 UserDefinedConstraint::setLowerBound(const std::string& lowerBound)
 {
-  unsigned int coreLevel = getLevel();
-  unsigned int coreVersion = getVersion();
   unsigned int pkgVersion = getPackageVersion();
 
-  if (coreLevel == 3 && coreVersion == 1 && pkgVersion == 3)
+  if (pkgVersion >= 3)
   {
     if (!(SyntaxChecker::isValidInternalSId(lowerBound)))
     {
@@ -298,11 +292,9 @@ UserDefinedConstraint::setLowerBound(const std::string& lowerBound)
 int
 UserDefinedConstraint::setUpperBound(const std::string& upperBound)
 {
-  unsigned int coreLevel = getLevel();
-  unsigned int coreVersion = getVersion();
   unsigned int pkgVersion = getPackageVersion();
 
-  if (coreLevel == 3 && coreVersion == 1 && pkgVersion == 3)
+  if (pkgVersion >= 3)
   {
     if (!(SyntaxChecker::isValidInternalSId(upperBound)))
     {
@@ -509,10 +501,6 @@ UserDefinedConstraint::addUserDefinedConstraintComponent(const
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != udcc->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (matchesRequiredSBMLNamespacesForAddition(static_cast<const
     SBase*>(udcc)) == false)
   {
@@ -643,11 +631,9 @@ UserDefinedConstraint::hasRequiredAttributes() const
 {
   bool allPresent = true;
 
-  unsigned int level = getLevel();
-  unsigned int version = getVersion();
   unsigned int pkgVersion = getPackageVersion();
 
-  if (level == 3 && version == 1 && pkgVersion == 3)
+  if (pkgVersion >= 3)
   {
     if (isSetLowerBound() == false)
     {
@@ -655,7 +641,7 @@ UserDefinedConstraint::hasRequiredAttributes() const
     }
   }
 
-  if (level == 3 && version == 1 && pkgVersion == 3)
+  if (pkgVersion >= 3)
   {
     if (isSetUpperBound() == false)
     {
@@ -1335,11 +1321,9 @@ UserDefinedConstraint::addExpectedAttributes(ExpectedAttributes& attributes)
 {
   SBase::addExpectedAttributes(attributes);
 
-  unsigned int level = getLevel();
-  unsigned int coreVersion = getVersion();
   unsigned int pkgVersion = getPackageVersion();
 
-  if (level == 3 && coreVersion == 1 && pkgVersion == 3)
+  if (pkgVersion >= 3)
   {
     attributes.add("id");
     attributes.add("name");
@@ -1428,7 +1412,7 @@ UserDefinedConstraint::readAttributes(const XMLAttributes& attributes,
     }
   }
 
-  if (level == 3 && version == 1 && pkgVersion == 3)
+  if (pkgVersion >= 3)
   {
     readL3V1V3Attributes(attributes);
   }
@@ -1581,11 +1565,9 @@ UserDefinedConstraint::writeAttributes(XMLOutputStream& stream) const
 {
   SBase::writeAttributes(stream);
 
-  unsigned int level = getLevel();
-  unsigned int version = getVersion();
   unsigned int pkgVersion = getPackageVersion();
 
-  if (level == 3 && version == 1 && pkgVersion == 3)
+  if (pkgVersion >= 3)
   {
     writeL3V1V3Attributes(stream);
   }

--- a/src/sbml/packages/fbc/sbml/UserDefinedConstraintComponent.cpp
+++ b/src/sbml/packages/fbc/sbml/UserDefinedConstraintComponent.cpp
@@ -292,11 +292,9 @@ UserDefinedConstraintComponent::isSetVariableType() const
 int
 UserDefinedConstraintComponent::setId(const std::string& id)
 {
-  unsigned int coreLevel = getLevel();
-  unsigned int coreVersion = getVersion();
   unsigned int pkgVersion = getPackageVersion();
 
-  if (coreLevel == 3 && coreVersion == 1 && pkgVersion == 3)
+  if (pkgVersion >= 3)
   {
     return SyntaxChecker::checkAndSetSId(id, mId);
   }
@@ -314,11 +312,9 @@ UserDefinedConstraintComponent::setId(const std::string& id)
 int
 UserDefinedConstraintComponent::setName(const std::string& name)
 {
-  unsigned int coreLevel = getLevel();
-  unsigned int coreVersion = getVersion();
   unsigned int pkgVersion = getPackageVersion();
 
-  if (coreLevel == 3 && coreVersion == 1 && pkgVersion == 3)
+  if (pkgVersion >= 3)
   {
     mName = name;
     return LIBSBML_OPERATION_SUCCESS;
@@ -337,11 +333,9 @@ UserDefinedConstraintComponent::setName(const std::string& name)
 int
 UserDefinedConstraintComponent::setCoefficient(const std::string& coefficient)
 {
-  unsigned int coreLevel = getLevel();
-  unsigned int coreVersion = getVersion();
   unsigned int pkgVersion = getPackageVersion();
 
-  if (coreLevel == 3 && coreVersion == 1 && pkgVersion == 3)
+  if (pkgVersion >= 3)
   {
     if (!(SyntaxChecker::isValidInternalSId(coefficient)))
     {
@@ -367,11 +361,9 @@ UserDefinedConstraintComponent::setCoefficient(const std::string& coefficient)
 int
 UserDefinedConstraintComponent::setVariable(const std::string& variable)
 {
-  unsigned int coreLevel = getLevel();
-  unsigned int coreVersion = getVersion();
   unsigned int pkgVersion = getPackageVersion();
 
-  if (coreLevel == 3 && coreVersion == 1 && pkgVersion == 3)
+  if (pkgVersion >= 3)
   {
     if (!(SyntaxChecker::isValidInternalSId(variable)))
     {
@@ -397,11 +389,9 @@ UserDefinedConstraintComponent::setVariable(const std::string& variable)
 int
 UserDefinedConstraintComponent::setVariable2(const std::string& variable)
 {
-  unsigned int coreLevel = getLevel();
-  unsigned int coreVersion = getVersion();
   unsigned int pkgVersion = getPackageVersion();
 
-  if (coreLevel == 3 && coreVersion == 1 && pkgVersion == 3)
+  if (pkgVersion >= 3)
   {
     if (!(SyntaxChecker::isValidInternalSId(variable)))
     {
@@ -428,11 +418,9 @@ int
 UserDefinedConstraintComponent::setVariableType(const FbcVariableType_t
   variableType)
 {
-  unsigned int coreLevel = getLevel();
-  unsigned int coreVersion = getVersion();
   unsigned int pkgVersion = getPackageVersion();
 
-  if (coreLevel == 3 && coreVersion == 1 && pkgVersion == 3)
+  if (pkgVersion >= 3)
   {
     if (FbcVariableType_isValid(variableType) == 0)
     {
@@ -460,11 +448,9 @@ int
 UserDefinedConstraintComponent::setVariableType(const std::string&
   variableType)
 {
-  unsigned int coreLevel = getLevel();
-  unsigned int coreVersion = getVersion();
   unsigned int pkgVersion = getPackageVersion();
 
-  if (coreLevel == 3 && coreVersion == 1 && pkgVersion == 3)
+  if (pkgVersion >= 3)
   {
     mVariableType = FbcVariableType_fromString(variableType.c_str());
 
@@ -649,28 +635,18 @@ UserDefinedConstraintComponent::hasRequiredAttributes() const
 {
   bool allPresent = true;
 
-  unsigned int level = getLevel();
-  unsigned int version = getVersion();
   unsigned int pkgVersion = getPackageVersion();
 
-  if (level == 3 && version == 1 && pkgVersion == 3)
+  if (pkgVersion >= 3)
   {
     if (isSetCoefficient() == false)
     {
       allPresent = false;
     }
-  }
-
-  if (level == 3 && version == 1 && pkgVersion == 3)
-  {
     if (isSetVariable() == false)
     {
       allPresent = false;
     }
-  }
-
-  if (level == 3 && version == 1 && pkgVersion == 3)
-  {
     if (isSetVariableType() == false)
     {
       allPresent = false;
@@ -1099,11 +1075,9 @@ UserDefinedConstraintComponent::addExpectedAttributes(ExpectedAttributes&
 {
   SBase::addExpectedAttributes(attributes);
 
-  unsigned int level = getLevel();
-  unsigned int coreVersion = getVersion();
   unsigned int pkgVersion = getPackageVersion();
 
-  if (level == 3 && coreVersion == 1 && pkgVersion == 3)
+  if (pkgVersion >= 3)
   {
     attributes.add("id");
     attributes.add("name");
@@ -1194,7 +1168,7 @@ UserDefinedConstraintComponent::readAttributes(const XMLAttributes& attributes,
     }
   }
 
-  if (level == 3 && version == 1 && pkgVersion == 3)
+  if (pkgVersion >= 3)
   {
     readL3V1V3Attributes(attributes);
   }
@@ -1448,10 +1422,9 @@ UserDefinedConstraintComponent::writeAttributes(XMLOutputStream& stream) const
   SBase::writeAttributes(stream);
 
   unsigned int level = getLevel();
-  unsigned int version = getVersion();
   unsigned int pkgVersion = getPackageVersion();
 
-  if (level == 3 && pkgVersion == 3)
+  if (level == 3 && pkgVersion >= 3)
   {
     writeL3V1V3Attributes(stream);
   }


### PR DESCRIPTION
Fixes #360 

Some objects already didn't check the version, and some didn't check the level, either.  This standardizes on just checking the package version.

Doesn't fix anything for other packages, just FBC.