### PR TITLE
 - ensure expat can be found when crosscompiling

### DIFF
--- a/CMakeModules/FindEXPAT.cmake
+++ b/CMakeModules/FindEXPAT.cmake
@@ -48,11 +48,13 @@ find_path(EXPAT_INCLUDE_DIR expat.h
           /opt/csw/include   # Blastwave
           /opt/include
           /usr/freeware/include
-          NO_DEFAULT_PATH)
+          NO_DEFAULT_PATH
+          CMAKE_FIND_ROOT_PATH_BOTH)
 endif ()
 
 if (NOT EXPAT_INCLUDE_DIR)
-    find_path(EXPAT_INCLUDE_DIR expat.h)
+    find_path(EXPAT_INCLUDE_DIR expat.h
+    CMAKE_FIND_ROOT_PATH_BOTH)
 endif ()
 
 find_library(EXPAT_LIBRARY 
@@ -81,11 +83,13 @@ find_library(EXPAT_LIBRARY
           /opt/csw/lib   # Blastwave
           /opt/lib
           /usr/freeware/lib64
-          NO_DEFAULT_PATH)
+          NO_DEFAULT_PATH
+          CMAKE_FIND_ROOT_PATH_BOTH)
 endif()
 
 if (NOT EXPAT_LIBRARY)
-    find_library(EXPAT_LIBRARY NAMES libexpat expat)
+    find_library(EXPAT_LIBRARY NAMES libexpat expat
+    CMAKE_FIND_ROOT_PATH_BOTH )
 endif ()
 
 mark_as_advanced(EXPAT_INCLUDE_DIR EXPAT_LIBRARY)


### PR DESCRIPTION
## Description
expat is currently not found when crosscompiling, this commit fixes the issue 

## Motivation and Context
fixes the issue that pyodide cant compile libsbml

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Change in documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have updated all documentation necessary.
- [ ] I have checked spelling in (new) comments.

## Testing
- [X] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested -->

