### PR TITLE
Assignment cycle optimization

### DIFF
--- a/src/sbml/validator/constraints/AssignmentCycles.cpp
+++ b/src/sbml/validator/constraints/AssignmentCycles.cpp
@@ -274,9 +274,9 @@ bool
 AssignmentCycles::alreadyExistsInMap(IdMap& map, 
                                      const pair<const std::string, std::string>& dependency) const
 {
-  auto range = map.equal_range(dependency.first);
+  IdRange range = map.equal_range(dependency.first);
 
-  for (auto it = range.first; it != range.second; ++it)
+  for (IdIter it = range.first; it != range.second; ++it)
   {
       if (it->second == dependency.second)
           return true;

--- a/src/sbml/validator/constraints/AssignmentCycles.cpp
+++ b/src/sbml/validator/constraints/AssignmentCycles.cpp
@@ -84,7 +84,7 @@ AssignmentCycles::~AssignmentCycles ()
 void
 AssignmentCycles::check_ (const Model& m, const Model& object)
 {
-  // this rule ony applies in l2v2 and beyond
+  // this rule only applies in l2v2 and beyond
   if (object.getLevel() == 1 
     || (object.getLevel() == 2 && object.getVersion() == 1))
     return;
@@ -271,21 +271,19 @@ AssignmentCycles::determineAllDependencies()
 
 
 bool 
-AssignmentCycles::alreadyExistsInMap(IdMap map, 
-                                     pair<const std::string, std::string> dependency)
+AssignmentCycles::alreadyExistsInMap(IdMap& map, 
+                                     const pair<const std::string, std::string>& dependency) const
 {
-  bool exists = false;
-
   IdIter it;
   
-  for (it = map.begin(); it != map.end(); it++)
+  for (it = map.begin(); it != map.end(); ++it)
   {
     if (((*it).first == dependency.first)
       && ((*it).second == dependency.second))
-      exists = true;
+      return true;
   }
 
-  return exists;
+  return false;
 }
 
   

--- a/src/sbml/validator/constraints/AssignmentCycles.cpp
+++ b/src/sbml/validator/constraints/AssignmentCycles.cpp
@@ -274,13 +274,12 @@ bool
 AssignmentCycles::alreadyExistsInMap(IdMap& map, 
                                      const pair<const std::string, std::string>& dependency) const
 {
-  IdIter it;
-  
-  for (it = map.begin(); it != map.end(); ++it)
+  auto range = map.equal_range(dependency.first);
+
+  for (auto it = range.first; it != range.second; ++it)
   {
-    if (((*it).first == dependency.first)
-      && ((*it).second == dependency.second))
-      return true;
+      if (it->second == dependency.second)
+          return true;
   }
 
   return false;

--- a/src/sbml/validator/constraints/AssignmentCycles.h
+++ b/src/sbml/validator/constraints/AssignmentCycles.h
@@ -92,8 +92,8 @@ protected:
 
 
   /* helper function to check if a pair already exists */
-  bool alreadyExistsInMap(IdMap map, 
-                          std::pair<const std::string, std::string> dependency);
+  bool alreadyExistsInMap(IdMap& map, 
+                          const std::pair<const std::string, std::string>& dependency) const;
 
   
   /* check for explicit use of original variable */


### PR DESCRIPTION
## Description
This PR optimizes the determination of assignment cycle dependencies by avoiding to copy elements and using equal_range and early return when an existing edge was determined. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here, using the 'fixes #<issue>' syntax. -->
Drastically improves speed of the assignment cycle determination. fixes #374 



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Change in documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have updated all documentation necessary.
- [ ] I have checked spelling in (new) comments.

## Testing
- [X] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested -->

