### PR TITLE
add printf style formatting to Rf_error calls

### DIFF
--- a/src/bindings/r/local.i
+++ b/src/bindings/r/local.i
@@ -230,10 +230,10 @@ namespace std
     $action
   }
   catch (const SBMLConstructorException &e){
-    Rf_error(e.what());    
+    Rf_error("%s", e.what());    
   }
   catch (const SBMLExtensionException &e){
-    Rf_error(e.what());    
+    Rf_error("%s", e.what());    
   }  
 }
 %enddef
@@ -311,7 +311,7 @@ SBMLCONSTRUCTOR_EXCEPTION(ListOfUnits)
     $action
   }
   catch (const XMLConstructorException &e){
-    Rf_error(e.what());    
+    Rf_error("%s", e.what());    
   }
   
 }


### PR DESCRIPTION
## Description
This change adds prinf style formatting to Rf_error calls. Without this, compilation fails when -Wformat-security is passed to gcc. 

```
/home/spot/git/libsbml/libsbml-5.20.2/build/src/bindings/r/libsbml_wrap.cpp:330601:17: error: format not a string literal and no format arguments [-Werror=format-security]
330601 |         Rf_error(e.what());
       |         ~~~~~~~~^~~~~~~~~~

```
I have tested this in Fedora 41 (Rawhide) against gcc-14.0.1 and R 4.4.0 and it resolves the "Fails To Build From Source" issue.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here, using the 'fixes #<issue>' syntax. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Change in documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have updated all documentation necessary.
- [x] I have checked spelling in (new) comments.

## Testing
- [X] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested -->

