### PR TITLE
Change model failures to slightly more likely mistake.

### DIFF
--- a/src/sbml/validator/test/test-data/sbml-general-consistency-constraints/21104-fail-01-02.xml
+++ b/src/sbml/validator/test/test-data/sbml-general-consistency-constraints/21104-fail-01-02.xml
@@ -15,7 +15,7 @@ listOfModifiers (optional), kineticLaw. (References: L2V2 Section 4.13.)
 		<listOfReactions>
 			<reaction id="r">
 				<listOfReactants>
-					<modiferSpeciesReference species="s"/>
+					<modifierSpeciesReference species="s"/>
 				</listOfReactants>
 				<listOfProducts>
 					<speciesReference species="s"/>

--- a/src/sbml/validator/test/test-data/sbml-general-consistency-constraints/21104-fail-01-04.xml
+++ b/src/sbml/validator/test/test-data/sbml-general-consistency-constraints/21104-fail-01-04.xml
@@ -15,7 +15,7 @@ listOfModifiers (optional), kineticLaw. (References: L2V2 Section 4.13.)
 		<listOfReactions>
 			<reaction id="r">
 				<listOfReactants>
-					<modiferSpeciesReference species="s"/>
+					<modifierSpeciesReference species="s"/>
 				</listOfReactants>
 				<listOfProducts>
 					<speciesReference species="s"/>

--- a/src/sbml/validator/test/test-data/sbml-general-consistency-constraints/21104-fail-01-06.xml
+++ b/src/sbml/validator/test/test-data/sbml-general-consistency-constraints/21104-fail-01-06.xml
@@ -15,7 +15,7 @@ listOfModifiers (optional), kineticLaw. (References: L2V2 Section 4.13.)
 		<listOfReactions>
 			<reaction id="r">
 				<listOfReactants>
-					<modiferSpeciesReference species="s"/>
+					<modifierSpeciesReference species="s"/>
 				</listOfReactants>
 				<listOfProducts>
 					<speciesReference species="s"/>

--- a/src/sbml/validator/test/test-data/sbml-general-consistency-constraints/21104-fail-01-12.xml
+++ b/src/sbml/validator/test/test-data/sbml-general-consistency-constraints/21104-fail-01-12.xml
@@ -15,7 +15,7 @@ listOfModifiers (optional), kineticLaw. (References: L2V2 Section 4.13.)
 		<listOfReactions>
 			<reaction id="r">
 				<listOfReactants>
-					<modiferSpeciesReference species="s"/>
+					<modifierSpeciesReference species="s"/>
 				</listOfReactants>
 				<listOfProducts>
 					<speciesReference species="s"/>

--- a/src/sbml/validator/test/test-data/sbml-general-consistency-constraints/21104-fail-01-13.xml
+++ b/src/sbml/validator/test/test-data/sbml-general-consistency-constraints/21104-fail-01-13.xml
@@ -30,7 +30,7 @@
           <speciesReference species="s" stoichiometry="1" constant="true"/>
         </listOfReactants>
         <listOfProducts>
-          <modiferSpeciesReference species="s" constant="true"/>
+          <modifierSpeciesReference species="s" constant="true"/>
         </listOfProducts>
       </reaction>
     </listOfReactions>

--- a/src/sbml/validator/test/test-data/sbml-general-consistency-constraints/21104-fail-01-16.xml
+++ b/src/sbml/validator/test/test-data/sbml-general-consistency-constraints/21104-fail-01-16.xml
@@ -15,7 +15,7 @@ listOfModifiers (optional), kineticLaw. (References: L2V2 Section 4.13.)
 		<listOfReactions>
 			<reaction id="r">
 				<listOfReactants>
-					<modiferSpeciesReference species="s"/>
+					<modifierSpeciesReference species="s"/>
 				</listOfReactants>
 				<listOfProducts>
 					<speciesReference species="s"/>

--- a/src/sbml/validator/test/test-data/sbml-general-consistency-constraints/21104-fail-01-17.xml
+++ b/src/sbml/validator/test/test-data/sbml-general-consistency-constraints/21104-fail-01-17.xml
@@ -30,7 +30,7 @@
           <speciesReference species="s" stoichiometry="1" constant="true"/>
         </listOfReactants>
         <listOfProducts>
-          <modiferSpeciesReference species="s" constant="true"/>
+          <modifierSpeciesReference species="s" constant="true"/>
         </listOfProducts>
       </reaction>
     </listOfReactions>


### PR DESCRIPTION
The original version of these files was indeed wrong as per the failure they are supposed to test, but it's slightly more likely that someone might make a mistake putting in a correctly-spelled-but-incorrectly-placed 'modifierSpeciesReference' than they are to put in an incorrectly-spelled-and-also-incorrectly-placed 'modiferSpeciesReference'.

See #372.