### PR TITLE
Issue 385: flexibility with running strict unit validation

### DIFF
--- a/src/sbml/SBMLDocument.cpp
+++ b/src/sbml/SBMLDocument.cpp
@@ -730,6 +730,12 @@ SBMLDocument::checkConsistency ()
 }
 
 
+unsigned int
+SBMLDocument::checkConsistencyWithStrictUnits ()
+{
+  return checkConsistencyWithStrictUnits(LIBSBML_OVERRIDE_ERROR);
+}
+
 /*
  * Performs a set of semantic consistency checks on the document.  Query
  * the results by calling getNumErrors() and getError().

--- a/src/sbml/SBMLDocument.cpp
+++ b/src/sbml/SBMLDocument.cpp
@@ -737,7 +737,7 @@ SBMLDocument::checkConsistency ()
  * @return the number of failed checks (errors) encountered.
  */
 unsigned int
-SBMLDocument::checkConsistencyWithStrictUnits ()
+SBMLDocument::checkConsistencyWithStrictUnits (XMLErrorSeverityOverride_t strictErrorOverride /* = LIBSBML_OVERRIDE_ERROR */)
 {
   // keep a copy of the override status
   // and then override any change
@@ -781,7 +781,7 @@ SBMLDocument::checkConsistencyWithStrictUnits ()
   else
   {
     // log as errors
-    getErrorLog()->setSeverityOverride(LIBSBML_OVERRIDE_ERROR);
+    getErrorLog()->setSeverityOverride(strictErrorOverride);
     StrictUnitConsistencyValidator unit_validator;
     unit_validator.init();
     unsigned int nerrors = unit_validator.validate(*this);

--- a/src/sbml/SBMLDocument.h
+++ b/src/sbml/SBMLDocument.h
@@ -344,6 +344,7 @@ class SBMLLevelVersionConverter;
 #define StrictUnitsCheckON 0x80
 #define StrictUnitsCheckOFF 0x7f
 #define AllChecksON       0x7f
+#define AllChecksONWithStrictUnits 0xff
 /** @endcond */
 
 

--- a/src/sbml/SBMLDocument.h
+++ b/src/sbml/SBMLDocument.h
@@ -1015,8 +1015,28 @@ public:
    *
    * @see SBMLDocument::checkInternalConsistency()
    */
-  unsigned int checkConsistencyWithStrictUnits (XMLErrorSeverityOverride_t strictErrorOverride = LIBSBML_OVERRIDE_ERROR );
+  unsigned int checkConsistencyWithStrictUnits ();
 
+  /**
+   * Performs consistency checking and validation on this SBML document
+   * using the ultra strict units validator that assumes that there
+   * are no hidden numerical conversion factors.
+   *
+   * If this method returns a nonzero value (meaning, one or more
+   * consistency checks have failed for SBML document), the failures may be
+   * due to warnings @em or errors.  Callers should inspect the severity
+   * flag in the individual SBMLError objects returned by
+   * SBMLDocument::getError(@if java long@endif) to determine the nature of the failures.
+   *
+   * @param strictErrorOverride the severity of the error to use for strict units checking
+   *       by default unit validations will be flagged as an error using this method. Use
+   *       LIBSBML_OVERRIDE_WARNING to change this to a warning.
+   * 
+   * @return the number of failed checks (errors) encountered.
+   *
+   * @see SBMLDocument::checkInternalConsistency()
+   */
+  unsigned int checkConsistencyWithStrictUnits (XMLErrorSeverityOverride_t strictErrorOverride);
 
   /**
    * Performs consistency checking and validation on this SBML document.

--- a/src/sbml/SBMLDocument.h
+++ b/src/sbml/SBMLDocument.h
@@ -341,6 +341,8 @@ class SBMLLevelVersionConverter;
 #define OverdeterCheckOFF 0xdf
 #define PracticeCheckON   0x40
 #define PracticeCheckOFF  0xbf
+#define StrictUnitsCheckON 0x80
+#define StrictUnitsCheckOFF 0x7f
 #define AllChecksON       0x7f
 /** @endcond */
 
@@ -1005,11 +1007,15 @@ public:
    * flag in the individual SBMLError objects returned by
    * SBMLDocument::getError(@if java long@endif) to determine the nature of the failures.
    *
+   * @param strictErrorOverride the severity of the error to use for strict units checking
+   *       by default unit validations will be flagged as an error using this method. Use
+   *       LIBSBML_OVERRIDE_WARNING to change this to a warning.
+   * 
    * @return the number of failed checks (errors) encountered.
    *
    * @see SBMLDocument::checkInternalConsistency()
    */
-  unsigned int checkConsistencyWithStrictUnits ();
+  unsigned int checkConsistencyWithStrictUnits (XMLErrorSeverityOverride_t strictErrorOverride = LIBSBML_OVERRIDE_ERROR );
 
 
   /**

--- a/src/sbml/SBMLDocument.h
+++ b/src/sbml/SBMLDocument.h
@@ -305,7 +305,7 @@
 #include <sbml/SBMLErrorLog.h>
 #include <sbml/SBase.h>
 #include <sbml/SBMLTransforms.h>
-
+#include <sbml/xml/XMLError.h>
 
 #ifdef __cplusplus
 
@@ -318,7 +318,6 @@ LIBSBML_CPP_NAMESPACE_BEGIN
 class Model;
 class ConversionProperties;
 class SBMLVisitor;
-class XMLError;
 
 class SBMLValidator;
 class SBMLInternalValidator;

--- a/src/sbml/SBMLError.cpp
+++ b/src/sbml/SBMLError.cpp
@@ -171,7 +171,8 @@ static struct sbmlCategoryString {
   { LIBSBML_CAT_MODELING_PRACTICE,      "Modeling practice"           },
   { LIBSBML_CAT_INTERNAL_CONSISTENCY,   "Internal consistency"        },
   { LIBSBML_CAT_SBML_L2V4_COMPAT,	"Translation to SBML L2V4"    },
-  { LIBSBML_CAT_SBML_L3V1_COMPAT, "Translation to SBML L3V1Core" }
+  { LIBSBML_CAT_SBML_L3V1_COMPAT, "Translation to SBML L3V1Core" },
+  { LIBSBML_CAT_STRICT_UNITS_CONSISTENCY, "Strict unit consistency"   }
 };
 
 static unsigned int sbmlCategoryStringTableSize

--- a/src/sbml/SBMLError.h
+++ b/src/sbml/SBMLError.h
@@ -1039,6 +1039,9 @@ typedef enum
   , LIBSBML_CAT_SBML_COMPATIBILITY
     /*!< Category of errors that can only occur during attempted
      * translation from one Level/Version of SBML to another. */
+  , LIBSBML_CAT_STRICT_UNITS_CONSISTENCY
+    /*!< Category of errors that occur running the strict unit 
+     * validator. */
 
 } SBMLErrorCategory_t;
 

--- a/src/sbml/test/TestConsistencyChecks.cpp
+++ b/src/sbml/test/TestConsistencyChecks.cpp
@@ -150,10 +150,55 @@ START_TEST (test_strict_unit_consistency_checks)
   fail_unless(d->getError(0)->getErrorId() == 10513);
   fail_unless(d->getError(0)->getSeverity() == LIBSBML_SEV_ERROR);
 
+  d->getErrorLog()->clearLog();
+
+  // now once more as warning
+  errors = d->checkConsistencyWithStrictUnits(LIBSBML_OVERRIDE_WARNING);
+
+  fail_unless(errors == 1);
+  fail_unless(d->getError(0)->getErrorId() == 10513);
+  fail_unless(d->getError(0)->getSeverity() == LIBSBML_SEV_WARNING);
+
+
+
   delete d;
 }
 END_TEST
 
