### PR TITLE
Replace deprecated unittest.makeSuite()

### DIFF
--- a/src/bindings/python/test.py
+++ b/src/bindings/python/test.py
@@ -43,6 +43,7 @@ test_files   = "/Test*.py"
 
 def suite():
   suite = unittest.TestSuite()
+  loader = unittest.TestLoader()
   cwd = os.getcwd()    
   sys.path.append(cwd)
   os.chdir(test_basedir + '/..')
@@ -52,7 +53,7 @@ def suite():
       module_name = re.compile(r"\.py$").sub('',os.path.basename(file))     
       module = __import__(module_name)
       class_name = getattr(module, module_name)
-      suite.addTest(unittest.makeSuite(class_name))
+      suite.addTest(loader.loadTestsFromTestCase(class_name))
   return suite
 
 if __name__ == "__main__":

--- a/src/bindings/python/test/annotation/TestAnnotationCopyAndClone.py
+++ b/src/bindings/python/test/annotation/TestAnnotationCopyAndClone.py
@@ -223,7 +223,7 @@ class TestAnnotationCopyAndClone(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestAnnotationCopyAndClone))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestAnnotationCopyAndClone))
 
   return suite
 

--- a/src/bindings/python/test/annotation/TestCVTerms.py
+++ b/src/bindings/python/test/annotation/TestCVTerms.py
@@ -124,7 +124,7 @@ class TestCVTerms(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestCVTerms))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestCVTerms))
 
   return suite
 

--- a/src/bindings/python/test/annotation/TestCVTerms_newSetters.py
+++ b/src/bindings/python/test/annotation/TestCVTerms_newSetters.py
@@ -124,7 +124,7 @@ class TestCVTerms_newSetters(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestCVTerms_newSetters))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestCVTerms_newSetters))
 
   return suite
 

--- a/src/bindings/python/test/annotation/TestDate_newSetters.py
+++ b/src/bindings/python/test/annotation/TestDate_newSetters.py
@@ -190,7 +190,7 @@ class TestDate_newSetters(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestDate_newSetters))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestDate_newSetters))
 
   return suite
 

--- a/src/bindings/python/test/annotation/TestL3ModelHistory.py
+++ b/src/bindings/python/test/annotation/TestL3ModelHistory.py
@@ -341,7 +341,7 @@ class TestL3ModelHistory(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestL3ModelHistory))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestL3ModelHistory))
 
   return suite
 

--- a/src/bindings/python/test/annotation/TestModelCreator_newSetters.py
+++ b/src/bindings/python/test/annotation/TestModelCreator_newSetters.py
@@ -111,7 +111,7 @@ class TestModelCreator_newSetters(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestModelCreator_newSetters))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestModelCreator_newSetters))
 
   return suite
 

--- a/src/bindings/python/test/annotation/TestModelHistory.py
+++ b/src/bindings/python/test/annotation/TestModelHistory.py
@@ -280,7 +280,7 @@ class TestModelHistory(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestModelHistory))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestModelHistory))
 
   return suite
 

--- a/src/bindings/python/test/annotation/TestModelHistory_newSetters.py
+++ b/src/bindings/python/test/annotation/TestModelHistory_newSetters.py
@@ -127,7 +127,7 @@ class TestModelHistory_newSetters(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestModelHistory_newSetters))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestModelHistory_newSetters))
 
   return suite
 

--- a/src/bindings/python/test/annotation/TestRDFAnnotation.py
+++ b/src/bindings/python/test/annotation/TestRDFAnnotation.py
@@ -746,7 +746,7 @@ class TestRDFAnnotation(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestRDFAnnotation))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestRDFAnnotation))
 
   return suite
 

--- a/src/bindings/python/test/annotation/TestRDFAnnotation2.py
+++ b/src/bindings/python/test/annotation/TestRDFAnnotation2.py
@@ -239,7 +239,7 @@ class TestRDFAnnotation2(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestRDFAnnotation2))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestRDFAnnotation2))
 
   return suite
 

--- a/src/bindings/python/test/annotation/TestRDFAnnotationC.py
+++ b/src/bindings/python/test/annotation/TestRDFAnnotationC.py
@@ -221,7 +221,7 @@ class TestRDFAnnotationC(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestRDFAnnotationC))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestRDFAnnotationC))
 
   return suite
 

