### PR TITLE
Detect ZLIB using find module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -534,68 +534,25 @@ Separate multiple directories using semicolons." )
 #
 # Locate zlib
 #
-
-set(ZLIB_INITIAL_VALUE)
-if (NOT LIBZ_LIBRARY)
-find_library(LIBZ_LIBRARY
-    NAMES zdll.lib z zlib.lib
-    PATHS /usr/lib /usr/local/lib
-          ${CMAKE_OSX_SYSROOT}/usr/lib
-          ${LIBSBML_DEPENDENCY_DIR}/lib
-          NO_DEFAULT_PATH
-          NO_CMAKE_ENVIRONMENT_PATH
-          NO_CMAKE_PATH
-          NO_SYSTEM_ENVIRONMENT_PATH
-          NO_CMAKE_SYSTEM_PATH
-          DOC "The file name of the zip compression library."
-    )
-endif()
-if (NOT LIBZ_LIBRARY)
-find_library(LIBZ_LIBRARY
-    NAMES zdll.lib z zlib.lib
-    PATHS /usr/lib /usr/local/lib
-          ${CMAKE_OSX_SYSROOT}/usr/lib
-          ${LIBSBML_DEPENDENCY_DIR}/lib
-    DOC "The file name of the zip compression library."
-    )
+find_package(ZLIB QUIET)
+set(ZLIB_INITIAL_VALUE ON)
+if(NOT TARGET ZLIB::ZLIB)
+set(ZLIB_INITIAL_VALUE OFF)
 endif()
 
-if(EXISTS ${LIBZ_LIBRARY})
-    set(ZLIB_INITIAL_VALUE ON)
-else()
-    set(ZLIB_INITIAL_VALUE OFF)
-endif()
 option(WITH_ZLIB     "Enable the use of zip compression."    ${ZLIB_INITIAL_VALUE} )
 
 set(USE_ZLIB OFF)
 if(WITH_ZLIB)
 
-  if (NOT LIBZ_INCLUDE_DIR)
-    find_path(LIBZ_INCLUDE_DIR
-        NAMES zlib.h zlib/zlib.h
-        PATHS ${CMAKE_OSX_SYSROOT}/usr/include
-              /usr/include /usr/local/include
-              ${LIBSBML_DEPENDENCY_DIR}/include
-              NO_DEFAULT_PATH
-        DOC "The directory containing the zlib include files."
-              )
-  endif()
-    if (NOT LIBZ_INCLUDE_DIR)
-        find_path(LIBZ_INCLUDE_DIR
-        NAMES zlib.h zlib/zlib.h
-        PATHS ${CMAKE_OSX_SYSROOT}/usr/include
-              /usr/include /usr/local/include
-              ${LIBSBML_DEPENDENCY_DIR}/include
-        DOC "The directory containing the zlib include files."
-              )
-    endif()
-    set(USE_ZLIB ON)
-    add_definitions( -DUSE_ZLIB )
+  find_package(ZLIB REQUIRED)
+  set(USE_ZLIB ON)
+  add_definitions( -DUSE_ZLIB )
   list(APPEND SWIG_EXTRA_ARGS -DUSE_ZLIB)
 
     # make sure that we have a valid zip library
-    file(TO_CMAKE_PATH "${LIBZ_LIBRARY}" LIBZ_CMAKE_PATH)
-    check_library_exists("${LIBZ_CMAKE_PATH}" "gzopen" "" LIBZ_FOUND_SYMBOL)
+    file(TO_CMAKE_PATH "${ZLIB_LIBRARY}" LIBZ_CMAKE_PATH)
+    check_library_exists("${LIBZ_CMAKE_PATH}" "gzopen" "" LIBZ_CMAKE_PATH)
     if(NOT LIBZ_FOUND_SYMBOL)
         # this is odd, but on windows this check always fails! must be a
         # bug in the current cmake version so for now only issue this
@@ -609,19 +566,11 @@ ${LIBSBML_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeError.log")
         endif()
     endif()
 
-    if(NOT EXISTS "${LIBZ_INCLUDE_DIR}/zlib.h")
+    if(NOT EXISTS "${ZLIB_INCLUDE_DIR}/zlib.h")
         message(FATAL_ERROR
 "The include directory specified for zlib does not appear to be
 valid. It should contain the file zlib.h, but it does not.")
     endif()
-
-  if(NOT TARGET ZLIB::ZLIB)
-    add_library(ZLIB::ZLIB UNKNOWN IMPORTED)
-    set_target_properties(ZLIB::ZLIB PROPERTIES
-      IMPORTED_LINK_INTERFACE_LANGUAGES "C"
-      IMPORTED_LOCATION "${LIBZ_LIBRARY}"
-      INTERFACE_INCLUDE_DIRECTORIES "${LIBZ_INCLUDE_DIR}")
-  endif()
 
   list(APPEND LIBSBML_FIND_MODULES "${CMAKE_CURRENT_SOURCE_DIR}/CMakeModules/FindZLIB.cmake")
 


### PR DESCRIPTION
## Description
This change detects ZLIB using the included Find Module. 

## Motivation and Context
This solves the problem, that currently conda packages dont build because zlib cannot be found, even though it is compiled and present from the dependencies package. 


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Change in documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have updated all documentation necessary.
- [ ] I have checked spelling in (new) comments.

## Testing
- [ ] Testing is done automatically and codecov shows test coverage
- [x] This cannot be tested automatically <!-- describe how it has been tested -->
while this is not automatically tested, you can easily see that with this change the variable is picked up from the defined LIBSBML_DEPENDENCY_DIR where before it would have picked up from the system (or not at all)

