### PR TITLE
 #390: add hasPrefix to xmlnode / xmlattributes

### DIFF
--- a/src/sbml/xml/XMLAttributes.cpp
+++ b/src/sbml/xml/XMLAttributes.cpp
@@ -1448,6 +1448,13 @@ XMLAttributes_getPrefix (const XMLAttributes_t *xa, int index)
   return xa->getPrefix(index).empty() ? NULL : safe_strdup(xa->getPrefix(index).c_str());
 }
 
+LIBLAX_EXTERN
+int
+XMLAttributes_hasPrefix (const XMLAttributes_t *xa, int index)
+{
+  if (xa == NULL) return 0;
+  return xa->getPrefix(index).empty() ? 0 : 1;
+}
 
 LIBLAX_EXTERN
 char *

--- a/src/sbml/xml/XMLAttributes.h
+++ b/src/sbml/xml/XMLAttributes.h
@@ -2165,6 +2165,25 @@ LIBLAX_EXTERN
 char *
 XMLAttributes_getPrefix (const XMLAttributes_t *xa, int index);
 
+/**
+ * Return whether an attribute in this XMLAttributes_t structure (by position) has a prefix.
+ *
+ * @param xa the XMLAttributes_t structure.
+ * @param index an integer, the position of the attribute whose value is
+ * required.
+ *
+ * @return 1 if the attribute has a prefix, 0 otherwise.
+ *
+ * @note If index
+ * is out of range, 0 will be returned.
+ * Use XMLAttributes_hasAttribute() != 0 to test for attribute existence.
+ *
+ * @memberof XMLAttributes_t
+ */
+LIBLAX_EXTERN
+int
+XMLAttributes_hasPrefix (const XMLAttributes_t *xa, int index);
+
 
 /**
  * Return the namespace URI of an attribute in this XMLAttributes_t structure (by position).

--- a/src/sbml/xml/XMLNode.cpp
+++ b/src/sbml/xml/XMLNode.cpp
@@ -874,6 +874,13 @@ XMLNode_getPrefix (const XMLNode_t *node)
   return node->getPrefix().empty() ? NULL : node->getPrefix().c_str();
 }
 
+LIBLAX_EXTERN
+int
+XMLNode_hasPrefix (const XMLNode_t *node)
+{
+  if (node == NULL) return 0;
+  return node->getPrefix().empty() ? 0 : 1;
+}
 
 LIBLAX_EXTERN
 const char *

--- a/src/sbml/xml/XMLNode.h
+++ b/src/sbml/xml/XMLNode.h
@@ -833,8 +833,7 @@ XMLNode_getName (const XMLNode_t *node);
  *
  * @return the namespace prefix of this XML element.
  *
- * @note If no prefix
- * exists, an empty string will be return.
+ * @note If no prefix exists, NULL will be returned.
  *
  * @memberof XMLNode_t
  */
@@ -842,6 +841,19 @@ LIBLAX_EXTERN
 const char *
 XMLNode_getPrefix (const XMLNode_t *node);
 
+/**
+ * Returns a flag, whether this XML element has a namespace prefix.
+ *
+ * @param node XMLNode_t structure to be queried.
+ *
+ * @return 1 (true) if this XML element has a namespace prefix, 
+ *         0 (false) otherwise.
+ *
+ * @memberof XMLNode_t
+ */
+LIBLAX_EXTERN
+int
+XMLNode_hasPrefix (const XMLNode_t *node);
 
 /**
  * Returns the namespace URI of this XML element.

--- a/src/sbml/xml/test/TestXMLNode.cpp
+++ b/src/sbml/xml/test/TestXMLNode.cpp
@@ -180,6 +180,7 @@ START_TEST (test_XMLNode_createFromToken)
 
   fail_unless(strcmp(XMLNode_getName(node), "attr") == 0);
   fail_unless(strcmp(XMLNode_getPrefix(node), "prefix") == 0);
+  fail_unless(XMLNode_hasPrefix(node) == 1);
   fail_unless(strcmp(XMLNode_getURI(node), "uri") == 0);
   fail_unless (XMLNode_getChild(node, 1) != NULL);
 
@@ -220,6 +221,7 @@ START_TEST (test_XMLNode_createElement)
   fail_unless(XMLNode_getNumChildren(snode) == 0);
   fail_unless(strcmp(XMLNode_getName  (snode), name  ) == 0);
   fail_unless(strcmp(XMLNode_getPrefix(snode), prefix) == 0);
+  fail_unless(XMLNode_hasPrefix(snode) == 1);
   fail_unless(strcmp(XMLNode_getURI   (snode), uri   ) == 0);
   fail_unless(XMLNode_isElement(snode) == 1);
   fail_unless(XMLNode_isStart  (snode) == 1);
@@ -266,6 +268,7 @@ START_TEST (test_XMLNode_createElement)
   fail_unless(XMLNode_getNumChildren(snode) == 0);
   fail_unless(strcmp(XMLNode_getName  (snode), "test") == 0);
   fail_unless(XMLNode_getPrefix(snode) == NULL );
+  fail_unless(XMLNode_hasPrefix(snode) == 0 );
   fail_unless(XMLNode_getURI   (snode) == NULL );
   fail_unless(XMLNode_isElement(snode) == 1);
   fail_unless(XMLNode_isStart  (snode) == 1);
@@ -284,6 +287,7 @@ START_TEST (test_XMLNode_createElement)
   free(test);
 
   fail_unless(XMLAttributes_getPrefix(cattr, 0) == NULL);
+  fail_unless(XMLAttributes_hasPrefix(cattr, 0) == 0);
   fail_unless(XMLAttributes_getURI   (cattr, 0) == NULL);
 
   /* end element */
@@ -293,6 +297,7 @@ START_TEST (test_XMLNode_createElement)
   fail_unless(XMLNode_getNumChildren(enode) == 0);
   fail_unless(strcmp(XMLNode_getName(enode), "test") == 0);
   fail_unless(XMLNode_getPrefix(enode) == NULL );
+  fail_unless(XMLNode_hasPrefix(enode) == 0 );
   fail_unless(XMLNode_getURI   (enode) == NULL );
   fail_unless(XMLNode_isElement(enode) == 1);
   fail_unless(XMLNode_isStart  (enode) == 0);


### PR DESCRIPTION
## Description
This PR adds a _hasPrefix method to xmlnode and xmlattributes. It also fixes the documentation string, 
to make clear that indeed NULL will be returned by _getPrefix if no prefix is present. 

## Motivation and Context
fixes #390

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Change in documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have updated all documentation necessary.
- [ ] I have checked spelling in (new) comments.

## Testing
- [X] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested -->

