### PR TITLE
A hack fix for issue 320, but it works.

### DIFF
--- a/src/sbml/SBMLTransforms.cpp
+++ b/src/sbml/SBMLTransforms.cpp
@@ -553,7 +553,9 @@ SBMLTransforms::clearComponentValues(const Model* m)
   }
 
   // otherwise remove only specific set
-	mModelValues.erase(m);
+  if (!mModelValues.empty()) {
+      mModelValues.erase(m);
+  }
 }
 
 


### PR DESCRIPTION
This fixes the bug in Antimony where somehow the order of deletion causes a crash here at the end of the program.  It wouldn't work if I actually used mModelValues, but I don't, and figuring out the actual cause is too much work, sadly.

No tests added, because it's been impossible to recreate this situation anywhere other than in the Antimony test program.