### PR TITLE
Remove all checks for SBML core version when adding package elements.

### DIFF
--- a/src/sbml/packages/comp/extension/CompModelPlugin.cpp
+++ b/src/sbml/packages/comp/extension/CompModelPlugin.cpp
@@ -286,10 +286,6 @@ CompModelPlugin::addSubmodel (const Submodel* submodel)
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != submodel->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (getPackageVersion() != submodel->getPackageVersion())
   {
     return LIBSBML_PKG_VERSION_MISMATCH;
@@ -426,10 +422,6 @@ CompModelPlugin::addPort (const Port* port)
   else if (getLevel() != port->getLevel())
   {
     return LIBSBML_LEVEL_MISMATCH;
-  }
-  else if (getVersion() != port->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
   }
   else if (getPackageVersion() != port->getPackageVersion())
   {

--- a/src/sbml/packages/comp/extension/CompSBMLDocumentPlugin.cpp
+++ b/src/sbml/packages/comp/extension/CompSBMLDocumentPlugin.cpp
@@ -373,10 +373,6 @@ CompSBMLDocumentPlugin::addModelDefinition (const ModelDefinition* modelDefiniti
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != modelDefinition->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (getPackageVersion() != modelDefinition->getPackageVersion())
   {
     return LIBSBML_PKG_VERSION_MISMATCH;
@@ -510,10 +506,6 @@ CompSBMLDocumentPlugin::addExternalModelDefinition (const ExternalModelDefinitio
   else if (getLevel() != externalModelDefinition->getLevel())
   {
     return LIBSBML_LEVEL_MISMATCH;
-  }
-  else if (getVersion() != externalModelDefinition->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
   }
   else if (getPackageVersion() != externalModelDefinition->getPackageVersion())
   {

--- a/src/sbml/packages/comp/extension/CompSBasePlugin.cpp
+++ b/src/sbml/packages/comp/extension/CompSBasePlugin.cpp
@@ -336,10 +336,6 @@ CompSBasePlugin::addReplacedElement (const ReplacedElement* replacedElement)
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != replacedElement->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (getPackageVersion() != replacedElement->getPackageVersion())
   {
     return LIBSBML_PKG_VERSION_MISMATCH;
@@ -422,10 +418,6 @@ CompSBasePlugin::setReplacedBy (const ReplacedBy* replacedBy)
   else if (getLevel() != replacedBy->getLevel())
   {
     return LIBSBML_LEVEL_MISMATCH;
-  }
-  else if (getVersion() != replacedBy->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
   }
   else if (getPackageVersion() != replacedBy->getPackageVersion())
   {

--- a/src/sbml/packages/comp/sbml/SBaseRef.cpp
+++ b/src/sbml/packages/comp/sbml/SBaseRef.cpp
@@ -474,10 +474,6 @@ SBaseRef::setSBaseRef (const SBaseRef* sBaseRef)
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != sBaseRef->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (getPackageVersion() != sBaseRef->getPackageVersion())
   {
     return LIBSBML_PKG_VERSION_MISMATCH;

--- a/src/sbml/packages/comp/sbml/Submodel.cpp
+++ b/src/sbml/packages/comp/sbml/Submodel.cpp
@@ -474,10 +474,6 @@ Submodel::addDeletion (const Deletion* deletion)
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != deletion->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (getPackageVersion() != deletion->getPackageVersion())
   {
     return LIBSBML_PKG_VERSION_MISMATCH;

--- a/src/sbml/packages/distrib/extension/DistribSBasePlugin.cpp
+++ b/src/sbml/packages/distrib/extension/DistribSBasePlugin.cpp
@@ -175,10 +175,6 @@ DistribSBasePlugin::addUncertainty(const Uncertainty* u)
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != u->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (getPackageVersion() != u->getPackageVersion())
   {
     return LIBSBML_PKG_VERSION_MISMATCH;

--- a/src/sbml/packages/distrib/sbml/ListOfUncertParameters.cpp
+++ b/src/sbml/packages/distrib/sbml/ListOfUncertParameters.cpp
@@ -220,10 +220,6 @@ ListOfUncertParameters::addUncertParameter(const UncertParameter* up)
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != up->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (matchesRequiredSBMLNamespacesForAddition(static_cast<const
     SBase*>(up)) == false)
   {
@@ -253,10 +249,6 @@ ListOfUncertParameters::addUncertSpan(const UncertSpan* up)
   else if (getLevel() != up->getLevel())
   {
     return LIBSBML_LEVEL_MISMATCH;
-  }
-  else if (getVersion() != up->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
   }
   else if (matchesRequiredSBMLNamespacesForAddition(static_cast<const
     SBase*>(up)) == false)

--- a/src/sbml/packages/distrib/sbml/ListOfUncertainties.cpp
+++ b/src/sbml/packages/distrib/sbml/ListOfUncertainties.cpp
@@ -217,10 +217,6 @@ ListOfUncertainties::addUncertainty(const Uncertainty* u)
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != u->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (matchesRequiredSBMLNamespacesForAddition(static_cast<const
     SBase*>(u)) == false)
   {

--- a/src/sbml/packages/distrib/sbml/UncertParameter.cpp
+++ b/src/sbml/packages/distrib/sbml/UncertParameter.cpp
@@ -647,10 +647,6 @@ UncertParameter::addUncertParameter(const UncertParameter* up1)
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != up1->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (matchesRequiredSBMLNamespacesForAddition(static_cast<const
     SBase*>(up1)) == false)
   {
@@ -680,10 +676,6 @@ UncertParameter::addUncertSpan(const UncertSpan* up1)
   else if (getLevel() != up1->getLevel())
   {
     return LIBSBML_LEVEL_MISMATCH;
-  }
-  else if (getVersion() != up1->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
   }
   else if (matchesRequiredSBMLNamespacesForAddition(static_cast<const
     SBase*>(up1)) == false)

--- a/src/sbml/packages/distrib/sbml/Uncertainty.cpp
+++ b/src/sbml/packages/distrib/sbml/Uncertainty.cpp
@@ -226,10 +226,6 @@ Uncertainty::addUncertParameter(const UncertParameter* up)
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != up->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (matchesRequiredSBMLNamespacesForAddition(static_cast<const
     SBase*>(up)) == false)
   {
@@ -259,10 +255,6 @@ Uncertainty::addUncertSpan(const UncertSpan* up)
   else if (getLevel() != up->getLevel())
   {
     return LIBSBML_LEVEL_MISMATCH;
-  }
-  else if (getVersion() != up->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
   }
   else if (matchesRequiredSBMLNamespacesForAddition(static_cast<const
     SBase*>(up)) == false)

--- a/src/sbml/packages/groups/extension/GroupsModelPlugin.cpp
+++ b/src/sbml/packages/groups/extension/GroupsModelPlugin.cpp
@@ -195,10 +195,6 @@ GroupsModelPlugin::addGroup(const Group* g)
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != g->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (getPackageVersion() != g->getPackageVersion())
   {
     return LIBSBML_PKG_VERSION_MISMATCH;

--- a/src/sbml/packages/groups/sbml/Group.cpp
+++ b/src/sbml/packages/groups/sbml/Group.cpp
@@ -410,10 +410,6 @@ Group::addMember(const Member* m)
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != m->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (matchesRequiredSBMLNamespacesForAddition(static_cast<const
     SBase*>(m)) == false)
   {

--- a/src/sbml/packages/groups/sbml/ListOfGroups.cpp
+++ b/src/sbml/packages/groups/sbml/ListOfGroups.cpp
@@ -212,10 +212,6 @@ ListOfGroups::addGroup(const Group* g)
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != g->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (matchesRequiredSBMLNamespacesForAddition(static_cast<const
     SBase*>(g)) == false)
   {

--- a/src/sbml/packages/groups/sbml/ListOfMembers.cpp
+++ b/src/sbml/packages/groups/sbml/ListOfMembers.cpp
@@ -312,10 +312,6 @@ ListOfMembers::addMember(const Member* m)
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != m->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (matchesRequiredSBMLNamespacesForAddition(static_cast<const
     SBase*>(m)) == false)
   {

--- a/src/sbml/packages/layout/extension/LayoutModelPlugin.cpp
+++ b/src/sbml/packages/layout/extension/LayoutModelPlugin.cpp
@@ -452,10 +452,6 @@ LayoutModelPlugin::addLayout (const Layout* layout)
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != layout->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (getPackageVersion() != layout->getPackageVersion())
   {
     return LIBSBML_PKG_VERSION_MISMATCH;

--- a/src/sbml/packages/layout/sbml/Curve.cpp
+++ b/src/sbml/packages/layout/sbml/Curve.cpp
@@ -330,10 +330,6 @@ Curve::addCurveSegment (const LineSegment* segment)
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != segment->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (matchesRequiredSBMLNamespacesForAddition(static_cast<const
     SBase*>(segment)) == false)
   {

--- a/src/sbml/packages/layout/sbml/GeneralGlyph.cpp
+++ b/src/sbml/packages/layout/sbml/GeneralGlyph.cpp
@@ -523,10 +523,6 @@ GeneralGlyph::addReferenceGlyph (const ReferenceGlyph* glyph)
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != glyph->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (getPackageVersion() != glyph->getPackageVersion())
   {
     return LIBSBML_PKG_VERSION_MISMATCH;
@@ -554,10 +550,6 @@ GeneralGlyph::addSubGlyph (const GraphicalObject* glyph)
   else if (getLevel() != glyph->getLevel())
   {
     return LIBSBML_LEVEL_MISMATCH;
-  }
-  else if (getVersion() != glyph->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
   }
   else if (getPackageVersion() != glyph->getPackageVersion())
   {

--- a/src/sbml/packages/layout/sbml/Layout.cpp
+++ b/src/sbml/packages/layout/sbml/Layout.cpp
@@ -1156,10 +1156,6 @@ Layout::addCompartmentGlyph (const CompartmentGlyph* glyph)
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != glyph->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (getPackageVersion() != glyph->getPackageVersion())
   {
     return LIBSBML_PKG_VERSION_MISMATCH;
@@ -1188,10 +1184,6 @@ Layout::addSpeciesGlyph (const SpeciesGlyph* glyph)
   else if (getLevel() != glyph->getLevel())
   {
     return LIBSBML_LEVEL_MISMATCH;
-  }
-  else if (getVersion() != glyph->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
   }
   else if (getPackageVersion() != glyph->getPackageVersion())
   {
@@ -1222,10 +1214,6 @@ Layout::addReactionGlyph (const ReactionGlyph* glyph)
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != glyph->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (getPackageVersion() != glyph->getPackageVersion())
   {
     return LIBSBML_PKG_VERSION_MISMATCH;
@@ -1255,10 +1243,6 @@ Layout::addTextGlyph (const TextGlyph* glyph)
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != glyph->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (getPackageVersion() != glyph->getPackageVersion())
   {
     return LIBSBML_PKG_VERSION_MISMATCH;
@@ -1287,10 +1271,6 @@ Layout::addAdditionalGraphicalObject (const GraphicalObject* glyph)
   else if (getLevel() != glyph->getLevel())
   {
     return LIBSBML_LEVEL_MISMATCH;
-  }
-  else if (getVersion() != glyph->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
   }
   else if (getPackageVersion() != glyph->getPackageVersion())
   {

--- a/src/sbml/packages/layout/sbml/ReactionGlyph.cpp
+++ b/src/sbml/packages/layout/sbml/ReactionGlyph.cpp
@@ -411,10 +411,6 @@ ReactionGlyph::addSpeciesReferenceGlyph (const SpeciesReferenceGlyph* glyph)
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != glyph->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (getPackageVersion() != glyph->getPackageVersion())
   {
     return LIBSBML_PKG_VERSION_MISMATCH;

--- a/src/sbml/packages/multi/extension/MultiCompartmentPlugin.cpp
+++ b/src/sbml/packages/multi/extension/MultiCompartmentPlugin.cpp
@@ -556,10 +556,6 @@ MultiCompartmentPlugin::addCompartmentReference (const CompartmentReference* com
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != compartmentReference->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (getPackageVersion() != compartmentReference->getPackageVersion())
   {
     return LIBSBML_PKG_VERSION_MISMATCH;

--- a/src/sbml/packages/multi/extension/MultiModelPlugin.cpp
+++ b/src/sbml/packages/multi/extension/MultiModelPlugin.cpp
@@ -294,10 +294,6 @@ MultiModelPlugin::addMultiSpeciesType (const MultiSpeciesType* multiSpeciesType)
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != multiSpeciesType->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (getPackageVersion() != multiSpeciesType->getPackageVersion())
   {
     return LIBSBML_PKG_VERSION_MISMATCH;

--- a/src/sbml/packages/multi/extension/MultiSpeciesPlugin.cpp
+++ b/src/sbml/packages/multi/extension/MultiSpeciesPlugin.cpp
@@ -453,10 +453,6 @@ MultiSpeciesPlugin::addOutwardBindingSite (const OutwardBindingSite* outwardBind
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != outwardBindingSite->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (getPackageVersion() != outwardBindingSite->getPackageVersion())
   {
     return LIBSBML_PKG_VERSION_MISMATCH;
@@ -606,10 +602,6 @@ MultiSpeciesPlugin::addSpeciesFeature (const SpeciesFeature* speciesFeature)
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != speciesFeature->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (getPackageVersion() != speciesFeature->getPackageVersion())
   {
     return LIBSBML_PKG_VERSION_MISMATCH;
@@ -707,10 +699,6 @@ MultiSpeciesPlugin::addSubListOfSpeciesFeatures (SubListOfSpeciesFeatures* subLi
   else if (getLevel() != subListOfSpeciesFeatures->getLevel())
   {
     return LIBSBML_LEVEL_MISMATCH;
-  }
-  else if (getVersion() != subListOfSpeciesFeatures->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
   }
   else if (getPackageVersion() != subListOfSpeciesFeatures->getPackageVersion())
   {

--- a/src/sbml/packages/multi/extension/MultiSpeciesReferencePlugin.cpp
+++ b/src/sbml/packages/multi/extension/MultiSpeciesReferencePlugin.cpp
@@ -268,10 +268,6 @@ MultiSpeciesReferencePlugin::addSpeciesTypeComponentMapInProduct (const SpeciesT
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != speciesTypeComponentMapInProduct->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (getPackageVersion() != speciesTypeComponentMapInProduct->getPackageVersion())
   {
     return LIBSBML_PKG_VERSION_MISMATCH;

--- a/src/sbml/packages/multi/sbml/MultiSpeciesType.cpp
+++ b/src/sbml/packages/multi/sbml/MultiSpeciesType.cpp
@@ -414,10 +414,6 @@ MultiSpeciesType::addSpeciesFeatureType(const SpeciesFeatureType* sft)
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != sft->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (matchesRequiredSBMLNamespacesForAddition(static_cast<const SBase *>(sft)) == false)
   {
     return LIBSBML_NAMESPACES_MISMATCH;
@@ -570,10 +566,6 @@ MultiSpeciesType::addSpeciesTypeInstance(const SpeciesTypeInstance* sti)
   else if (getLevel() != sti->getLevel())
   {
     return LIBSBML_LEVEL_MISMATCH;
-  }
-  else if (getVersion() != sti->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
   }
   else if (matchesRequiredSBMLNamespacesForAddition(static_cast<const SBase *>(sti)) == false)
   {
@@ -728,10 +720,6 @@ MultiSpeciesType::addSpeciesTypeComponentIndex(const SpeciesTypeComponentIndex* 
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != stci->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (matchesRequiredSBMLNamespacesForAddition(static_cast<const SBase *>(stci)) == false)
   {
     return LIBSBML_NAMESPACES_MISMATCH;
@@ -884,10 +872,6 @@ MultiSpeciesType::addInSpeciesTypeBond(const InSpeciesTypeBond* istb)
   else if (getLevel() != istb->getLevel())
   {
     return LIBSBML_LEVEL_MISMATCH;
-  }
-  else if (getVersion() != istb->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
   }
   else if (matchesRequiredSBMLNamespacesForAddition(static_cast<const SBase *>(istb)) == false)
   {

--- a/src/sbml/packages/multi/sbml/SpeciesFeature.cpp
+++ b/src/sbml/packages/multi/sbml/SpeciesFeature.cpp
@@ -509,10 +509,6 @@ SpeciesFeature::addSpeciesFeatureValue(const SpeciesFeatureValue* sfv)
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != sfv->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (matchesRequiredSBMLNamespacesForAddition(static_cast<const SBase *>(sfv)) == false)
   {
     return LIBSBML_NAMESPACES_MISMATCH;

--- a/src/sbml/packages/multi/sbml/SpeciesFeatureType.cpp
+++ b/src/sbml/packages/multi/sbml/SpeciesFeatureType.cpp
@@ -392,10 +392,6 @@ SpeciesFeatureType::addPossibleSpeciesFeatureValue(const PossibleSpeciesFeatureV
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != psfv->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (matchesRequiredSBMLNamespacesForAddition(static_cast<const SBase *>(psfv)) == false)
   {
     return LIBSBML_NAMESPACES_MISMATCH;

--- a/src/sbml/packages/qual/extension/QualModelPlugin.cpp
+++ b/src/sbml/packages/qual/extension/QualModelPlugin.cpp
@@ -808,10 +808,6 @@ QualModelPlugin::addQualitativeSpecies (const QualitativeSpecies* qual)
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != qual->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (getPackageVersion() != qual->getPackageVersion())
   {
     return LIBSBML_PKG_VERSION_MISMATCH;
@@ -989,10 +985,6 @@ QualModelPlugin::addTransition (const Transition* qual)
   else if (getLevel() != qual->getLevel())
   {
     return LIBSBML_LEVEL_MISMATCH;
-  }
-  else if (getVersion() != qual->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
   }
   else if (getPackageVersion() != qual->getPackageVersion())
   {

--- a/src/sbml/packages/qual/sbml/FunctionTerm.cpp
+++ b/src/sbml/packages/qual/sbml/FunctionTerm.cpp
@@ -1046,10 +1046,6 @@ ListOfFunctionTerms::setDefaultTerm(const DefaultTerm* dt)
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != dt->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else
   {
     delete mDefaultTerm;

--- a/src/sbml/packages/qual/sbml/Transition.cpp
+++ b/src/sbml/packages/qual/sbml/Transition.cpp
@@ -413,10 +413,6 @@ Transition::addInput(const Input* i)
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != i->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (matchesRequiredSBMLNamespacesForAddition(static_cast<const SBase *>(i)) == false)
   {
     return LIBSBML_NAMESPACES_MISMATCH;
@@ -597,10 +593,6 @@ Transition::addOutput(const Output* i)
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != i->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (matchesRequiredSBMLNamespacesForAddition(static_cast<const SBase *>(i)) == false)
   {
     return LIBSBML_NAMESPACES_MISMATCH;
@@ -761,10 +753,6 @@ Transition::addFunctionTerm(const FunctionTerm* i)
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != i->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (matchesRequiredSBMLNamespacesForAddition(static_cast<const SBase *>(i)) == false)
   {
     return LIBSBML_NAMESPACES_MISMATCH;
@@ -840,10 +828,6 @@ Transition::setDefaultTerm(const DefaultTerm* i)
   else if (getLevel() != i->getLevel())
   {
     return LIBSBML_LEVEL_MISMATCH;
-  }
-  else if (getVersion() != i->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
   }
   else if (matchesRequiredSBMLNamespacesForAddition(static_cast<const SBase *>(i)) == false)
   {

--- a/src/sbml/packages/render/sbml/GlobalRenderInformation.cpp
+++ b/src/sbml/packages/render/sbml/GlobalRenderInformation.cpp
@@ -309,10 +309,6 @@ GlobalRenderInformation::addGlobalStyle(const GlobalStyle* gs)
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != gs->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (matchesRequiredSBMLNamespacesForAddition(static_cast<const
     SBase*>(gs)) == false)
   {

--- a/src/sbml/packages/render/sbml/GradientBase.cpp
+++ b/src/sbml/packages/render/sbml/GradientBase.cpp
@@ -529,10 +529,6 @@ GradientBase::addGradientStop(const GradientStop* gs)
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != gs->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (matchesRequiredSBMLNamespacesForAddition(static_cast<const
     SBase*>(gs)) == false)
   {

--- a/src/sbml/packages/render/sbml/ListOfColorDefinitions.cpp
+++ b/src/sbml/packages/render/sbml/ListOfColorDefinitions.cpp
@@ -259,10 +259,6 @@ ListOfColorDefinitions::addColorDefinition(const ColorDefinition* cd)
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != cd->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (matchesRequiredSBMLNamespacesForAddition(static_cast<const
     SBase*>(cd)) == false)
   {

--- a/src/sbml/packages/render/sbml/ListOfCurveElements.cpp
+++ b/src/sbml/packages/render/sbml/ListOfCurveElements.cpp
@@ -288,10 +288,6 @@ ListOfCurveElements::addRenderPoint(const RenderPoint* rp)
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != rp->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (matchesRequiredSBMLNamespacesForAddition(static_cast<const
     SBase*>(rp)) == false)
   {

--- a/src/sbml/packages/render/sbml/ListOfDrawables.cpp
+++ b/src/sbml/packages/render/sbml/ListOfDrawables.cpp
@@ -225,10 +225,6 @@ ListOfDrawables::addTransformation2D(const Transformation2D* td)
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != td->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (matchesRequiredSBMLNamespacesForAddition(static_cast<const
     SBase*>(td)) == false)
   {

--- a/src/sbml/packages/render/sbml/ListOfGlobalRenderInformation.cpp
+++ b/src/sbml/packages/render/sbml/ListOfGlobalRenderInformation.cpp
@@ -567,10 +567,6 @@ ListOfGlobalRenderInformation::addGlobalRenderInformation(const
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != gri->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (matchesRequiredSBMLNamespacesForAddition(static_cast<const
     SBase*>(gri)) == false)
   {

--- a/src/sbml/packages/render/sbml/ListOfGlobalStyles.cpp
+++ b/src/sbml/packages/render/sbml/ListOfGlobalStyles.cpp
@@ -247,10 +247,6 @@ ListOfGlobalStyles::addGlobalStyle(const GlobalStyle* gs)
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != gs->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (matchesRequiredSBMLNamespacesForAddition(static_cast<const
     SBase*>(gs)) == false)
   {

--- a/src/sbml/packages/render/sbml/ListOfGradientDefinitions.cpp
+++ b/src/sbml/packages/render/sbml/ListOfGradientDefinitions.cpp
@@ -269,10 +269,6 @@ ListOfGradientDefinitions::addGradientBase(const GradientBase* gb)
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != gb->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (matchesRequiredSBMLNamespacesForAddition(static_cast<const
     SBase*>(gb)) == false)
   {

--- a/src/sbml/packages/render/sbml/ListOfGradientStops.cpp
+++ b/src/sbml/packages/render/sbml/ListOfGradientStops.cpp
@@ -268,10 +268,6 @@ ListOfGradientStops::addGradientStop(const GradientStop* gs)
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != gs->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (matchesRequiredSBMLNamespacesForAddition(static_cast<const
     SBase*>(gs)) == false)
   {

--- a/src/sbml/packages/render/sbml/ListOfLineEndings.cpp
+++ b/src/sbml/packages/render/sbml/ListOfLineEndings.cpp
@@ -259,10 +259,6 @@ ListOfLineEndings::addLineEnding(const LineEnding* le)
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != le->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (matchesRequiredSBMLNamespacesForAddition(static_cast<const
     SBase*>(le)) == false)
   {

--- a/src/sbml/packages/render/sbml/ListOfLocalRenderInformation.cpp
+++ b/src/sbml/packages/render/sbml/ListOfLocalRenderInformation.cpp
@@ -548,10 +548,6 @@ ListOfLocalRenderInformation::addLocalRenderInformation(const
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != lri->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (matchesRequiredSBMLNamespacesForAddition(static_cast<const
     SBase*>(lri)) == false)
   {

--- a/src/sbml/packages/render/sbml/ListOfLocalStyles.cpp
+++ b/src/sbml/packages/render/sbml/ListOfLocalStyles.cpp
@@ -263,10 +263,6 @@ ListOfLocalStyles::addLocalStyle(const LocalStyle* ls)
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != ls->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (matchesRequiredSBMLNamespacesForAddition(static_cast<const
     SBase*>(ls)) == false)
   {

--- a/src/sbml/packages/render/sbml/LocalRenderInformation.cpp
+++ b/src/sbml/packages/render/sbml/LocalRenderInformation.cpp
@@ -290,10 +290,6 @@ LocalRenderInformation::addLocalStyle(const LocalStyle* ls)
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != ls->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (matchesRequiredSBMLNamespacesForAddition(static_cast<const
     SBase*>(ls)) == false)
   {

--- a/src/sbml/packages/render/sbml/Polygon.cpp
+++ b/src/sbml/packages/render/sbml/Polygon.cpp
@@ -385,10 +385,6 @@ Polygon::addElement(const RenderPoint* rp)
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != rp->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (matchesRequiredSBMLNamespacesForAddition(static_cast<const
     SBase*>(rp)) == false)
   {

--- a/src/sbml/packages/render/sbml/RenderCurve.cpp
+++ b/src/sbml/packages/render/sbml/RenderCurve.cpp
@@ -437,10 +437,6 @@ RenderCurve::addElement(const RenderPoint* rp)
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != rp->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (matchesRequiredSBMLNamespacesForAddition(static_cast<const
     SBase*>(rp)) == false)
   {

--- a/src/sbml/packages/render/sbml/RenderGroup.cpp
+++ b/src/sbml/packages/render/sbml/RenderGroup.cpp
@@ -1044,10 +1044,6 @@ RenderGroup::addElement(const Transformation2D* td)
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != td->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (matchesRequiredSBMLNamespacesForAddition(static_cast<const
     SBase*>(td)) == false)
   {
@@ -1077,10 +1073,6 @@ RenderGroup::addChildElement(const Transformation2D* td)
   else if (getLevel() != td->getLevel())
   {
     return LIBSBML_LEVEL_MISMATCH;
-  }
-  else if (getVersion() != td->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
   }
   else if (matchesRequiredSBMLNamespacesForAddition(static_cast<const
     SBase*>(td)) == false)

--- a/src/sbml/packages/render/sbml/RenderInformationBase.cpp
+++ b/src/sbml/packages/render/sbml/RenderInformationBase.cpp
@@ -694,10 +694,6 @@ RenderInformationBase::addColorDefinition(const ColorDefinition* cd)
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != cd->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (matchesRequiredSBMLNamespacesForAddition(static_cast<const
     SBase*>(cd)) == false)
   {
@@ -855,10 +851,6 @@ RenderInformationBase::addGradientDefinition(const GradientBase* gb)
   else if (getLevel() != gb->getLevel())
   {
     return LIBSBML_LEVEL_MISMATCH;
-  }
-  else if (getVersion() != gb->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
   }
   else if (matchesRequiredSBMLNamespacesForAddition(static_cast<const
     SBase*>(gb)) == false)
@@ -1045,10 +1037,6 @@ RenderInformationBase::addLineEnding(const LineEnding* le)
   else if (getLevel() != le->getLevel())
   {
     return LIBSBML_LEVEL_MISMATCH;
-  }
-  else if (getVersion() != le->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
   }
   else if (matchesRequiredSBMLNamespacesForAddition(static_cast<const
     SBase*>(le)) == false)

--- a/src/sbml/packages/spatial/extension/SpatialCompartmentPlugin.cpp
+++ b/src/sbml/packages/spatial/extension/SpatialCompartmentPlugin.cpp
@@ -189,10 +189,6 @@ SpatialCompartmentPlugin::setCompartmentMapping(const CompartmentMapping*
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != compartmentMapping->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (getPackageVersion() != compartmentMapping->getPackageVersion())
   {
     return LIBSBML_PKG_VERSION_MISMATCH;

--- a/src/sbml/packages/spatial/extension/SpatialModelPlugin.cpp
+++ b/src/sbml/packages/spatial/extension/SpatialModelPlugin.cpp
@@ -181,10 +181,6 @@ SpatialModelPlugin::setGeometry(const Geometry* geometry)
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != geometry->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (getPackageVersion() != geometry->getPackageVersion())
   {
     return LIBSBML_PKG_VERSION_MISMATCH;

--- a/src/sbml/packages/spatial/extension/SpatialParameterPlugin.cpp
+++ b/src/sbml/packages/spatial/extension/SpatialParameterPlugin.cpp
@@ -343,10 +343,6 @@ SpatialParameterPlugin::setSpatialSymbolReference(const SpatialSymbolReference*
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != spatialSymbolReference->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (getPackageVersion() != spatialSymbolReference->getPackageVersion())
   {
     return LIBSBML_PKG_VERSION_MISMATCH;
@@ -381,10 +377,6 @@ SpatialParameterPlugin::setAdvectionCoefficient(const AdvectionCoefficient*
   else if (getLevel() != advectionCoefficient->getLevel())
   {
     return LIBSBML_LEVEL_MISMATCH;
-  }
-  else if (getVersion() != advectionCoefficient->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
   }
   else if (getPackageVersion() != advectionCoefficient->getPackageVersion())
   {
@@ -421,10 +413,6 @@ SpatialParameterPlugin::setBoundaryCondition(const BoundaryCondition*
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != boundaryCondition->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (getPackageVersion() != boundaryCondition->getPackageVersion())
   {
     return LIBSBML_PKG_VERSION_MISMATCH;
@@ -459,10 +447,6 @@ SpatialParameterPlugin::setDiffusionCoefficient(const DiffusionCoefficient*
   else if (getLevel() != diffusionCoefficient->getLevel())
   {
     return LIBSBML_LEVEL_MISMATCH;
-  }
-  else if (getVersion() != diffusionCoefficient->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
   }
   else if (getPackageVersion() != diffusionCoefficient->getPackageVersion())
   {

--- a/src/sbml/packages/spatial/sbml/AnalyticGeometry.cpp
+++ b/src/sbml/packages/spatial/sbml/AnalyticGeometry.cpp
@@ -235,10 +235,6 @@ AnalyticGeometry::addAnalyticVolume(const AnalyticVolume* av)
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != av->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (matchesRequiredSBMLNamespacesForAddition(static_cast<const
     SBase*>(av)) == false)
   {

--- a/src/sbml/packages/spatial/sbml/CSGSetOperator.cpp
+++ b/src/sbml/packages/spatial/sbml/CSGSetOperator.cpp
@@ -422,10 +422,6 @@ CSGSetOperator::addCSGNode(const CSGNode* csgn)
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != csgn->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (matchesRequiredSBMLNamespacesForAddition(static_cast<const
     SBase*>(csgn)) == false)
   {

--- a/src/sbml/packages/spatial/sbml/CSGeometry.cpp
+++ b/src/sbml/packages/spatial/sbml/CSGeometry.cpp
@@ -235,10 +235,6 @@ CSGeometry::addCSGObject(const CSGObject* csgo)
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != csgo->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (matchesRequiredSBMLNamespacesForAddition(static_cast<const
     SBase*>(csgo)) == false)
   {

--- a/src/sbml/packages/spatial/sbml/Domain.cpp
+++ b/src/sbml/packages/spatial/sbml/Domain.cpp
@@ -350,10 +350,6 @@ Domain::addInteriorPoint(const InteriorPoint* ip)
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != ip->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (matchesRequiredSBMLNamespacesForAddition(static_cast<const
     SBase*>(ip)) == false)
   {

--- a/src/sbml/packages/spatial/sbml/Geometry.cpp
+++ b/src/sbml/packages/spatial/sbml/Geometry.cpp
@@ -371,10 +371,6 @@ Geometry::addCoordinateComponent(const CoordinateComponent* cc)
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != cc->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (matchesRequiredSBMLNamespacesForAddition(static_cast<const
     SBase*>(cc)) == false)
   {
@@ -528,10 +524,6 @@ Geometry::addDomainType(const DomainType* dt)
   else if (getLevel() != dt->getLevel())
   {
     return LIBSBML_LEVEL_MISMATCH;
-  }
-  else if (getVersion() != dt->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
   }
   else if (matchesRequiredSBMLNamespacesForAddition(static_cast<const
     SBase*>(dt)) == false)
@@ -709,10 +701,6 @@ Geometry::addDomain(const Domain* d)
   else if (getLevel() != d->getLevel())
   {
     return LIBSBML_LEVEL_MISMATCH;
-  }
-  else if (getVersion() != d->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
   }
   else if (matchesRequiredSBMLNamespacesForAddition(static_cast<const
     SBase*>(d)) == false)
@@ -911,10 +899,6 @@ Geometry::addAdjacentDomains(const AdjacentDomains* ad)
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != ad->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (matchesRequiredSBMLNamespacesForAddition(static_cast<const
     SBase*>(ad)) == false)
   {
@@ -1069,10 +1053,6 @@ Geometry::addGeometryDefinition(const GeometryDefinition* gd)
   else if (getLevel() != gd->getLevel())
   {
     return LIBSBML_LEVEL_MISMATCH;
-  }
-  else if (getVersion() != gd->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
   }
   else if (matchesRequiredSBMLNamespacesForAddition(static_cast<const
     SBase*>(gd)) == false)
@@ -1339,10 +1319,6 @@ Geometry::addSampledField(const SampledField* sf)
   else if (getLevel() != sf->getLevel())
   {
     return LIBSBML_LEVEL_MISMATCH;
-  }
-  else if (getVersion() != sf->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
   }
   else if (matchesRequiredSBMLNamespacesForAddition(static_cast<const
     SBase*>(sf)) == false)

--- a/src/sbml/packages/spatial/sbml/ListOfAdjacentDomains.cpp
+++ b/src/sbml/packages/spatial/sbml/ListOfAdjacentDomains.cpp
@@ -219,10 +219,6 @@ ListOfAdjacentDomains::addAdjacentDomains(const AdjacentDomains* ad)
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != ad->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (matchesRequiredSBMLNamespacesForAddition(static_cast<const
     SBase*>(ad)) == false)
   {

--- a/src/sbml/packages/spatial/sbml/ListOfAnalyticVolumes.cpp
+++ b/src/sbml/packages/spatial/sbml/ListOfAnalyticVolumes.cpp
@@ -224,10 +224,6 @@ ListOfAnalyticVolumes::addAnalyticVolume(const AnalyticVolume* av)
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != av->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (matchesRequiredSBMLNamespacesForAddition(static_cast<const
     SBase*>(av)) == false)
   {

--- a/src/sbml/packages/spatial/sbml/ListOfCSGNodes.cpp
+++ b/src/sbml/packages/spatial/sbml/ListOfCSGNodes.cpp
@@ -226,10 +226,6 @@ ListOfCSGNodes::addCSGNode(const CSGNode* csgn)
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != csgn->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (matchesRequiredSBMLNamespacesForAddition(static_cast<const
     SBase*>(csgn)) == false)
   {

--- a/src/sbml/packages/spatial/sbml/ListOfCSGObjects.cpp
+++ b/src/sbml/packages/spatial/sbml/ListOfCSGObjects.cpp
@@ -220,10 +220,6 @@ ListOfCSGObjects::addCSGObject(const CSGObject* csgo)
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != csgo->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (matchesRequiredSBMLNamespacesForAddition(static_cast<const
     SBase*>(csgo)) == false)
   {

--- a/src/sbml/packages/spatial/sbml/ListOfCoordinateComponents.cpp
+++ b/src/sbml/packages/spatial/sbml/ListOfCoordinateComponents.cpp
@@ -229,10 +229,6 @@ ListOfCoordinateComponents::addCoordinateComponent(const CoordinateComponent*
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != cc->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (matchesRequiredSBMLNamespacesForAddition(static_cast<const
     SBase*>(cc)) == false)
   {

--- a/src/sbml/packages/spatial/sbml/ListOfDomainTypes.cpp
+++ b/src/sbml/packages/spatial/sbml/ListOfDomainTypes.cpp
@@ -216,10 +216,6 @@ ListOfDomainTypes::addDomainType(const DomainType* dt)
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != dt->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (matchesRequiredSBMLNamespacesForAddition(static_cast<const
     SBase*>(dt)) == false)
   {

--- a/src/sbml/packages/spatial/sbml/ListOfDomains.cpp
+++ b/src/sbml/packages/spatial/sbml/ListOfDomains.cpp
@@ -218,10 +218,6 @@ ListOfDomains::addDomain(const Domain* d)
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != d->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (matchesRequiredSBMLNamespacesForAddition(static_cast<const
     SBase*>(d)) == false)
   {

--- a/src/sbml/packages/spatial/sbml/ListOfGeometryDefinitions.cpp
+++ b/src/sbml/packages/spatial/sbml/ListOfGeometryDefinitions.cpp
@@ -234,10 +234,6 @@ ListOfGeometryDefinitions::addGeometryDefinition(const GeometryDefinition* gd)
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != gd->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (matchesRequiredSBMLNamespacesForAddition(static_cast<const
     SBase*>(gd)) == false)
   {

--- a/src/sbml/packages/spatial/sbml/ListOfInteriorPoints.cpp
+++ b/src/sbml/packages/spatial/sbml/ListOfInteriorPoints.cpp
@@ -217,10 +217,6 @@ ListOfInteriorPoints::addInteriorPoint(const InteriorPoint* ip)
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != ip->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (matchesRequiredSBMLNamespacesForAddition(static_cast<const
     SBase*>(ip)) == false)
   {

--- a/src/sbml/packages/spatial/sbml/ListOfOrdinalMappings.cpp
+++ b/src/sbml/packages/spatial/sbml/ListOfOrdinalMappings.cpp
@@ -219,10 +219,6 @@ ListOfOrdinalMappings::addOrdinalMapping(const OrdinalMapping* om)
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != om->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (matchesRequiredSBMLNamespacesForAddition(static_cast<const
     SBase*>(om)) == false)
   {

--- a/src/sbml/packages/spatial/sbml/ListOfParametricObjects.cpp
+++ b/src/sbml/packages/spatial/sbml/ListOfParametricObjects.cpp
@@ -221,10 +221,6 @@ ListOfParametricObjects::addParametricObject(const ParametricObject* po)
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != po->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (matchesRequiredSBMLNamespacesForAddition(static_cast<const
     SBase*>(po)) == false)
   {

--- a/src/sbml/packages/spatial/sbml/ListOfSampledFields.cpp
+++ b/src/sbml/packages/spatial/sbml/ListOfSampledFields.cpp
@@ -217,10 +217,6 @@ ListOfSampledFields::addSampledField(const SampledField* sf)
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != sf->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (matchesRequiredSBMLNamespacesForAddition(static_cast<const
     SBase*>(sf)) == false)
   {

--- a/src/sbml/packages/spatial/sbml/ListOfSampledVolumes.cpp
+++ b/src/sbml/packages/spatial/sbml/ListOfSampledVolumes.cpp
@@ -217,10 +217,6 @@ ListOfSampledVolumes::addSampledVolume(const SampledVolume* sv)
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != sv->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (matchesRequiredSBMLNamespacesForAddition(static_cast<const
     SBase*>(sv)) == false)
   {

--- a/src/sbml/packages/spatial/sbml/MixedGeometry.cpp
+++ b/src/sbml/packages/spatial/sbml/MixedGeometry.cpp
@@ -219,10 +219,6 @@ MixedGeometry::addGeometryDefinition(const GeometryDefinition* gd)
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != gd->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (matchesRequiredSBMLNamespacesForAddition(static_cast<const
     SBase*>(gd)) == false)
   {
@@ -491,10 +487,6 @@ MixedGeometry::addOrdinalMapping(const OrdinalMapping* om)
   else if (getLevel() != om->getLevel())
   {
     return LIBSBML_LEVEL_MISMATCH;
-  }
-  else if (getVersion() != om->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
   }
   else if (matchesRequiredSBMLNamespacesForAddition(static_cast<const
     SBase*>(om)) == false)

--- a/src/sbml/packages/spatial/sbml/ParametricGeometry.cpp
+++ b/src/sbml/packages/spatial/sbml/ParametricGeometry.cpp
@@ -349,10 +349,6 @@ ParametricGeometry::addParametricObject(const ParametricObject* po)
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != po->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (matchesRequiredSBMLNamespacesForAddition(static_cast<const
     SBase*>(po)) == false)
   {

--- a/src/sbml/packages/spatial/sbml/SampledFieldGeometry.cpp
+++ b/src/sbml/packages/spatial/sbml/SampledFieldGeometry.cpp
@@ -297,10 +297,6 @@ SampledFieldGeometry::addSampledVolume(const SampledVolume* sv)
   {
     return LIBSBML_LEVEL_MISMATCH;
   }
-  else if (getVersion() != sv->getVersion())
-  {
-    return LIBSBML_VERSION_MISMATCH;
-  }
   else if (matchesRequiredSBMLNamespacesForAddition(static_cast<const
     SBase*>(sv)) == false)
   {


### PR DESCRIPTION
This was already done for FBC; do this for all other packages as well.

FBC had additional checks in places for checking the core version, because FBC itself had different versions.  But no other package yet has other versions, so nobody had added those additional (unnecessary) checks.