+START_TEST (test_check_consistency_settings)
+{
+  SBMLReader        reader;
+  SBMLDocument*     d;
+  unsigned int errors;
+  std::string filename(TestDataDirectory);
+  filename += "l3v1-units.xml";
+
+
+  d = reader.readSBML(filename);
+
+  if (d == NULL)
+  {
+    fail("readSBML(\"l3v1-units.xml\") returned a NULL pointer.");
+  }
+
+  errors = d->checkConsistency();
+
+  fail_unless(errors == 0);
+
+  d->getErrorLog()->clearLog();
+
+  // now enable the strict units check
+  d->setConsistencyChecks(LIBSBML_CAT_STRICT_UNITS_CONSISTENCY, true);
+
+  errors = d->checkConsistency();
+
+  fail_unless(errors == 1);
+  fail_unless(d->getError(0)->getErrorId() == 10513);
+  fail_unless(d->getError(0)->getSeverity() == LIBSBML_SEV_WARNING);
+
+  delete d;
+}
+END_TEST
 
 Suite *
 create_suite_TestConsistencyChecks (void)
@@ -164,6 +209,7 @@ create_suite_TestConsistencyChecks (void)
 
   tcase_add_test(tcase, test_consistency_checks);
   tcase_add_test(tcase, test_strict_unit_consistency_checks);
+  tcase_add_test(tcase, test_check_consistency_settings);
 
   suite_add_tcase(suite, tcase);
 

--- a/src/sbml/validator/Validator.cpp
+++ b/src/sbml/validator/Validator.cpp
@@ -864,7 +864,8 @@ Validator::validate (const SBMLDocument& d)
 
   if (m != NULL)
   {
-    if (this->getCategory() == LIBSBML_CAT_UNITS_CONSISTENCY)
+    if (this->getCategory() == LIBSBML_CAT_UNITS_CONSISTENCY ||
+        this->getCategory() == LIBSBML_CAT_STRICT_UNITS_CONSISTENCY)
     {
       /* create list of formula units for validation */
       if (!m->isPopulatedListFormulaUnitsData())


### PR DESCRIPTION
## Description
This PR adds the strict unit validator to the options, so it can be run using checkConsistency. Additionally it adds an override flag to checkConsistencyWithStrictUnits, so that callers can decide as to the status of unit issues. 

The PR is written so that the behavior with it is the same as before: 

* callers have to explicitly enable `StrictUnitsCheckON` with `setConsistencyChecks` for it to be run with `checkConsistency`
* the test shows the behavior of both modes

## Motivation and Context
fixes #385 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Change in documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have updated all documentation necessary.
- [ ] I have checked spelling in (new) comments.

## Testing
- [X] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested -->

