### PR TITLE
Fix behavior of render getAllElements and memory leaks from there and elsewhere.

### DIFF
--- a/src/sbml/packages/render/sbml/ListOfGlobalRenderInformation.cpp
+++ b/src/sbml/packages/render/sbml/ListOfGlobalRenderInformation.cpp
@@ -789,6 +789,8 @@ ListOfGlobalRenderInformation::getAllElements(ElementFilter* filter)
 {
   List* ret = new List();
   List* sublist = ListOf::getAllElements(filter);
+  ret->transferFrom(sublist);
+  delete sublist;
 
   ADD_FILTERED_POINTER(ret, sublist, mDefaultValues, filter);
 

--- a/src/sbml/packages/render/sbml/ListOfLocalRenderInformation.cpp
+++ b/src/sbml/packages/render/sbml/ListOfLocalRenderInformation.cpp
@@ -760,6 +760,8 @@ ListOfLocalRenderInformation::getAllElements(ElementFilter* filter)
 {
   List* ret = new List();
   List* sublist = ListOf::getAllElements(filter);
+  ret->transferFrom(sublist);
+  delete sublist;
 
   ADD_FILTERED_POINTER(ret, sublist, mDefaultValues, filter);
 

--- a/src/sbml/packages/render/sbml/Style.cpp
+++ b/src/sbml/packages/render/sbml/Style.cpp
@@ -601,6 +601,7 @@ Style::createGroup()
 
   delete renderns;
   this->setGroup(g);
+  delete g;
 
   connectToChild();
 
@@ -1280,6 +1281,7 @@ Style::createObject(XMLInputStream& stream)
     RenderGroup* g = new RenderGroup(renderns);
     g->setElementName(name);
     setGroup(g);
+    delete g;
     obj = &mGroup;
   }
 


### PR DESCRIPTION
The sublist wasn't being deleted, and its contents weren't being transferred.
