### PR TITLE
Enable CMake user option `BUILD_SHARED_LIB`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,10 +171,20 @@ set (LIBSBML_FIND_MODULES "${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules/FindLIBSBML.
 #
 
 # Build static / shared library
-option(BUILD_SHARED_LIBS  "Build shared library. (Set to OFF to build static libraries.)" ON)
+# 
+# Here we check whether the user has defined BUILD_SHARED_LIBS. If it is
+# defined we will honor the value, otherwise we continue to use the 
+# LIBSBML_SKIP variables to determine whether to build shared or static
+# libraries.
 
-if(NOT BUILD_SHARED_LIBS)
-  set(LIBSBML_SKIP_SHARED_LIBRARY ON)
+if(DEFINED BUILD_SHARED_LIBS)
+  if (BUILD_SHARED_LIBS)
+    set(LIBSBML_SKIP_SHARED_LIBRARY OFF)
+    set(LIBSBML_SKIP_STATIC_LIBRARY ON)
+  else()
+    set(LIBSBML_SKIP_SHARED_LIBRARY ON)
+    set(LIBSBML_SKIP_STATIC_LIBRARY OFF)
+  endif()
 endif()
 
 # Whether to compile examples

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,7 +171,11 @@ set (LIBSBML_FIND_MODULES "${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules/FindLIBSBML.
 #
 
 # Build static / shared library
-# option(BUILD_SHARED_LIBS  "Build shared library. (Set to OFF to build static libraries.)" OFF)
+option(BUILD_SHARED_LIBS  "Build shared library. (Set to OFF to build static libraries.)" ON)
+
+if(NOT BUILD_SHARED_LIBS)
+  set(LIBSBML_SKIP_SHARED_LIBRARY ON)
+endif()
 
 # Whether to compile examples
 option(WITH_EXAMPLES "Compile the libSBML example programs."  OFF)


### PR DESCRIPTION
## Description
The CMake configuration does not respect the user option "-DBUILD_SHARED_LIB=<ON/OFF>". Package managers (and users) commonly use this main configuration option to decide whether to build the project as a shared or static library. Specifically, library build systems for dependencies of R-packages expect the `BUILD_SHARED_LIB` option: ([Windows build system](https://github.com/r-windows/rtools-packages/blob/31f09c0801f9b038e91e8905ad83473a7c447472/mingw-w64-libsbml/PKGBUILD), [MacOS build system](https://github.com/R-macos/recipes/pull/49)).

Generally, the `BUILD_SHARED_LIB` variable directly affects the command `add_library()` if no type (`SHARED` or `STATIC`) is given to the function. Instead of `BUILD_SHARED_LIB`, libsbml's CMake setup seems to use the non-canonical options `LIBSBML_SKIP_SHARED_LIBRARY` and `LIBSBML_SKIP_STATIC_LIBRARY`:

https://github.com/sbmlteam/libsbml/blob/a3e217851f18d3c5e8e2b0082fb98176738491e8/src/CMakeLists.txt#L512C1-L513C2
https://github.com/sbmlteam/libsbml/blob/a3e217851f18d3c5e8e2b0082fb98176738491e8/src/CMakeLists.txt#L462C1-L464C2


## Motivation and Context
Although I think the libsbml-specific shared/static build config options (LIBSBML_SKIP_<SHARED/STATIC>_LIBRARY) are totally fine, I would suggest enabling the widespread user option `BUILD_SHARED_LIB` as well, which would make libsbml also more accessible and easier to implement for developers of packages and toolchains.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Change in documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have updated all documentation necessary.
- [X] I have checked spelling in (new) comments.

## Testing
- [ ] Testing is done automatically and codecov shows test coverage
- [X] This cannot be tested automatically
I tested the new option manually using the CMake GUI in Windows. It worked as expected: Shared library build can be skipped with the new option "-DBUILD_SHARED_LIB=OFF".