--- a/src/bindings/python/test/annotation/TestValidation.py
+++ b/src/bindings/python/test/annotation/TestValidation.py
@@ -156,7 +156,7 @@ class TestValidation(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestValidation))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestValidation))
 
   return suite
 

--- a/src/bindings/python/test/math/TestASTNode.py
+++ b/src/bindings/python/test/math/TestASTNode.py
@@ -1158,7 +1158,7 @@ class TestASTNode(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestASTNode))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestASTNode))
 
   return suite
 

--- a/src/bindings/python/test/math/TestL3FormulaParserC.py
+++ b/src/bindings/python/test/math/TestL3FormulaParserC.py
@@ -1268,7 +1268,7 @@ class TestL3FormulaParserC(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestL3FormulaParserC))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestL3FormulaParserC))
 
   return suite
 

--- a/src/bindings/python/test/math/TestMathReadFromFile1.py
+++ b/src/bindings/python/test/math/TestMathReadFromFile1.py
@@ -96,7 +96,7 @@ class TestMathReadFromFile1(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestMathReadFromFile1))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestMathReadFromFile1))
 
   return suite
 

--- a/src/bindings/python/test/math/TestMathReadFromFile2.py
+++ b/src/bindings/python/test/math/TestMathReadFromFile2.py
@@ -120,7 +120,7 @@ class TestMathReadFromFile2(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestMathReadFromFile2))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestMathReadFromFile2))
 
   return suite
 

--- a/src/bindings/python/test/math/TestReadMathML.py
+++ b/src/bindings/python/test/math/TestReadMathML.py
@@ -935,7 +935,7 @@ class TestReadMathML(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestReadMathML))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestReadMathML))
 
   return suite
 

--- a/src/bindings/python/test/math/TestValidASTNode.py
+++ b/src/bindings/python/test/math/TestValidASTNode.py
@@ -239,7 +239,7 @@ class TestValidASTNode(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestValidASTNode))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestValidASTNode))
 
   return suite
 

--- a/src/bindings/python/test/math/TestWriteMathML.py
+++ b/src/bindings/python/test/math/TestWriteMathML.py
@@ -568,7 +568,7 @@ class TestWriteMathML(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestWriteMathML))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestWriteMathML))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestAlgebraicRule.py
+++ b/src/bindings/python/test/sbml/TestAlgebraicRule.py
@@ -106,7 +106,7 @@ class TestAlgebraicRule(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestAlgebraicRule))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestAlgebraicRule))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestAncestor.py
+++ b/src/bindings/python/test/sbml/TestAncestor.py
@@ -887,7 +887,7 @@ class TestAncestor(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestAncestor))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestAncestor))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestAssignmentRule.py
+++ b/src/bindings/python/test/sbml/TestAssignmentRule.py
@@ -127,7 +127,7 @@ class TestAssignmentRule(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestAssignmentRule))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestAssignmentRule))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestCompartment.py
+++ b/src/bindings/python/test/sbml/TestCompartment.py
@@ -226,7 +226,7 @@ class TestCompartment(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestCompartment))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestCompartment))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestCompartmentType.py
+++ b/src/bindings/python/test/sbml/TestCompartmentType.py
@@ -121,7 +121,7 @@ class TestCompartmentType(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestCompartmentType))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestCompartmentType))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestCompartmentType_newSetters.py
+++ b/src/bindings/python/test/sbml/TestCompartmentType_newSetters.py
@@ -94,7 +94,7 @@ class TestCompartmentType_newSetters(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestCompartmentType_newSetters))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestCompartmentType_newSetters))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestCompartmentVolumeRule.py
+++ b/src/bindings/python/test/sbml/TestCompartmentVolumeRule.py
@@ -83,7 +83,7 @@ class TestCompartmentVolumeRule(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestCompartmentVolumeRule))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestCompartmentVolumeRule))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestCompartment_newSetters.py
+++ b/src/bindings/python/test/sbml/TestCompartment_newSetters.py
@@ -285,7 +285,7 @@ class TestCompartment_newSetters(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestCompartment_newSetters))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestCompartment_newSetters))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestConsistencyChecks.py
+++ b/src/bindings/python/test/sbml/TestConsistencyChecks.py
@@ -80,7 +80,7 @@ class TestConsistencyChecks(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestConsistencyChecks))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestConsistencyChecks))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestConstraint.py
+++ b/src/bindings/python/test/sbml/TestConstraint.py
@@ -120,7 +120,7 @@ class TestConstraint(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestConstraint))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestConstraint))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestConstraint_newSetters.py
+++ b/src/bindings/python/test/sbml/TestConstraint_newSetters.py
@@ -108,7 +108,7 @@ class TestConstraint_newSetters(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestConstraint_newSetters))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestConstraint_newSetters))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestCopyAndClone.py
+++ b/src/bindings/python/test/sbml/TestCopyAndClone.py
@@ -925,7 +925,7 @@ class TestCopyAndClone(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestCopyAndClone))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestCopyAndClone))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestDelay.py
+++ b/src/bindings/python/test/sbml/TestDelay.py
@@ -123,7 +123,7 @@ class TestDelay(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestDelay))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestDelay))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestEvent.py
+++ b/src/bindings/python/test/sbml/TestEvent.py
@@ -214,7 +214,7 @@ class TestEvent(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestEvent))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestEvent))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestEventAssignment.py
+++ b/src/bindings/python/test/sbml/TestEventAssignment.py
@@ -120,7 +120,7 @@ class TestEventAssignment(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestEventAssignment))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestEventAssignment))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestEventAssignment_newSetters.py
+++ b/src/bindings/python/test/sbml/TestEventAssignment_newSetters.py
@@ -90,7 +90,7 @@ class TestEventAssignment_newSetters(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestEventAssignment_newSetters))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestEventAssignment_newSetters))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestEvent_newSetters.py
+++ b/src/bindings/python/test/sbml/TestEvent_newSetters.py
@@ -262,7 +262,7 @@ class TestEvent_newSetters(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestEvent_newSetters))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestEvent_newSetters))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestFunctionDefinition.py
+++ b/src/bindings/python/test/sbml/TestFunctionDefinition.py
@@ -186,7 +186,7 @@ class TestFunctionDefinition(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestFunctionDefinition))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestFunctionDefinition))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestFunctionDefinition_newSetters.py
+++ b/src/bindings/python/test/sbml/TestFunctionDefinition_newSetters.py
@@ -114,7 +114,7 @@ class TestFunctionDefinition_newSetters(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestFunctionDefinition_newSetters))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestFunctionDefinition_newSetters))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestGetMultipleObjects.py
+++ b/src/bindings/python/test/sbml/TestGetMultipleObjects.py
@@ -282,7 +282,7 @@ class TestGetMultipleObjects(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestGetMultipleObjects))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestGetMultipleObjects))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestInitialAssignment.py
+++ b/src/bindings/python/test/sbml/TestInitialAssignment.py
@@ -120,7 +120,7 @@ class TestInitialAssignment(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestInitialAssignment))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestInitialAssignment))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestInitialAssignment_newSetters.py
+++ b/src/bindings/python/test/sbml/TestInitialAssignment_newSetters.py
@@ -90,7 +90,7 @@ class TestInitialAssignment_newSetters(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestInitialAssignment_newSetters))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestInitialAssignment_newSetters))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestInternalConsistencyChecks.py
+++ b/src/bindings/python/test/sbml/TestInternalConsistencyChecks.py
@@ -1621,7 +1621,7 @@ class TestInternalConsistencyChecks(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestInternalConsistencyChecks))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestInternalConsistencyChecks))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestKineticLaw.py
+++ b/src/bindings/python/test/sbml/TestKineticLaw.py
@@ -220,7 +220,7 @@ class TestKineticLaw(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestKineticLaw))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestKineticLaw))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestKineticLaw_newSetters.py
+++ b/src/bindings/python/test/sbml/TestKineticLaw_newSetters.py
@@ -239,7 +239,7 @@ class TestKineticLaw_newSetters(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestKineticLaw_newSetters))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestKineticLaw_newSetters))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestL3Compartment.py
+++ b/src/bindings/python/test/sbml/TestL3Compartment.py
@@ -226,7 +226,7 @@ class TestL3Compartment(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestL3Compartment))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestL3Compartment))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestL3Event.py
+++ b/src/bindings/python/test/sbml/TestL3Event.py
@@ -177,7 +177,7 @@ class TestL3Event(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestL3Event))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestL3Event))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestL3KineticLaw.py
+++ b/src/bindings/python/test/sbml/TestL3KineticLaw.py
@@ -106,7 +106,7 @@ class TestL3KineticLaw(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestL3KineticLaw))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestL3KineticLaw))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestL3LocalParameter.py
+++ b/src/bindings/python/test/sbml/TestL3LocalParameter.py
@@ -161,7 +161,7 @@ class TestL3LocalParameter(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestL3LocalParameter))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestL3LocalParameter))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestL3Model.py
+++ b/src/bindings/python/test/sbml/TestL3Model.py
@@ -243,7 +243,7 @@ class TestL3Model(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestL3Model))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestL3Model))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestL3Parameter.py
+++ b/src/bindings/python/test/sbml/TestL3Parameter.py
@@ -177,7 +177,7 @@ class TestL3Parameter(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestL3Parameter))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestL3Parameter))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestL3Reaction.py
+++ b/src/bindings/python/test/sbml/TestL3Reaction.py
@@ -175,7 +175,7 @@ class TestL3Reaction(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestL3Reaction))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestL3Reaction))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestL3Species.py
+++ b/src/bindings/python/test/sbml/TestL3Species.py
@@ -331,7 +331,7 @@ class TestL3Species(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestL3Species))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestL3Species))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestL3SpeciesReference.py
+++ b/src/bindings/python/test/sbml/TestL3SpeciesReference.py
@@ -174,7 +174,7 @@ class TestL3SpeciesReference(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestL3SpeciesReference))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestL3SpeciesReference))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestL3Trigger.py
+++ b/src/bindings/python/test/sbml/TestL3Trigger.py
@@ -103,7 +103,7 @@ class TestL3Trigger(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestL3Trigger))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestL3Trigger))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestL3Unit.py
+++ b/src/bindings/python/test/sbml/TestL3Unit.py
@@ -153,7 +153,7 @@ class TestL3Unit(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestL3Unit))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestL3Unit))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestListOf.py
+++ b/src/bindings/python/test/sbml/TestListOf.py
@@ -132,7 +132,7 @@ class TestListOf(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestListOf))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestListOf))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestModel.py
+++ b/src/bindings/python/test/sbml/TestModel.py
@@ -927,7 +927,7 @@ class TestModel(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestModel))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestModel))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestModel_newSetters.py
+++ b/src/bindings/python/test/sbml/TestModel_newSetters.py
@@ -1010,7 +1010,7 @@ class TestModel_newSetters(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestModel_newSetters))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestModel_newSetters))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestModifierSpeciesReference.py
+++ b/src/bindings/python/test/sbml/TestModifierSpeciesReference.py
@@ -101,7 +101,7 @@ class TestModifierSpeciesReference(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestModifierSpeciesReference))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestModifierSpeciesReference))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestParameter.py
+++ b/src/bindings/python/test/sbml/TestParameter.py
@@ -133,7 +133,7 @@ class TestParameter(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestParameter))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestParameter))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestParameterRule.py
+++ b/src/bindings/python/test/sbml/TestParameterRule.py
@@ -100,7 +100,7 @@ class TestParameterRule(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestParameterRule))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestParameterRule))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestParameter_newSetters.py
+++ b/src/bindings/python/test/sbml/TestParameter_newSetters.py
@@ -154,7 +154,7 @@ class TestParameter_newSetters(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestParameter_newSetters))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestParameter_newSetters))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestPriority.py
+++ b/src/bindings/python/test/sbml/TestPriority.py
@@ -123,7 +123,7 @@ class TestPriority(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestPriority))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestPriority))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestRateRule.py
+++ b/src/bindings/python/test/sbml/TestRateRule.py
@@ -98,7 +98,7 @@ class TestRateRule(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestRateRule))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestRateRule))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestReaction.py
+++ b/src/bindings/python/test/sbml/TestReaction.py
@@ -244,7 +244,7 @@ class TestReaction(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestReaction))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestReaction))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestReaction_newSetters.py
+++ b/src/bindings/python/test/sbml/TestReaction_newSetters.py
@@ -294,7 +294,7 @@ class TestReaction_newSetters(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestReaction_newSetters))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestReaction_newSetters))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestReadFromFile1.py
+++ b/src/bindings/python/test/sbml/TestReadFromFile1.py
@@ -156,7 +156,7 @@ class TestReadFromFile1(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestReadFromFile1))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestReadFromFile1))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestReadFromFile2.py
+++ b/src/bindings/python/test/sbml/TestReadFromFile2.py
@@ -249,7 +249,7 @@ class TestReadFromFile2(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestReadFromFile2))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestReadFromFile2))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestReadFromFile3.py
+++ b/src/bindings/python/test/sbml/TestReadFromFile3.py
@@ -156,7 +156,7 @@ class TestReadFromFile3(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestReadFromFile3))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestReadFromFile3))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestReadFromFile4.py
+++ b/src/bindings/python/test/sbml/TestReadFromFile4.py
@@ -74,7 +74,7 @@ class TestReadFromFile4(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestReadFromFile4))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestReadFromFile4))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestReadFromFile5.py
+++ b/src/bindings/python/test/sbml/TestReadFromFile5.py
@@ -177,7 +177,7 @@ class TestReadFromFile5(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestReadFromFile5))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestReadFromFile5))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestReadFromFile6.py
+++ b/src/bindings/python/test/sbml/TestReadFromFile6.py
@@ -168,7 +168,7 @@ class TestReadFromFile6(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestReadFromFile6))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestReadFromFile6))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestReadFromFile7.py
+++ b/src/bindings/python/test/sbml/TestReadFromFile7.py
@@ -240,7 +240,7 @@ class TestReadFromFile7(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestReadFromFile7))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestReadFromFile7))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestReadFromFile8.py
+++ b/src/bindings/python/test/sbml/TestReadFromFile8.py
@@ -75,7 +75,7 @@ class TestReadFromFile8(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestReadFromFile8))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestReadFromFile8))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestReadFromFile9.py
+++ b/src/bindings/python/test/sbml/TestReadFromFile9.py
@@ -252,7 +252,7 @@ class TestReadFromFile9(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestReadFromFile9))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestReadFromFile9))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestReadSBML.py
+++ b/src/bindings/python/test/sbml/TestReadSBML.py
@@ -1497,7 +1497,7 @@ class TestReadSBML(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestReadSBML))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestReadSBML))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestRequiredAttributes.py
+++ b/src/bindings/python/test/sbml/TestRequiredAttributes.py
@@ -267,7 +267,7 @@ class TestRequiredAttributes(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestRequiredAttributes))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestRequiredAttributes))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestRequiredElements.py
+++ b/src/bindings/python/test/sbml/TestRequiredElements.py
@@ -233,7 +233,7 @@ class TestRequiredElements(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestRequiredElements))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestRequiredElements))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestRule.py
+++ b/src/bindings/python/test/sbml/TestRule.py
@@ -88,7 +88,7 @@ class TestRule(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestRule))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestRule))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestRule_newSetters.py
+++ b/src/bindings/python/test/sbml/TestRule_newSetters.py
@@ -173,7 +173,7 @@ class TestRule_newSetters(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestRule_newSetters))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestRule_newSetters))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestSBMLConstructorException.py
+++ b/src/bindings/python/test/sbml/TestSBMLConstructorException.py
@@ -1547,7 +1547,7 @@ class TestSBMLConstructorException(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestSBMLConstructorException))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestSBMLConstructorException))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestSBMLConvert.py
+++ b/src/bindings/python/test/sbml/TestSBMLConvert.py
@@ -465,7 +465,7 @@ class TestSBMLConvert(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestSBMLConvert))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestSBMLConvert))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestSBMLConvertStrict.py
+++ b/src/bindings/python/test/sbml/TestSBMLConvertStrict.py
@@ -155,7 +155,7 @@ class TestSBMLConvertStrict(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestSBMLConvertStrict))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestSBMLConvertStrict))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestSBMLDocument.py
+++ b/src/bindings/python/test/sbml/TestSBMLDocument.py
@@ -177,7 +177,7 @@ class TestSBMLDocument(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestSBMLDocument))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestSBMLDocument))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestSBMLError.py
+++ b/src/bindings/python/test/sbml/TestSBMLError.py
@@ -92,7 +92,7 @@ class TestSBMLError(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestSBMLError))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestSBMLError))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestSBMLNamespaces.py
+++ b/src/bindings/python/test/sbml/TestSBMLNamespaces.py
@@ -152,7 +152,7 @@ class TestSBMLNamespaces(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestSBMLNamespaces))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestSBMLNamespaces))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestSBMLParentObject.py
+++ b/src/bindings/python/test/sbml/TestSBMLParentObject.py
@@ -758,7 +758,7 @@ class TestSBMLParentObject(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestSBMLParentObject))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestSBMLParentObject))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestSBase.py
+++ b/src/bindings/python/test/sbml/TestSBase.py
@@ -1421,7 +1421,7 @@ class TestSBase(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestSBase))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestSBase))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestSBase_newSetters.py
+++ b/src/bindings/python/test/sbml/TestSBase_newSetters.py
@@ -1370,7 +1370,7 @@ class TestSBase_newSetters(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestSBase_newSetters))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestSBase_newSetters))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestSpecies.py
+++ b/src/bindings/python/test/sbml/TestSpecies.py
@@ -212,7 +212,7 @@ class TestSpecies(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestSpecies))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestSpecies))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestSpeciesConcentrationRule.py
+++ b/src/bindings/python/test/sbml/TestSpeciesConcentrationRule.py
@@ -83,7 +83,7 @@ class TestSpeciesConcentrationRule(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestSpeciesConcentrationRule))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestSpeciesConcentrationRule))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestSpeciesReference.py
+++ b/src/bindings/python/test/sbml/TestSpeciesReference.py
@@ -128,7 +128,7 @@ class TestSpeciesReference(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestSpeciesReference))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestSpeciesReference))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestSpeciesReference_newSetters.py
+++ b/src/bindings/python/test/sbml/TestSpeciesReference_newSetters.py
@@ -265,7 +265,7 @@ class TestSpeciesReference_newSetters(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestSpeciesReference_newSetters))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestSpeciesReference_newSetters))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestSpeciesType.py
+++ b/src/bindings/python/test/sbml/TestSpeciesType.py
@@ -121,7 +121,7 @@ class TestSpeciesType(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestSpeciesType))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestSpeciesType))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestSpeciesType_newSetters.py
+++ b/src/bindings/python/test/sbml/TestSpeciesType_newSetters.py
@@ -101,7 +101,7 @@ class TestSpeciesType_newSetters(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestSpeciesType_newSetters))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestSpeciesType_newSetters))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestSpecies_newSetters.py
+++ b/src/bindings/python/test/sbml/TestSpecies_newSetters.py
@@ -370,7 +370,7 @@ class TestSpecies_newSetters(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestSpecies_newSetters))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestSpecies_newSetters))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestStoichiometryMath.py
+++ b/src/bindings/python/test/sbml/TestStoichiometryMath.py
@@ -123,7 +123,7 @@ class TestStoichiometryMath(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestStoichiometryMath))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestStoichiometryMath))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestSyntaxChecker.py
+++ b/src/bindings/python/test/sbml/TestSyntaxChecker.py
@@ -96,7 +96,7 @@ class TestSyntaxChecker(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestSyntaxChecker))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestSyntaxChecker))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestTrigger.py
+++ b/src/bindings/python/test/sbml/TestTrigger.py
@@ -123,7 +123,7 @@ class TestTrigger(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestTrigger))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestTrigger))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestUnit.py
+++ b/src/bindings/python/test/sbml/TestUnit.py
@@ -194,7 +194,7 @@ class TestUnit(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestUnit))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestUnit))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestUnitDefinition.py
+++ b/src/bindings/python/test/sbml/TestUnitDefinition.py
@@ -468,7 +468,7 @@ class TestUnitDefinition(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestUnitDefinition))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestUnitDefinition))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestUnitDefinition_newSetters.py
+++ b/src/bindings/python/test/sbml/TestUnitDefinition_newSetters.py
@@ -140,7 +140,7 @@ class TestUnitDefinition_newSetters(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestUnitDefinition_newSetters))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestUnitDefinition_newSetters))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestUnitKind.py
+++ b/src/bindings/python/test/sbml/TestUnitKind.py
@@ -185,7 +185,7 @@ class TestUnitKind(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestUnitKind))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestUnitKind))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestUnit_newSetters.py
+++ b/src/bindings/python/test/sbml/TestUnit_newSetters.py
@@ -124,7 +124,7 @@ class TestUnit_newSetters(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestUnit_newSetters))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestUnit_newSetters))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestWriteL3SBML.py
+++ b/src/bindings/python/test/sbml/TestWriteL3SBML.py
@@ -546,7 +546,7 @@ class TestWriteL3SBML(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestWriteL3SBML))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestWriteL3SBML))
 
   return suite
 

--- a/src/bindings/python/test/sbml/TestWriteSBML.py
+++ b/src/bindings/python/test/sbml/TestWriteSBML.py
@@ -1677,7 +1677,7 @@ class TestWriteSBML(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestWriteSBML))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestWriteSBML))
 
   return suite
 

--- a/src/bindings/python/test/xml/TestXMLAttributes.py
+++ b/src/bindings/python/test/xml/TestXMLAttributes.py
@@ -137,7 +137,7 @@ class TestXMLAttributes(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestXMLAttributes))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestXMLAttributes))
 
   return suite
 

--- a/src/bindings/python/test/xml/TestXMLAttributesC.py
+++ b/src/bindings/python/test/xml/TestXMLAttributesC.py
@@ -220,7 +220,7 @@ class TestXMLAttributesC(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestXMLAttributesC))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestXMLAttributesC))
 
   return suite
 

--- a/src/bindings/python/test/xml/TestXMLCopyAndClone.py
+++ b/src/bindings/python/test/xml/TestXMLCopyAndClone.py
@@ -289,7 +289,7 @@ class TestXMLCopyAndClone(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestXMLCopyAndClone))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestXMLCopyAndClone))
 
   return suite
 

--- a/src/bindings/python/test/xml/TestXMLError.py
+++ b/src/bindings/python/test/xml/TestXMLError.py
@@ -94,7 +94,7 @@ class TestXMLError(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestXMLError))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestXMLError))
 
   return suite
 

--- a/src/bindings/python/test/xml/TestXMLErrorC.py
+++ b/src/bindings/python/test/xml/TestXMLErrorC.py
@@ -63,7 +63,7 @@ class TestXMLErrorC(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestXMLErrorC))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestXMLErrorC))
 
   return suite
 

--- a/src/bindings/python/test/xml/TestXMLNamespaces.py
+++ b/src/bindings/python/test/xml/TestXMLNamespaces.py
@@ -239,7 +239,7 @@ class TestXMLNamespaces(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestXMLNamespaces))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestXMLNamespaces))
 
   return suite
 

--- a/src/bindings/python/test/xml/TestXMLNode.py
+++ b/src/bindings/python/test/xml/TestXMLNode.py
@@ -907,7 +907,7 @@ class TestXMLNode(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestXMLNode))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestXMLNode))
 
   return suite
 

--- a/src/bindings/python/test/xml/TestXMLNode_newSetters.py
+++ b/src/bindings/python/test/xml/TestXMLNode_newSetters.py
@@ -218,7 +218,7 @@ class TestXMLNode_newSetters(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestXMLNode_newSetters))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestXMLNode_newSetters))
 
   return suite
 

--- a/src/bindings/python/test/xml/TestXMLOutputStream.py
+++ b/src/bindings/python/test/xml/TestXMLOutputStream.py
@@ -149,7 +149,7 @@ class TestXMLOutputStream(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestXMLOutputStream))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestXMLOutputStream))
 
   return suite
 

--- a/src/bindings/python/test/xml/TestXMLToken.py
+++ b/src/bindings/python/test/xml/TestXMLToken.py
@@ -471,7 +471,7 @@ class TestXMLToken(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestXMLToken))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestXMLToken))
 
   return suite
 

--- a/src/bindings/python/test/xml/TestXMLToken_newSetters.py
+++ b/src/bindings/python/test/xml/TestXMLToken_newSetters.py
@@ -344,7 +344,7 @@ class TestXMLToken_newSetters(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestXMLToken_newSetters))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestXMLToken_newSetters))
 
   return suite
 

--- a/src/bindings/python/test/xml/TestXMLTriple.py
+++ b/src/bindings/python/test/xml/TestXMLTriple.py
@@ -60,7 +60,7 @@ class TestXMLTriple(unittest.TestCase):
 
 def suite():
   suite = unittest.TestSuite()
-  suite.addTest(unittest.makeSuite(TestXMLTriple))
+  suite.addTest(unittest.TestLoader.loadTestsFromTestCase(TestXMLTriple))
 
   return suite
 


### PR DESCRIPTION
The function has been deprecated in Python 3.11 and will be removed from
the upcoming Python 3.13.

See: https://docs.python.org/3.13/whatsnew/3.13.html#unittest
