### PR TITLE
#417 : when reading  L3 document with l2 layout ignore required flag

### DIFF
--- a/src/sbml/extension/test/TestSBMLDocumentPlugin.cpp
+++ b/src/sbml/extension/test/TestSBMLDocumentPlugin.cpp
@@ -173,6 +173,9 @@ START_TEST(test_SBMLDocumentPlugin_read)
     fail_unless(sbml.find("layout_L2:") != std::string::npos);
   }
 
+  SBMLDocument* roundtrip = readSBMLFromString(sbml.c_str());
+  fail_unless(roundtrip->getNumErrors(LIBSBML_SEV_ERROR) == 0);
+
 }
 END_TEST
 

--- a/src/sbml/extension/test/TestSBMLDocumentPlugin.cpp
+++ b/src/sbml/extension/test/TestSBMLDocumentPlugin.cpp
@@ -58,6 +58,7 @@
 
 #include "TestPackage.h"
 
+extern char *TestDataDirectory;
 
 using namespace std;
 LIBSBML_CPP_NAMESPACE_USE
@@ -143,6 +144,35 @@ START_TEST (test_SBMLDocumentPlugin_c_api)
 }
 END_TEST
 
+START_TEST(test_SBMLDocumentPlugin_read)
+{
+  auto& instance = SBMLExtensionRegistry::getInstance();
+  bool layout_enabled = instance.getExtension("layout") != NULL;
+
+  std::string filename(TestDataDirectory);
+  filename += "issue417.xml";
+  auto* doc = readSBML(filename.c_str());
+  fail_unless(doc != NULL);
+  fail_unless(doc->getModel() != NULL);
+  int numErrors = doc->getNumErrors(LIBSBML_SEV_ERROR);
+  fail_unless(numErrors == 0);
+
+  std::string sbml = writeSBMLToString(doc);
+  delete doc;
+
+  if (layout_enabled) {
+    // layout is enabled, so we should not have the l2 required attribute 
+	// on the document
+    fail_unless(sbml.find("layout_L2:") == std::string::npos);
+  }
+  else {
+    // layout is not enabled, so we should have the l2 required attribute 
+	// on the document
+    fail_unless(sbml.find("layout_L2:") != std::string::npos);
+  }
+
+}
+END_TEST
 
 Suite *
 create_suite_SBMLDocumentPlugin (void)
@@ -152,6 +182,7 @@ create_suite_SBMLDocumentPlugin (void)
 	
   tcase_add_test( tcase, test_SBMLDocumentPlugin_create );
   tcase_add_test( tcase, test_SBMLDocumentPlugin_c_api );
+  tcase_add_test( tcase, test_SBMLDocumentPlugin_read );
   
   suite_add_tcase(suite, tcase);
 

--- a/src/sbml/extension/test/TestSBMLDocumentPlugin.cpp
+++ b/src/sbml/extension/test/TestSBMLDocumentPlugin.cpp
@@ -58,12 +58,14 @@
 
 #include "TestPackage.h"
 
-extern char *TestDataDirectory;
-
 using namespace std;
 LIBSBML_CPP_NAMESPACE_USE
 
 BEGIN_C_DECLS
+
+#include <sbml/util/util.h>
+
+extern char *TestDataDirectory;
 
 START_TEST (test_SBMLDocumentPlugin_create)
 {

--- a/src/sbml/extension/test/TestSBMLDocumentPlugin.cpp
+++ b/src/sbml/extension/test/TestSBMLDocumentPlugin.cpp
@@ -148,7 +148,7 @@ END_TEST
 
 START_TEST(test_SBMLDocumentPlugin_read)
 {
-  auto& instance = SBMLExtensionRegistry::getInstance();
+  SBMLExtensionRegistry& instance = SBMLExtensionRegistry::getInstance();
   bool layout_enabled = instance.getExtension("layout") != NULL;
 
   std::string filename(TestDataDirectory);
@@ -164,12 +164,12 @@ START_TEST(test_SBMLDocumentPlugin_read)
 
   if (layout_enabled) {
     // layout is enabled, so we should not have the l2 required attribute 
-  // on the document
+    // on the document
     fail_unless(sbml.find("layout_L2:") == std::string::npos);
   }
   else {
     // layout is not enabled, so we should have the l2 required attribute 
-  // on the document
+    // on the document
     fail_unless(sbml.find("layout_L2:") != std::string::npos);
   }
 

--- a/src/sbml/extension/test/TestSBMLDocumentPlugin.cpp
+++ b/src/sbml/extension/test/TestSBMLDocumentPlugin.cpp
@@ -149,7 +149,8 @@ END_TEST
 START_TEST(test_SBMLDocumentPlugin_read)
 {
   SBMLExtensionRegistry& instance = SBMLExtensionRegistry::getInstance();
-  bool layout_enabled = instance.getExtension("layout") != NULL;
+  SBMLExtension* layout = instance.getExtension("layout");
+  bool layout_enabled = layout != NULL;
 
   std::string filename(TestDataDirectory);
   filename += "issue417.xml";
@@ -159,23 +160,20 @@ START_TEST(test_SBMLDocumentPlugin_read)
   int numErrors = doc->getNumErrors(LIBSBML_SEV_ERROR);
   fail_unless(numErrors == 0);
 
-  std::string sbml = writeSBMLToString(doc);
+  std::string sbml = writeSBMLToStdString(doc);
   delete doc;
 
   if (layout_enabled) {
     // layout is enabled, so we should not have the l2 required attribute 
     // on the document
     fail_unless(sbml.find("layout_L2:") == std::string::npos);
-  }
-  else {
-    // layout is not enabled, so we should have the l2 required attribute 
-    // on the document
-    fail_unless(sbml.find("layout_L2:") != std::string::npos);
+    
+    delete layout;
   }
 
   SBMLDocument* roundtrip = readSBMLFromString(sbml.c_str());
   fail_unless(roundtrip->getNumErrors(LIBSBML_SEV_ERROR) == 0);
-  std::string sbml2 = writeSBMLToString(roundtrip);
+  std::string sbml2 = writeSBMLToStdString(roundtrip);
   delete roundtrip;
 
 }

--- a/src/sbml/extension/test/TestSBMLDocumentPlugin.cpp
+++ b/src/sbml/extension/test/TestSBMLDocumentPlugin.cpp
@@ -153,7 +153,7 @@ START_TEST(test_SBMLDocumentPlugin_read)
 
   std::string filename(TestDataDirectory);
   filename += "issue417.xml";
-  auto* doc = readSBML(filename.c_str());
+  SBMLDocument* doc = readSBML(filename.c_str());
   fail_unless(doc != NULL);
   fail_unless(doc->getModel() != NULL);
   int numErrors = doc->getNumErrors(LIBSBML_SEV_ERROR);
@@ -175,10 +175,7 @@ START_TEST(test_SBMLDocumentPlugin_read)
 
   SBMLDocument* roundtrip = readSBMLFromString(sbml.c_str());
   fail_unless(roundtrip->getNumErrors(LIBSBML_SEV_ERROR) == 0);
-
   std::string sbml2 = writeSBMLToString(roundtrip);
-
-
   delete roundtrip;
 
 }

--- a/src/sbml/extension/test/TestSBMLDocumentPlugin.cpp
+++ b/src/sbml/extension/test/TestSBMLDocumentPlugin.cpp
@@ -69,35 +69,35 @@ extern char *TestDataDirectory;
 
 START_TEST (test_SBMLDocumentPlugin_create)
 {
-	TestPkgNamespaces ns(3, 1, 1);
-	string uri = TestExtension::getXmlnsL3V1V1();
-	string prefix = "prefix";
-	std::vector<std::string> packageURIs;
-	packageURIs.push_back(uri);
+  TestPkgNamespaces ns(3, 1, 1);
+  string uri = TestExtension::getXmlnsL3V1V1();
+  string prefix = "prefix";
+  std::vector<std::string> packageURIs;
+  packageURIs.push_back(uri);
 
-	// create a creator for TestModelPlugins	
-	SBaseExtensionPoint sbmldocExtPoint("core",SBML_DOCUMENT);
-	SBasePluginCreator<SBMLDocumentPlugin, TestExtension> sbmldocPluginCreator(sbmldocExtPoint,packageURIs);
+  // create a creator for TestModelPlugins  
+  SBaseExtensionPoint sbmldocExtPoint("core",SBML_DOCUMENT);
+  SBasePluginCreator<SBMLDocumentPlugin, TestExtension> sbmldocPluginCreator(sbmldocExtPoint,packageURIs);
 
-	fail_unless(sbmldocPluginCreator.getNumOfSupportedPackageURI() == 1);		
-	fail_unless(strcmp(sbmldocPluginCreator.getSupportedPackageURI(0).c_str(), uri.c_str()) == 0);
-	fail_unless(strcmp(sbmldocPluginCreator.getSupportedPackageURI(10000).c_str(), "") == 0);
-	fail_unless(sbmldocPluginCreator.getTargetExtensionPoint().getPackageName() == sbmldocExtPoint.getPackageName());
-	fail_unless(sbmldocPluginCreator.getTargetExtensionPoint().getTypeCode() == sbmldocExtPoint.getTypeCode());
-	fail_unless(sbmldocPluginCreator.getTargetPackageName() == sbmldocExtPoint.getPackageName());	
-	fail_unless(sbmldocPluginCreator.getTargetSBMLTypeCode() == sbmldocExtPoint.getTypeCode());		
-	fail_unless(sbmldocPluginCreator.isSupported(uri));	
+  fail_unless(sbmldocPluginCreator.getNumOfSupportedPackageURI() == 1);    
+  fail_unless(strcmp(sbmldocPluginCreator.getSupportedPackageURI(0).c_str(), uri.c_str()) == 0);
+  fail_unless(strcmp(sbmldocPluginCreator.getSupportedPackageURI(10000).c_str(), "") == 0);
+  fail_unless(sbmldocPluginCreator.getTargetExtensionPoint().getPackageName() == sbmldocExtPoint.getPackageName());
+  fail_unless(sbmldocPluginCreator.getTargetExtensionPoint().getTypeCode() == sbmldocExtPoint.getTypeCode());
+  fail_unless(sbmldocPluginCreator.getTargetPackageName() == sbmldocExtPoint.getPackageName());  
+  fail_unless(sbmldocPluginCreator.getTargetSBMLTypeCode() == sbmldocExtPoint.getTypeCode());    
+  fail_unless(sbmldocPluginCreator.isSupported(uri));  
 
-	SBMLDocumentPlugin *plugin = sbmldocPluginCreator.createPlugin(uri, prefix, ns.getNamespaces());
+  SBMLDocumentPlugin *plugin = sbmldocPluginCreator.createPlugin(uri, prefix, ns.getNamespaces());
 
-	fail_unless(plugin != NULL);
+  fail_unless(plugin != NULL);
   fail_unless(plugin->isSetRequired() == false);
-	fail_unless(plugin->getRequired() == true);
-	plugin->setRequired(false);
+  fail_unless(plugin->getRequired() == true);
+  plugin->setRequired(false);
   fail_unless(plugin->isSetRequired() == true);
-	fail_unless(plugin->getRequired() == false);
+  fail_unless(plugin->getRequired() == false);
 
-	delete plugin;
+  delete plugin;
 
 
 }
@@ -106,26 +106,26 @@ END_TEST
 START_TEST (test_SBMLDocumentPlugin_c_api)
 {
   TestPkgNamespaces ns(3, 1, 1);
-	string uri = TestExtension::getXmlnsL3V1V1();
-	string prefix = "prefix";
-	std::vector<std::string> packageURIs;
-	packageURIs.push_back(uri);
+  string uri = TestExtension::getXmlnsL3V1V1();
+  string prefix = "prefix";
+  std::vector<std::string> packageURIs;
+  packageURIs.push_back(uri);
 
-	// create a creator for TestModelPlugins	
-	SBaseExtensionPoint sbmldocExtPoint("core",SBML_DOCUMENT);
-	SBasePluginCreator<SBMLDocumentPlugin, TestExtension> sbmldocPluginCreator(sbmldocExtPoint,packageURIs);
+  // create a creator for TestModelPlugins  
+  SBaseExtensionPoint sbmldocExtPoint("core",SBML_DOCUMENT);
+  SBasePluginCreator<SBMLDocumentPlugin, TestExtension> sbmldocPluginCreator(sbmldocExtPoint,packageURIs);
 
-	fail_unless(sbmldocPluginCreator.getNumOfSupportedPackageURI() == 1);		
-	fail_unless(strcmp(sbmldocPluginCreator.getSupportedPackageURI(0).c_str(), uri.c_str()) == 0);
-	fail_unless(strcmp(sbmldocPluginCreator.getSupportedPackageURI(10000).c_str(), "") == 0);
-	fail_unless(sbmldocPluginCreator.getTargetExtensionPoint().getPackageName() == sbmldocExtPoint.getPackageName());
-	fail_unless(sbmldocPluginCreator.getTargetExtensionPoint().getTypeCode() == sbmldocExtPoint.getTypeCode());
-	fail_unless(sbmldocPluginCreator.getTargetPackageName() == sbmldocExtPoint.getPackageName());	
-	fail_unless(sbmldocPluginCreator.getTargetSBMLTypeCode() == sbmldocExtPoint.getTypeCode());		
-	fail_unless(sbmldocPluginCreator.isSupported(uri));	
+  fail_unless(sbmldocPluginCreator.getNumOfSupportedPackageURI() == 1);    
+  fail_unless(strcmp(sbmldocPluginCreator.getSupportedPackageURI(0).c_str(), uri.c_str()) == 0);
+  fail_unless(strcmp(sbmldocPluginCreator.getSupportedPackageURI(10000).c_str(), "") == 0);
+  fail_unless(sbmldocPluginCreator.getTargetExtensionPoint().getPackageName() == sbmldocExtPoint.getPackageName());
+  fail_unless(sbmldocPluginCreator.getTargetExtensionPoint().getTypeCode() == sbmldocExtPoint.getTypeCode());
+  fail_unless(sbmldocPluginCreator.getTargetPackageName() == sbmldocExtPoint.getPackageName());  
+  fail_unless(sbmldocPluginCreator.getTargetSBMLTypeCode() == sbmldocExtPoint.getTypeCode());    
+  fail_unless(sbmldocPluginCreator.isSupported(uri));  
 
   SBMLDocumentPlugin_t* plugin = SBMLDocumentPlugin_create(uri.c_str(), prefix.c_str(), &ns);
-	fail_unless(plugin != NULL);
+  fail_unless(plugin != NULL);
   fail_unless(SBMLDocumentPlugin_isSetRequired(plugin) == (int)false);
   fail_unless(SBMLDocumentPlugin_getRequired(plugin) == (int)true);
   SBMLDocumentPlugin_setRequired(plugin, (int)true); 
@@ -164,19 +164,19 @@ START_TEST(test_SBMLDocumentPlugin_read)
 
   if (layout_enabled) {
     // layout is enabled, so we should not have the l2 required attribute 
-	// on the document
+  // on the document
     fail_unless(sbml.find("layout_L2:") == std::string::npos);
   }
   else {
     // layout is not enabled, so we should have the l2 required attribute 
-	// on the document
+  // on the document
     fail_unless(sbml.find("layout_L2:") != std::string::npos);
   }
 
   SBMLDocument* roundtrip = readSBMLFromString(sbml.c_str());
   fail_unless(roundtrip->getNumErrors(LIBSBML_SEV_ERROR) == 0);
 
-	std::string sbml2 = writeSBMLToString(roundtrip);
+  std::string sbml2 = writeSBMLToString(roundtrip);
 
 
   delete roundtrip;
@@ -189,7 +189,7 @@ create_suite_SBMLDocumentPlugin (void)
 {
   Suite *suite = suite_create("SBMLDocumentPlugin");
   TCase *tcase = tcase_create("SBMLDocumentPlugin");
-	
+  
   tcase_add_test( tcase, test_SBMLDocumentPlugin_create );
   tcase_add_test( tcase, test_SBMLDocumentPlugin_c_api );
   tcase_add_test( tcase, test_SBMLDocumentPlugin_read );

--- a/src/sbml/extension/test/TestSBMLDocumentPlugin.cpp
+++ b/src/sbml/extension/test/TestSBMLDocumentPlugin.cpp
@@ -176,6 +176,11 @@ START_TEST(test_SBMLDocumentPlugin_read)
   SBMLDocument* roundtrip = readSBMLFromString(sbml.c_str());
   fail_unless(roundtrip->getNumErrors(LIBSBML_SEV_ERROR) == 0);
 
+	std::string sbml2 = writeSBMLToString(roundtrip);
+
+
+  delete roundtrip;
+
 }
 END_TEST
 

--- a/src/sbml/extension/test/test-data/issue417.xml
+++ b/src/sbml/extension/test/test-data/issue417.xml
@@ -1,0 +1,5618 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<sbml xmlns="http://www.sbml.org/sbml/level3/version2/core" layout:required="false" layout_L2:required="false" level="3" version="2" xmlns:layout="http://www.sbml.org/sbml/level3/version1/layout/version1" xmlns:layout_L2="http://projects.eml.org/bcb/sbml/level2">
+  <model areaUnits="area" extentUnits="substance" id="Westerhoff_Nat2020" lengthUnits="length" metaid="COPASI0" name="Westerhoff2020 - systems biology model of the coronavirus pandemic 2020" substanceUnits="substance" timeUnits="time" volumeUnits="volume">
+    <notes>
+      <body xmlns="http://www.w3.org/1999/xhtml">
+        <p>Using standard systems biology methodologies a 14-compartment dynamic model was developed for the Corona virus epidemic. The model predicts that: (i) it will be impossible to limit lockdown intensity such that sufficient herd immunity develops for this epidemic to die down, (ii) the death toll from the SARS-CoV-2 virus decreases very strongly with increasing intensity of the lockdown, but (iii) the duration of the epidemic increases at first with that intensity and then decreases again, such that (iv) it may be best to begin with selecting a lockdown intensity beyond the intensity that leads to the maximum duration, (v) an intermittent lockdown strategy should also work and might be more acceptable socially and economically, (vi) an initially intensive but adaptive lockdown strategy should be most efficient, both in terms of its low number of casualties and shorter duration, (vii) such an adaptive lockdown strategy offers the advantage of being robust to unexpected imports of the virus, e.g. due to international travel, (viii) the eradication strategy may still be superior as it leads to even fewer deaths and a shorter period of economic downturn, but should have the adaptive strategy as backup in case of unexpected infection imports, (ix) earlier detection of infections is the most effective way in which the epidemic can be controlled, whilst waiting for vaccines.</p>
+      </body>
+    </notes>
+    <annotation>
+      <celldesigner:extension xmlns:celldesigner="http://www.sbml.org/2001/ns/celldesigner">
+        <celldesigner:modelVersion>4.0</celldesigner:modelVersion>
+        <celldesigner:modelDisplay sizeX="1356" sizeY="412"/>
+        <celldesigner:listOfCompartmentAliases/>
+        <celldesigner:listOfComplexSpeciesAliases/>
+        <celldesigner:listOfSpeciesAliases>
+          <celldesigner:speciesAlias id="sa1" species="s4">
+            <celldesigner:activity>inactive</celldesigner:activity>
+            <celldesigner:bounds x="611.0157004275316" y="125.13814449062434" w="312.0" h="55.0"/>
+            <celldesigner:font size="30"/>
+            <celldesigner:view state="usual"/>
+            <celldesigner:usualView>
+              <celldesigner:innerPosition x="0.0" y="0.0"/>
+              <celldesigner:boxSize width="312.0" height="55.0"/>
+              <celldesigner:singleLine width="1.0"/>
+              <celldesigner:paint color="ffcc99ff" scheme="Color"/>
+            </celldesigner:usualView>
+            <celldesigner:briefView>
+              <celldesigner:innerPosition x="0.0" y="0.0"/>
+              <celldesigner:boxSize width="80.0" height="60.0"/>
+              <celldesigner:singleLine width="1.0"/>
+              <celldesigner:paint color="3fff0000" scheme="Color"/>
+            </celldesigner:briefView>
+            <celldesigner:info state="empty" angle="-1.5707963267948966"/>
+          </celldesigner:speciesAlias>
+          <celldesigner:speciesAlias id="sa2" species="s5">
+            <celldesigner:activity>inactive</celldesigner:activity>
+            <celldesigner:bounds x="634.0157004275316" y="235.13814449062434" w="276.0" h="55.0"/>
+            <celldesigner:font size="30"/>
+            <celldesigner:view state="usual"/>
+            <celldesigner:usualView>
+              <celldesigner:innerPosition x="0.0" y="0.0"/>
+              <celldesigner:boxSize width="276.0" height="55.0"/>
+              <celldesigner:singleLine width="1.0"/>
+              <celldesigner:paint color="ffffff66" scheme="Color"/>
+            </celldesigner:usualView>
+            <celldesigner:briefView>
+              <celldesigner:innerPosition x="0.0" y="0.0"/>
+              <celldesigner:boxSize width="80.0" height="60.0"/>
+              <celldesigner:singleLine width="1.0"/>
+              <celldesigner:paint color="3fff0000" scheme="Color"/>
+            </celldesigner:briefView>
+            <celldesigner:info state="empty" angle="-1.5707963267948966"/>
+          </celldesigner:speciesAlias>
+          <celldesigner:speciesAlias id="sa3" species="s6">
+            <celldesigner:activity>inactive</celldesigner:activity>
+            <celldesigner:bounds x="269.01570042753156" y="126.13814449062434" w="281.0" h="52.0"/>
+            <celldesigner:font size="30"/>
+            <celldesigner:view state="usual"/>
+            <celldesigner:usualView>
+              <celldesigner:innerPosition x="0.0" y="0.0"/>
+              <celldesigner:boxSize width="281.0" height="52.0"/>
+              <celldesigner:singleLine width="1.0"/>
+              <celldesigner:paint color="ffccffcc" scheme="Color"/>
+            </celldesigner:usualView>
+            <celldesigner:briefView>
+              <celldesigner:innerPosition x="0.0" y="0.0"/>
+              <celldesigner:boxSize width="80.0" height="60.0"/>
+              <celldesigner:singleLine width="1.0"/>
+              <celldesigner:paint color="3fff0000" scheme="Color"/>
+            </celldesigner:briefView>
+            <celldesigner:info state="empty" angle="-1.5707963267948966"/>
+          </celldesigner:speciesAlias>
+          <celldesigner:speciesAlias id="sa4" species="s7">
+            <celldesigner:activity>inactive</celldesigner:activity>
+            <celldesigner:bounds x="312.01570042753156" y="234.13814449062434" w="231.0" h="52.0"/>
+            <celldesigner:font size="30"/>
+            <celldesigner:view state="usual"/>
+            <celldesigner:usualView>
+              <celldesigner:innerPosition x="0.0" y="0.0"/>
+              <celldesigner:boxSize width="231.0" height="52.0"/>
+              <celldesigner:singleLine width="1.0"/>
+              <celldesigner:paint color="ffccffcc" scheme="Color"/>
+            </celldesigner:usualView>
+            <celldesigner:briefView>
+              <celldesigner:innerPosition x="0.0" y="0.0"/>
+              <celldesigner:boxSize width="80.0" height="60.0"/>
+              <celldesigner:singleLine width="1.0"/>
+              <celldesigner:paint color="3fff0000" scheme="Color"/>
+            </celldesigner:briefView>
+            <celldesigner:info state="empty" angle="-1.5707963267948966"/>
+          </celldesigner:speciesAlias>
+          <celldesigner:speciesAlias id="sa5" species="s8">
+            <celldesigner:activity>inactive</celldesigner:activity>
+            <celldesigner:bounds x="1041.0157004275316" y="237.13814449062434" w="309.0" h="53.0"/>
+            <celldesigner:font size="30"/>
+            <celldesigner:view state="usual"/>
+            <celldesigner:usualView>
+              <celldesigner:innerPosition x="0.0" y="0.0"/>
+              <celldesigner:boxSize width="309.0" height="53.0"/>
+              <celldesigner:singleLine width="1.0"/>
+              <celldesigner:paint color="ffff9900" scheme="Color"/>
+            </celldesigner:usualView>
+            <celldesigner:briefView>
+              <celldesigner:innerPosition x="0.0" y="0.0"/>
+              <celldesigner:boxSize width="80.0" height="60.0"/>
+              <celldesigner:singleLine width="1.0"/>
+              <celldesigner:paint color="3fff0000" scheme="Color"/>
+            </celldesigner:briefView>
+            <celldesigner:info state="empty" angle="-1.5707963267948966"/>
+          </celldesigner:speciesAlias>
+          <celldesigner:speciesAlias id="sa6" species="s9">
+            <celldesigner:activity>inactive</celldesigner:activity>
+            <celldesigner:bounds x="1031.0157004275316" y="127.13814449062434" w="319.0" h="53.0"/>
+            <celldesigner:font size="30"/>
+            <celldesigner:view state="usual"/>
+            <celldesigner:usualView>
+              <celldesigner:innerPosition x="0.0" y="0.0"/>
+              <celldesigner:boxSize width="319.0" height="53.0"/>
+              <celldesigner:singleLine width="1.0"/>
+              <celldesigner:paint color="ffcc99ff" scheme="Color"/>
+            </celldesigner:usualView>
+            <celldesigner:briefView>
+              <celldesigner:innerPosition x="0.0" y="0.0"/>
+              <celldesigner:boxSize width="80.0" height="60.0"/>
+              <celldesigner:singleLine width="1.0"/>
+              <celldesigner:paint color="3fff0000" scheme="Color"/>
+            </celldesigner:briefView>
+            <celldesigner:info state="empty" angle="-1.5707963267948966"/>
+          </celldesigner:speciesAlias>
+          <celldesigner:speciesAlias id="sa7" species="s14">
+            <celldesigner:activity>inactive</celldesigner:activity>
+            <celldesigner:bounds x="1049.0157004275316" y="349.1381444906243" w="299.0" h="44.0"/>
+            <celldesigner:font size="30"/>
+            <celldesigner:view state="usual"/>
+            <celldesigner:usualView>
+              <celldesigner:innerPosition x="0.0" y="0.0"/>
+              <celldesigner:boxSize width="299.0" height="44.0"/>
+              <celldesigner:singleLine width="1.0"/>
+              <celldesigner:paint color="ff33cc00" scheme="Color"/>
+            </celldesigner:usualView>
+            <celldesigner:briefView>
+              <celldesigner:innerPosition x="0.0" y="0.0"/>
+              <celldesigner:boxSize width="80.0" height="60.0"/>
+              <celldesigner:singleLine width="1.0"/>
+              <celldesigner:paint color="3fff0000" scheme="Color"/>
+            </celldesigner:briefView>
+            <celldesigner:info state="empty" angle="-1.5707963267948966"/>
+          </celldesigner:speciesAlias>
+          <celldesigner:speciesAlias id="sa8" species="s15">
+            <celldesigner:activity>inactive</celldesigner:activity>
+            <celldesigner:bounds x="1027.0157004275316" y="25.13814449062434" w="317.0" h="49.0"/>
+            <celldesigner:font size="30"/>
+            <celldesigner:view state="usual"/>
+            <celldesigner:usualView>
+              <celldesigner:innerPosition x="0.0" y="0.0"/>
+              <celldesigner:boxSize width="317.0" height="49.0"/>
+              <celldesigner:singleLine width="1.0"/>
+              <celldesigner:paint color="ffcc99ff" scheme="Color"/>
+            </celldesigner:usualView>
+            <celldesigner:briefView>
+              <celldesigner:innerPosition x="0.0" y="0.0"/>
+              <celldesigner:boxSize width="80.0" height="60.0"/>
+              <celldesigner:singleLine width="1.0"/>
+              <celldesigner:paint color="3fff0000" scheme="Color"/>
+            </celldesigner:briefView>
+            <celldesigner:info state="empty" angle="-1.5707963267948966"/>
+          </celldesigner:speciesAlias>
+          <celldesigner:speciesAlias id="sa9" species="s16">
+            <celldesigner:activity>inactive</celldesigner:activity>
+            <celldesigner:bounds x="59.015700427531556" y="132.13814449062434" w="59.0" h="45.0"/>
+            <celldesigner:font size="30"/>
+            <celldesigner:view state="usual"/>
+            <celldesigner:usualView>
+              <celldesigner:innerPosition x="0.0" y="0.0"/>
+              <celldesigner:boxSize width="59.0" height="45.0"/>
+              <celldesigner:singleLine width="1.0"/>
+              <celldesigner:paint color="ffccffcc" scheme="Color"/>
+            </celldesigner:usualView>
+            <celldesigner:briefView>
+              <celldesigner:innerPosition x="0.0" y="0.0"/>
+              <celldesigner:boxSize width="80.0" height="60.0"/>
+              <celldesigner:singleLine width="1.0"/>
+              <celldesigner:paint color="3fff0000" scheme="Color"/>
+            </celldesigner:briefView>
+            <celldesigner:info state="empty" angle="-1.5707963267948966"/>
+          </celldesigner:speciesAlias>
+          <celldesigner:speciesAlias id="sa10" species="s22">
+            <celldesigner:activity>inactive</celldesigner:activity>
+            <celldesigner:bounds x="27.015700427531556" y="343.1381444906243" w="492.0" h="55.0"/>
+            <celldesigner:font size="30"/>
+            <celldesigner:view state="usual"/>
+            <celldesigner:usualView>
+              <celldesigner:innerPosition x="0.0" y="0.0"/>
+              <celldesigner:boxSize width="492.0" height="55.0"/>
+              <celldesigner:singleLine width="1.0"/>
+              <celldesigner:paint color="ffff6666" scheme="Color"/>
+            </celldesigner:usualView>
+            <celldesigner:briefView>
+              <celldesigner:innerPosition x="0.0" y="0.0"/>
+              <celldesigner:boxSize width="80.0" height="60.0"/>
+              <celldesigner:singleLine width="1.0"/>
+              <celldesigner:paint color="3fff0000" scheme="Color"/>
+            </celldesigner:briefView>
+            <celldesigner:info state="empty" angle="-1.5707963267948966"/>
+          </celldesigner:speciesAlias>
+          <celldesigner:speciesAlias id="sa11" species="s13">
+            <celldesigner:activity>inactive</celldesigner:activity>
+            <celldesigner:bounds x="607.0157004275316" y="354.1381444906243" w="322.0" h="47.0"/>
+            <celldesigner:font size="30"/>
+            <celldesigner:view state="usual"/>
+            <celldesigner:usualView>
+              <celldesigner:innerPosition x="0.0" y="0.0"/>
+              <celldesigner:boxSize width="322.0" height="47.0"/>
+              <celldesigner:singleLine width="1.0"/>
+              <celldesigner:paint color="ffff00cc" scheme="Color"/>
+            </celldesigner:usualView>
+            <celldesigner:briefView>
+              <celldesigner:innerPosition x="0.0" y="0.0"/>
+              <celldesigner:boxSize width="80.0" height="60.0"/>
+              <celldesigner:singleLine width="1.0"/>
+              <celldesigner:paint color="3fff0000" scheme="Color"/>
+            </celldesigner:briefView>
+            <celldesigner:info state="empty" angle="-1.5707963267948966"/>
+          </celldesigner:speciesAlias>
+          <celldesigner:speciesAlias id="sa12" species="s18">
+            <celldesigner:activity>inactive</celldesigner:activity>
+            <celldesigner:bounds x="598.0157004275316" y="32.13814449062434" w="338.0" h="43.0"/>
+            <celldesigner:font size="30"/>
+            <celldesigner:view state="usual"/>
+            <celldesigner:usualView>
+              <celldesigner:innerPosition x="0.0" y="0.0"/>
+              <celldesigner:boxSize width="338.0" height="43.0"/>
+              <celldesigner:singleLine width="1.0"/>
+              <celldesigner:paint color="ffcccccc" scheme="Color"/>
+            </celldesigner:usualView>
+            <celldesigner:briefView>
+              <celldesigner:innerPosition x="0.0" y="0.0"/>
+              <celldesigner:boxSize width="80.0" height="60.0"/>
+              <celldesigner:singleLine width="1.0"/>
+              <celldesigner:paint color="3fff0000" scheme="Color"/>
+            </celldesigner:briefView>
+            <celldesigner:info state="empty" angle="-1.5707963267948966"/>
+          </celldesigner:speciesAlias>
+          <celldesigner:speciesAlias id="sa13" species="s25">
+            <celldesigner:activity>inactive</celldesigner:activity>
+            <celldesigner:bounds x="29.015700427531556" y="240.13814449062434" w="230.0" h="50.0"/>
+            <celldesigner:font size="30"/>
+            <celldesigner:view state="usual"/>
+            <celldesigner:usualView>
+              <celldesigner:innerPosition x="0.0" y="0.0"/>
+              <celldesigner:boxSize width="230.0" height="50.0"/>
+              <celldesigner:singleLine width="1.0"/>
+              <celldesigner:paint color="ffcccccc" scheme="Color"/>
+            </celldesigner:usualView>
+            <celldesigner:briefView>
+              <celldesigner:innerPosition x="0.0" y="0.0"/>
+              <celldesigner:boxSize width="80.0" height="60.0"/>
+              <celldesigner:singleLine width="1.0"/>
+              <celldesigner:paint color="3fff0000" scheme="Color"/>
+            </celldesigner:briefView>
+            <celldesigner:info state="empty" angle="-1.5707963267948966"/>
+          </celldesigner:speciesAlias>
+          <celldesigner:speciesAlias id="sa14" species="s29">
+            <celldesigner:activity>inactive</celldesigner:activity>
+            <celldesigner:bounds x="70.01570042753156" y="66.13814449062434" w="244.0" h="39.0"/>
+            <celldesigner:font size="30"/>
+            <celldesigner:view state="usual"/>
+            <celldesigner:usualView>
+              <celldesigner:innerPosition x="0.0" y="0.0"/>
+              <celldesigner:boxSize width="244.0" height="39.0"/>
+              <celldesigner:singleLine width="1.0"/>
+              <celldesigner:paint color="ff33ff33" scheme="Color"/>
+            </celldesigner:usualView>
+            <celldesigner:briefView>
+              <celldesigner:innerPosition x="0.0" y="0.0"/>
+              <celldesigner:boxSize width="80.0" height="60.0"/>
+              <celldesigner:singleLine width="1.0"/>
+              <celldesigner:paint color="3fff0000" scheme="Color"/>
+            </celldesigner:briefView>
+            <celldesigner:info state="empty" angle="-1.5707963267948966"/>
+          </celldesigner:speciesAlias>
+        </celldesigner:listOfSpeciesAliases>
+        <celldesigner:listOfGroups/>
+        <celldesigner:listOfProteins>
+          <celldesigner:protein id="pr1" name="S" type="GENERIC"/>
+        </celldesigner:listOfProteins>
+        <celldesigner:listOfGenes/>
+        <celldesigner:listOfRNAs/>
+        <celldesigner:listOfAntisenseRNAs/>
+        <celldesigner:listOfLayers/>
+        <celldesigner:listOfBlockDiagrams/>
+      </celldesigner:extension>
+      <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+        <rdf:Description rdf:about="#COPASI0">
+	<dc:creator>
+	<rdf:Bag>
+	<rdf:li rdf:parseType="Resource">
+	<vCard:N rdf:parseType="Resource">
+	<vCard:Family>Jost</vCard:Family>
+	<vCard:Given>Paul Jonas</vCard:Given>
+	</vCard:N>
+	<vCard:EMAIL>s6pajost@uni-bonn.de</vCard:EMAIL>
+	<vCard:ORG rdf:parseType="Resource">
+	<vCard:Orgname>University of Bonn</vCard:Orgname>
+	</vCard:ORG>
+	</rdf:li>
+	<rdf:li rdf:parseType="Resource">
+	<vCard:N rdf:parseType="Resource">
+	<vCard:Family>Pathirana</vCard:Family>
+	<vCard:Given>Dilan</vCard:Given>
+	</vCard:N>
+	<vCard:EMAIL>dilan.pathirana@outlook.com</vCard:EMAIL>
+	<vCard:ORG rdf:parseType="Resource">
+	<vCard:Orgname>University of Bonn</vCard:Orgname>
+	</vCard:ORG>
+	</rdf:li>
+	</rdf:Bag>
+	</dc:creator>
+	<dcterms:created rdf:parseType="Resource">
+	<dcterms:W3CDTF>2020-03-19T13:58:08Z</dcterms:W3CDTF>
+	</dcterms:created>
+	<dcterms:modified rdf:parseType="Resource">
+	<dcterms:W3CDTF>2020-03-19T13:58:08Z</dcterms:W3CDTF>
+	</dcterms:modified>
+	<bqmodel:is>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/biomodels.db/MODEL2102120001"/>
+	<rdf:li rdf:resource="http://identifiers.org/biomodels.db/BIOMD0000000988"/>
+	</rdf:Bag>
+	</bqmodel:is>
+	<bqbiol:is>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/doid/DOID:0080600"/>
+	</rdf:Bag>
+	</bqbiol:is>
+	<bqbiol:hasTaxon>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/taxonomy/2697049"/>
+	</rdf:Bag>
+	</bqbiol:hasTaxon>
+	<bqbiol:hasTaxon>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/taxonomy/9606"/>
+	</rdf:Bag>
+	</bqbiol:hasTaxon>
+	<bqbiol:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/pubmed/32532983"/>
+	</rdf:Bag>
+	</bqbiol:isDescribedBy>
+	<bqbiol:hasProperty>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/mamo/MAMO_0000028"/>
+	</rdf:Bag>
+	</bqbiol:hasProperty>
+	<bqmodel:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="https://identifiers.org/pubmed:32532983"/>
+	</rdf:Bag>
+	</bqmodel:isDescribedBy>
+	</rdf:Description>
+	
+      </rdf:RDF>
+      <COPASI xmlns="http://www.copasi.org/static/sbml">
+        <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#">
+          <rdf:Description rdf:about="#COPASI0">
+            <bqbiol:hasProperty rdf:resource="urn:miriam:mamo:MAMO_0000028"/>
+            <bqbiol:hasProperty rdf:resource="urn:miriam:mamo:MAMO_0000046"/>
+            <bqbiol:hasTaxon rdf:resource="urn:miriam:taxonomy:2697049"/>
+            <bqbiol:hasTaxon rdf:resource="urn:miriam:taxonomy:9606"/>
+            <dcterms:bibliographicCitation>
+              <rdf:Description>
+                <CopasiMT:isDescribedBy rdf:resource="urn:miriam:pubmed:32532983"/>
+              </rdf:Description>
+            </dcterms:bibliographicCitation>
+            <dcterms:created>
+              <rdf:Description>
+                <dcterms:W3CDTF>2020-03-19T13:58:08Z</dcterms:W3CDTF>
+              </rdf:Description>
+            </dcterms:created>
+            <dcterms:creator>
+              <rdf:Description>
+                <vCard:EMAIL>s6pajost@uni-bonn.de</vCard:EMAIL>
+                <vCard:N>
+                  <rdf:Description>
+                    <vCard:Family>Jost</vCard:Family>
+                    <vCard:Given>Paul Jonas</vCard:Given>
+                  </rdf:Description>
+                </vCard:N>
+                <vCard:ORG>
+                  <rdf:Description>
+                    <vCard:Orgname>University of Bonn</vCard:Orgname>
+                  </rdf:Description>
+                </vCard:ORG>
+              </rdf:Description>
+            </dcterms:creator>
+            <dcterms:creator>
+              <rdf:Description>
+                <vCard:EMAIL>dilan.pathirana@outlook.com</vCard:EMAIL>
+                <vCard:N>
+                  <rdf:Description>
+                    <vCard:Family>Pathirana</vCard:Family>
+                    <vCard:Given>Dilan</vCard:Given>
+                  </rdf:Description>
+                </vCard:N>
+                <vCard:ORG>
+                  <rdf:Description>
+                    <vCard:Orgname>University of Bonn</vCard:Orgname>
+                  </rdf:Description>
+                </vCard:ORG>
+              </rdf:Description>
+            </dcterms:creator>
+            <CopasiMT:is rdf:resource="urn:miriam:doid:DOID:0080600"/>
+          </rdf:Description>
+        </rdf:RDF>
+      </COPASI>
+      </annotation>
+      <layout:listOfLayouts xmlns:layout="http://www.sbml.org/sbml/level3/version1/layout/version1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+      <annotation>
+          <render:listOfGlobalRenderInformation xmlns:render="http://projects.eml.org/bcb/sbml/render/level2">
+            <render:renderInformation render:id="GlobalRenderInformation_0" render:name="Copasi simple style" render:backgroundColor="#FFFFFFFF">
+              <render:listOfColorDefinitions>
+                <render:colorDefinition render:id="black" render:value="#000000"/>
+                <render:colorDefinition render:id="white" render:value="#ffffff"/>
+                <render:colorDefinition render:id="transparent" render:value="#ffffff00"/>
+                <render:colorDefinition render:id="EmptySetOutline" render:value="#808080"/>
+                <render:colorDefinition render:id="EmptySetGradientStart" render:value="#ffffff"/>
+                <render:colorDefinition render:id="EmptySetGradientEnd" render:value="#d3d3d3"/>
+                <render:colorDefinition render:id="CompartmentBorder" render:value="#e69600b0"/>
+                <render:colorDefinition render:id="CloneMarkerColor" render:value="#ffa500"/>
+                <render:colorDefinition render:id="CurveColor" render:value="#000000a0"/>
+                <render:colorDefinition render:id="ModulationCurveColor" render:value="#0000a0a0"/>
+              </render:listOfColorDefinitions>
+              <render:listOfGradientDefinitions>
+                <render:linearGradient render:id="cloneMarker" render:x1="50%" render:x2="50%">
+                  <render:stop render:offset="0" render:stop-color="transparent"/>
+                  <render:stop render:offset="0.75" render:stop-color="transparent"/>
+                  <render:stop render:offset="0.76" render:stop-color="CloneMarkerColor"/>
+                  <render:stop render:offset="1" render:stop-color="CloneMarkerColor"/>
+                </render:linearGradient>
+                <render:linearGradient render:id="EmptySetGradient">
+                  <render:stop render:offset="0" render:stop-color="EmptySetGradientStart"/>
+                  <render:stop render:offset="100%" render:stop-color="EmptySetGradientEnd"/>
+                </render:linearGradient>
+              </render:listOfGradientDefinitions>
+              <render:listOfLineEndings>
+                <render:lineEnding render:id="ActivationHead">
+                  <layout:boundingBox layout:id="bb">
+                    <layout:position layout:x="-12" layout:y="-6"/>
+                    <layout:dimensions layout:width="12" layout:height="12"/>
+                  </layout:boundingBox>
+                  <render:g render:stroke="CurveColor" render:stroke-width="1" render:fill="white" render:font-weight="normal" render:font-style="normal" render:text-anchor="start" render:vtext-anchor="top">
+                    <render:ellipse render:stroke="black" render:stroke-width="1" render:cx="50%" render:cy="50%" render:rx="50%"/>
+                  </render:g>
+                </render:lineEnding>
+                <render:lineEnding render:id="TransitionHead">
+                  <layout:boundingBox layout:id="bb">
+                    <layout:position layout:x="-8" layout:y="-6"/>
+                    <layout:dimensions layout:width="12" layout:height="12"/>
+                  </layout:boundingBox>
+                  <render:g render:stroke="CurveColor" render:stroke-width="0.001" render:fill="CurveColor" render:font-weight="normal" render:font-style="normal" render:text-anchor="start" render:vtext-anchor="top">
+                    <render:polygon render:fill="CurveColor">
+                      <render:listOfElements>
+                        <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="0" render:y="0"/>
+                        <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="100%" render:y="50%"/>
+                        <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="0" render:y="100%"/>
+                        <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="33%" render:y="50%"/>
+                        <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="0" render:y="0"/>
+                      </render:listOfElements>
+                    </render:polygon>
+                  </render:g>
+                </render:lineEnding>
+                <render:lineEnding render:id="ModulationHead">
+                  <layout:boundingBox layout:id="bb">
+                    <layout:position layout:x="-5" layout:y="-5"/>
+                    <layout:dimensions layout:width="10" layout:height="10"/>
+                  </layout:boundingBox>
+                  <render:g render:stroke="ModulationCurveColor" render:stroke-width="1" render:fill="ModulationCurveColor" render:font-weight="normal" render:font-style="normal" render:text-anchor="start" render:vtext-anchor="top">
+                    <render:ellipse render:cx="50%" render:cy="50%" render:rx="45%"/>
+                  </render:g>
+                </render:lineEnding>
+                <render:lineEnding render:id="InhibitionHead">
+                  <layout:boundingBox layout:id="bb">
+                    <layout:position layout:x="-0.5" layout:y="-4"/>
+                    <layout:dimensions layout:width="0.6" layout:height="8"/>
+                  </layout:boundingBox>
+                  <render:g render:stroke="black" render:stroke-width="2" render:fill="black" render:font-weight="normal" render:font-style="normal" render:text-anchor="start" render:vtext-anchor="top">
+                    <render:polygon>
+                      <render:listOfElements>
+                        <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="0" render:y="0"/>
+                        <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="0.3" render:y="0"/>
+                        <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="0.3" render:y="8"/>
+                        <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="0" render:y="8"/>
+                      </render:listOfElements>
+                    </render:polygon>
+                  </render:g>
+                </render:lineEnding>
+              </render:listOfLineEndings>
+              <render:listOfStyles>
+                <render:style render:roleList="invisible">
+                  <render:g render:stroke="#ffffff00" render:stroke-width="0" render:fill="#ffffff00" render:fill-rule="nonzero" render:font-family="sans-serif" render:font-weight="normal" render:font-style="normal" render:text-anchor="start" render:vtext-anchor="top" render:font-size="0"/>
+                </render:style>
+                <render:style render:roleList="defaultText" render:typeList="TEXTGLYPH">
+                  <render:g render:stroke="black" render:stroke-width="1" render:fill-rule="nonzero" render:font-family="Verdana" render:font-weight="normal" render:font-style="normal" render:text-anchor="middle" render:vtext-anchor="middle" render:font-size="12"/>
+                </render:style>
+                <render:style render:roleList="sidesubstrate substrate" render:typeList="REACTIONGLYPH">
+                  <render:g render:stroke="CurveColor" render:stroke-width="3" render:fill-rule="nonzero" render:font-family="sans-serif" render:font-weight="normal" render:font-style="normal" render:text-anchor="start" render:vtext-anchor="top" render:font-size="0"/>
+                </render:style>
+                <render:style render:roleList="SBO-0000169 inhibition inhibitor">
+                  <render:g render:stroke="CurveColor" render:stroke-width="3" render:fill-rule="nonzero" render:endHead="InhibitionHead" render:font-family="sans-serif" render:font-weight="normal" render:font-style="normal" render:text-anchor="start" render:vtext-anchor="top" render:font-size="0"/>
+                </render:style>
+                <render:style render:roleList="SBO-0000168 modifier">
+                  <render:g render:stroke="ModulationCurveColor" render:stroke-width="3" render:fill="white" render:fill-rule="nonzero" render:endHead="ModulationHead" render:font-family="sans-serif" render:font-weight="normal" render:font-style="normal" render:text-anchor="start" render:vtext-anchor="top" render:font-size="0"/>
+                </render:style>
+                <render:style render:roleList="SBO-0000172 activator catalysis">
+                  <render:g render:stroke="CurveColor" render:stroke-width="3" render:fill="white" render:fill-rule="nonzero" render:endHead="ActivationHead" render:font-family="sans-serif" render:font-weight="normal" render:font-style="normal" render:text-anchor="start" render:vtext-anchor="top" render:font-size="0"/>
+                </render:style>
+                <render:style render:roleList="product sideproduct" render:typeList="product sideproduct">
+                  <render:g render:stroke="CurveColor" render:stroke-width="3" render:fill-rule="nonzero" render:endHead="TransitionHead" render:font-family="sans-serif" render:font-weight="normal" render:font-style="normal" render:text-anchor="start" render:vtext-anchor="top" render:font-size="0"/>
+                </render:style>
+                <render:style render:roleList="NO-SBO SBO-0000285" render:typeList="SPECIESGLYPH">
+                  <render:g render:stroke-width="0" render:fill="#a0e0a030" render:fill-rule="nonzero" render:font-family="sans-serif" render:font-weight="normal" render:font-style="normal" render:text-anchor="start" render:vtext-anchor="top" render:font-size="0">
+                    <render:rectangle render:x="0" render:y="0" render:width="100%" render:height="100%"/>
+                  </render:g>
+                </render:style>
+                <render:style render:roleList="SBO-0000289" render:typeList="COMPARTMENTGLYPH">
+                  <render:g render:stroke="CompartmentBorder" render:stroke-width="7" render:fill-rule="nonzero" render:font-family="sans-serif" render:font-weight="normal" render:font-style="normal" render:text-anchor="start" render:vtext-anchor="top" render:font-size="0">
+                    <render:rectangle render:x="0" render:y="0" render:width="100%" render:height="100%" render:rx="20" render:ry="20"/>
+                  </render:g>
+                </render:style>
+                <render:style render:typeList="ANY">
+                  <render:g render:stroke="black" render:stroke-width="0" render:fill="#f0707070" render:fill-rule="nonzero" render:font-family="sans-serif" render:font-weight="normal" render:font-style="normal" render:text-anchor="start" render:vtext-anchor="top" render:font-size="0">
+                    <render:rectangle render:x="0" render:y="0" render:width="100%" render:height="100%"/>
+                  </render:g>
+                </render:style>
+              </render:listOfStyles>
+            </render:renderInformation>
+          </render:listOfGlobalRenderInformation>
+        </annotation>
+          <layout:layout layout:id="layout_0" layout:name="Layout">
+        <annotation>
+            <render:listOfRenderInformation xmlns:render="http://projects.eml.org/bcb/sbml/render/level2">
+              <render:renderInformation render:id="LocalRenderInformation_0" render:backgroundColor="#FFFFFFFF">
+                <render:listOfColorDefinitions>
+                  <render:colorDefinition render:id="black" render:value="#000000"/>
+                  <render:colorDefinition render:id="ColorDefinition" render:value="#cc99ff"/>
+                  <render:colorDefinition render:id="ColorDefinition_1" render:value="#ccffcc"/>
+                  <render:colorDefinition render:id="ColorDefinition_2" render:value="#ffff66"/>
+                  <render:colorDefinition render:id="ColorDefinition_3" render:value="#ff9900"/>
+                  <render:colorDefinition render:id="ColorDefinition_4" render:value="#33cc00"/>
+                  <render:colorDefinition render:id="ColorDefinition_5" render:value="#ff6666"/>
+                  <render:colorDefinition render:id="ColorDefinition_6" render:value="#cccccc"/>
+                  <render:colorDefinition render:id="ColorDefinition_7" render:value="#ff00cc"/>
+                  <render:colorDefinition render:id="ColorDefinition_8" render:value="#33ff33"/>
+                </render:listOfColorDefinitions>
+                <render:listOfLineEndings>
+                  <render:lineEnding render:id="modifier_arrow">
+                    <layout:boundingBox layout:id="bb">
+                      <layout:position layout:x="-5" layout:y="-5"/>
+                      <layout:dimensions layout:width="10" layout:height="10"/>
+                    </layout:boundingBox>
+                    <render:g>
+                      <render:polygon render:stroke="#000000" render:fill="#000000">
+                        <render:listOfElements>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="0" render:y="50%"/>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="50%" render:y="100%"/>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="100%" render:y="50%"/>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="50%" render:y="0"/>
+                        </render:listOfElements>
+                      </render:polygon>
+                    </render:g>
+                  </render:lineEnding>
+                  <render:lineEnding render:id="inhibitor_arrow">
+                    <layout:boundingBox layout:id="bb">
+                      <layout:position layout:x="0" layout:y="-5"/>
+                      <layout:dimensions layout:width="3" layout:height="10"/>
+                    </layout:boundingBox>
+                    <render:g>
+                      <render:rectangle render:stroke-width="1" render:fill="#000000" render:x="0" render:y="0" render:width="100%" render:height="100%"/>
+                    </render:g>
+                  </render:lineEnding>
+                  <render:lineEnding render:id="activator_arrow">
+                    <layout:boundingBox layout:id="bb">
+                      <layout:position layout:x="-5" layout:y="-5"/>
+                      <layout:dimensions layout:width="10" layout:height="10"/>
+                    </layout:boundingBox>
+                    <render:g>
+                      <render:polygon>
+                        <render:listOfElements>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="0" render:y="0"/>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="0" render:y="100%"/>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="100%" render:y="50%"/>
+                        </render:listOfElements>
+                      </render:polygon>
+                    </render:g>
+                  </render:lineEnding>
+                  <render:lineEnding render:id="catalysis_arrow">
+                    <layout:boundingBox layout:id="bb">
+                      <layout:position layout:x="-5" layout:y="-5"/>
+                      <layout:dimensions layout:width="10" layout:height="10"/>
+                    </layout:boundingBox>
+                    <render:g>
+                      <render:ellipse render:stroke="#000000" render:stroke-width="1" render:fill="#ffffff" render:cx="5" render:cy="5" render:rx="5"/>
+                    </render:g>
+                  </render:lineEnding>
+                  <render:lineEnding render:id="product_arrow">
+                    <layout:boundingBox layout:id="bb">
+                      <layout:position layout:x="-10" layout:y="-5"/>
+                      <layout:dimensions layout:width="10" layout:height="10"/>
+                    </layout:boundingBox>
+                    <render:g>
+                      <render:polygon render:fill="#000000">
+                        <render:listOfElements>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="0" render:y="0"/>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="0" render:y="100%"/>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="100%" render:y="50%"/>
+                        </render:listOfElements>
+                      </render:polygon>
+                    </render:g>
+                  </render:lineEnding>
+                </render:listOfLineEndings>
+                <render:listOfStyles>
+                  <render:style render:typeList="REACTIONGLYPH SPECIESREFERENCEGLYPH">
+                    <render:g render:stroke="black" render:stroke-width="1" render:fill-rule="nonzero" render:font-family="sans-serif" render:font-weight="normal" render:font-style="normal" render:text-anchor="start" render:vtext-anchor="top" render:font-size="0"/>
+                  </render:style>
+                  <render:style render:roleList="modifier">
+                    <render:g render:stroke="black" render:stroke-width="1" render:fill-rule="nonzero" render:endHead="modifier_arrow" render:font-family="sans-serif" render:font-weight="normal" render:font-style="normal" render:text-anchor="start" render:vtext-anchor="top" render:font-size="0"/>
+                  </render:style>
+                  <render:style render:roleList="inhibitor">
+                    <render:g render:stroke="black" render:stroke-width="1" render:fill-rule="nonzero" render:endHead="inhibitor_arrow" render:font-family="sans-serif" render:font-weight="normal" render:font-style="normal" render:text-anchor="start" render:vtext-anchor="top" render:font-size="0"/>
+                  </render:style>
+                  <render:style render:roleList="activator">
+                    <render:g render:stroke="black" render:stroke-width="1" render:fill-rule="nonzero" render:endHead="activator_arrow" render:font-family="sans-serif" render:font-weight="normal" render:font-style="normal" render:text-anchor="start" render:vtext-anchor="top" render:font-size="0"/>
+                  </render:style>
+                  <render:style render:idList="layout_glyph_17 layout_glyph_24 layout_glyph_49">
+                    <render:g render:stroke="black" render:stroke-width="1" render:fill-rule="nonzero" render:endHead="catalysis_arrow" render:font-family="sans-serif" render:font-weight="normal" render:font-style="normal" render:text-anchor="start" render:vtext-anchor="top" render:font-size="0"/>
+                  </render:style>
+                  <render:style>
+                    <render:g render:stroke="black" render:stroke-width="1" render:stroke-dasharray="5 , 5" render:fill-rule="nonzero" render:endHead="catalysis_arrow" render:font-family="sans-serif" render:font-weight="normal" render:font-style="normal" render:text-anchor="start" render:vtext-anchor="top" render:font-size="0"/>
+                  </render:style>
+                  <render:style render:roleList="product sideproduct">
+                    <render:g render:stroke="black" render:stroke-width="1" render:fill-rule="nonzero" render:endHead="product_arrow" render:font-family="sans-serif" render:font-weight="normal" render:font-style="normal" render:text-anchor="start" render:vtext-anchor="top" render:font-size="0"/>
+                  </render:style>
+                  <render:style render:roleList="sidesubstrate substrate">
+                    <render:g render:stroke="black" render:stroke-width="1" render:fill-rule="nonzero" render:font-family="sans-serif" render:font-weight="normal" render:font-style="normal" render:text-anchor="start" render:vtext-anchor="top" render:font-size="0"/>
+                  </render:style>
+                  <render:style render:idList="layout_glyph_71">
+                    <render:g render:stroke="black" render:stroke-width="1" render:fill-rule="nonzero" render:font-family="Arial" render:font-weight="normal" render:font-style="normal" render:text-anchor="middle" render:vtext-anchor="middle" render:font-size="30"/>
+                  </render:style>
+                  <render:style render:idList="layout_glyph_72">
+                    <render:g render:stroke="black" render:stroke-width="1" render:fill-rule="nonzero" render:font-family="Arial" render:font-weight="normal" render:font-style="normal" render:text-anchor="middle" render:vtext-anchor="middle" render:font-size="30"/>
+                  </render:style>
+                  <render:style render:idList="layout_glyph_73">
+                    <render:g render:stroke="black" render:stroke-width="1" render:fill-rule="nonzero" render:font-family="Arial" render:font-weight="normal" render:font-style="normal" render:text-anchor="middle" render:vtext-anchor="middle" render:font-size="30"/>
+                  </render:style>
+                  <render:style render:idList="layout_glyph_74">
+                    <render:g render:stroke="black" render:stroke-width="1" render:fill-rule="nonzero" render:font-family="Arial" render:font-weight="normal" render:font-style="normal" render:text-anchor="middle" render:vtext-anchor="middle" render:font-size="30"/>
+                  </render:style>
+                  <render:style render:idList="layout_glyph_75">
+                    <render:g render:stroke="black" render:stroke-width="1" render:fill-rule="nonzero" render:font-family="Arial" render:font-weight="normal" render:font-style="normal" render:text-anchor="middle" render:vtext-anchor="middle" render:font-size="30"/>
+                  </render:style>
+                  <render:style render:idList="layout_glyph_76">
+                    <render:g render:stroke="black" render:stroke-width="1" render:fill-rule="nonzero" render:font-family="Arial" render:font-weight="normal" render:font-style="normal" render:text-anchor="middle" render:vtext-anchor="middle" render:font-size="30"/>
+                  </render:style>
+                  <render:style render:idList="layout_glyph_77">
+                    <render:g render:stroke="black" render:stroke-width="1" render:fill-rule="nonzero" render:font-family="Arial" render:font-weight="normal" render:font-style="normal" render:text-anchor="middle" render:vtext-anchor="middle" render:font-size="30"/>
+                  </render:style>
+                  <render:style render:idList="layout_glyph_78">
+                    <render:g render:stroke="black" render:stroke-width="1" render:fill-rule="nonzero" render:font-family="Arial" render:font-weight="normal" render:font-style="normal" render:text-anchor="middle" render:vtext-anchor="middle" render:font-size="30"/>
+                  </render:style>
+                  <render:style render:idList="layout_glyph_79">
+                    <render:g render:stroke="black" render:stroke-width="1" render:fill-rule="nonzero" render:font-family="Arial" render:font-weight="normal" render:font-style="normal" render:text-anchor="middle" render:vtext-anchor="middle" render:font-size="30"/>
+                  </render:style>
+                  <render:style render:idList="layout_glyph_80">
+                    <render:g render:stroke="black" render:stroke-width="1" render:fill-rule="nonzero" render:font-family="Arial" render:font-weight="normal" render:font-style="normal" render:text-anchor="middle" render:vtext-anchor="middle" render:font-size="30"/>
+                  </render:style>
+                  <render:style render:idList="layout_glyph_81">
+                    <render:g render:stroke="black" render:stroke-width="1" render:fill-rule="nonzero" render:font-family="Arial" render:font-weight="normal" render:font-style="normal" render:text-anchor="middle" render:vtext-anchor="middle" render:font-size="30"/>
+                  </render:style>
+                  <render:style render:idList="layout_glyph_82">
+                    <render:g render:stroke="black" render:stroke-width="1" render:fill-rule="nonzero" render:font-family="Arial" render:font-weight="normal" render:font-style="normal" render:text-anchor="middle" render:vtext-anchor="middle" render:font-size="30"/>
+                  </render:style>
+                  <render:style render:idList="layout_glyph_83">
+                    <render:g render:stroke="black" render:stroke-width="1" render:fill-rule="nonzero" render:font-family="Arial" render:font-weight="normal" render:font-style="normal" render:text-anchor="middle" render:vtext-anchor="middle" render:font-size="30"/>
+                  </render:style>
+                  <render:style render:idList="layout_glyph_84">
+                    <render:g render:stroke="black" render:stroke-width="1" render:fill-rule="nonzero" render:font-family="Arial" render:font-weight="normal" render:font-style="normal" render:text-anchor="middle" render:vtext-anchor="middle" render:font-size="30"/>
+                  </render:style>
+                  <render:style render:idList="layout_glyph_0">
+                    <render:g render:stroke-width="0" render:fill-rule="nonzero" render:font-family="sans-serif" render:font-weight="normal" render:font-style="normal" render:text-anchor="start" render:vtext-anchor="top" render:font-size="0">
+                      <render:polygon render:stroke="#000000" render:stroke-width="1" render:fill="ColorDefinition">
+                        <render:listOfElements>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="0" render:y="50%"/>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="15%" render:y="0"/>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="85%" render:y="0"/>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="100%" render:y="50%"/>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="85%" render:y="100%"/>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="15%" render:y="100%"/>
+                        </render:listOfElements>
+                      </render:polygon>
+                    </render:g>
+                  </render:style>
+                  <render:style render:idList="layout_glyph_3">
+                    <render:g render:stroke-width="0" render:fill-rule="nonzero" render:font-family="sans-serif" render:font-weight="normal" render:font-style="normal" render:text-anchor="start" render:vtext-anchor="top" render:font-size="0">
+                      <render:polygon render:stroke="#000000" render:stroke-width="1" render:fill="ColorDefinition_1">
+                        <render:listOfElements>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="0" render:y="50%"/>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="15%" render:y="0"/>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="85%" render:y="0"/>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="100%" render:y="50%"/>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="85%" render:y="100%"/>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="15%" render:y="100%"/>
+                        </render:listOfElements>
+                      </render:polygon>
+                    </render:g>
+                  </render:style>
+                  <render:style render:idList="layout_glyph_1">
+                    <render:g render:stroke-width="0" render:fill-rule="nonzero" render:font-family="sans-serif" render:font-weight="normal" render:font-style="normal" render:text-anchor="start" render:vtext-anchor="top" render:font-size="0">
+                      <render:polygon render:stroke="#000000" render:stroke-width="1" render:fill="ColorDefinition_2">
+                        <render:listOfElements>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="0" render:y="50%"/>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="15%" render:y="0"/>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="85%" render:y="0"/>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="100%" render:y="50%"/>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="85%" render:y="100%"/>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="15%" render:y="100%"/>
+                        </render:listOfElements>
+                      </render:polygon>
+                    </render:g>
+                  </render:style>
+                  <render:style render:idList="layout_glyph_2">
+                    <render:g render:stroke-width="0" render:fill-rule="nonzero" render:font-family="sans-serif" render:font-weight="normal" render:font-style="normal" render:text-anchor="start" render:vtext-anchor="top" render:font-size="0">
+                      <render:polygon render:stroke="#000000" render:stroke-width="1" render:fill="ColorDefinition_1">
+                        <render:listOfElements>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="0" render:y="50%"/>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="15%" render:y="0"/>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="85%" render:y="0"/>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="100%" render:y="50%"/>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="85%" render:y="100%"/>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="15%" render:y="100%"/>
+                        </render:listOfElements>
+                      </render:polygon>
+                    </render:g>
+                  </render:style>
+                  <render:style render:idList="layout_glyph_4">
+                    <render:g render:stroke-width="0" render:fill-rule="nonzero" render:font-family="sans-serif" render:font-weight="normal" render:font-style="normal" render:text-anchor="start" render:vtext-anchor="top" render:font-size="0">
+                      <render:polygon render:stroke="#000000" render:stroke-width="1" render:fill="ColorDefinition_3">
+                        <render:listOfElements>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="0" render:y="50%"/>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="15%" render:y="0"/>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="85%" render:y="0"/>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="100%" render:y="50%"/>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="85%" render:y="100%"/>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="15%" render:y="100%"/>
+                        </render:listOfElements>
+                      </render:polygon>
+                    </render:g>
+                  </render:style>
+                  <render:style render:idList="layout_glyph_5">
+                    <render:g render:stroke-width="0" render:fill-rule="nonzero" render:font-family="sans-serif" render:font-weight="normal" render:font-style="normal" render:text-anchor="start" render:vtext-anchor="top" render:font-size="0">
+                      <render:polygon render:stroke="#000000" render:stroke-width="1" render:fill="ColorDefinition">
+                        <render:listOfElements>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="0" render:y="50%"/>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="15%" render:y="0"/>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="85%" render:y="0"/>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="100%" render:y="50%"/>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="85%" render:y="100%"/>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="15%" render:y="100%"/>
+                        </render:listOfElements>
+                      </render:polygon>
+                    </render:g>
+                  </render:style>
+                  <render:style render:idList="layout_glyph_6">
+                    <render:g render:stroke-width="0" render:fill-rule="nonzero" render:font-family="sans-serif" render:font-weight="normal" render:font-style="normal" render:text-anchor="start" render:vtext-anchor="top" render:font-size="0">
+                      <render:polygon render:stroke="#000000" render:stroke-width="1" render:fill="ColorDefinition_4">
+                        <render:listOfElements>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="0" render:y="50%"/>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="15%" render:y="0"/>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="85%" render:y="0"/>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="100%" render:y="50%"/>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="85%" render:y="100%"/>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="15%" render:y="100%"/>
+                        </render:listOfElements>
+                      </render:polygon>
+                    </render:g>
+                  </render:style>
+                  <render:style render:idList="layout_glyph_8">
+                    <render:g render:stroke-width="0" render:fill-rule="nonzero" render:font-family="sans-serif" render:font-weight="normal" render:font-style="normal" render:text-anchor="start" render:vtext-anchor="top" render:font-size="0">
+                      <render:rectangle render:stroke="#000000" render:stroke-width="1" render:fill="ColorDefinition_1" render:x="0" render:y="0" render:width="59" render:height="45" render:rx="10%" render:ry="10%"/>
+                    </render:g>
+                  </render:style>
+                  <render:style render:idList="layout_glyph_9">
+                    <render:g render:stroke-width="0" render:fill-rule="nonzero" render:font-family="sans-serif" render:font-weight="normal" render:font-style="normal" render:text-anchor="start" render:vtext-anchor="top" render:font-size="0">
+                      <render:polygon render:stroke="#000000" render:stroke-width="1" render:fill="ColorDefinition_5">
+                        <render:listOfElements>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="0" render:y="50%"/>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="15%" render:y="0"/>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="85%" render:y="0"/>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="100%" render:y="50%"/>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="85%" render:y="100%"/>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="15%" render:y="100%"/>
+                        </render:listOfElements>
+                      </render:polygon>
+                    </render:g>
+                  </render:style>
+                  <render:style render:idList="layout_glyph_12">
+                    <render:g render:stroke-width="0" render:fill-rule="nonzero" render:font-family="sans-serif" render:font-weight="normal" render:font-style="normal" render:text-anchor="start" render:vtext-anchor="top" render:font-size="0">
+                      <render:polygon render:stroke="#000000" render:stroke-width="1" render:fill="ColorDefinition_6">
+                        <render:listOfElements>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="0" render:y="50%"/>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="15%" render:y="0"/>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="85%" render:y="0"/>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="100%" render:y="50%"/>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="85%" render:y="100%"/>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="15%" render:y="100%"/>
+                        </render:listOfElements>
+                      </render:polygon>
+                    </render:g>
+                  </render:style>
+                  <render:style render:idList="layout_glyph_10">
+                    <render:g render:stroke-width="0" render:fill-rule="nonzero" render:font-family="sans-serif" render:font-weight="normal" render:font-style="normal" render:text-anchor="start" render:vtext-anchor="top" render:font-size="0">
+                      <render:polygon render:stroke="#000000" render:stroke-width="1" render:fill="ColorDefinition_7">
+                        <render:listOfElements>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="0" render:y="50%"/>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="15%" render:y="0"/>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="85%" render:y="0"/>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="100%" render:y="50%"/>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="85%" render:y="100%"/>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="15%" render:y="100%"/>
+                        </render:listOfElements>
+                      </render:polygon>
+                    </render:g>
+                  </render:style>
+                  <render:style render:idList="layout_glyph_11">
+                    <render:g render:stroke-width="0" render:fill-rule="nonzero" render:font-family="sans-serif" render:font-weight="normal" render:font-style="normal" render:text-anchor="start" render:vtext-anchor="top" render:font-size="0">
+                      <render:polygon render:stroke="#000000" render:stroke-width="1" render:fill="ColorDefinition_6">
+                        <render:listOfElements>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="0" render:y="50%"/>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="15%" render:y="0"/>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="85%" render:y="0"/>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="100%" render:y="50%"/>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="85%" render:y="100%"/>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="15%" render:y="100%"/>
+                        </render:listOfElements>
+                      </render:polygon>
+                    </render:g>
+                  </render:style>
+                  <render:style render:idList="layout_glyph_7">
+                    <render:g render:stroke-width="0" render:fill-rule="nonzero" render:font-family="sans-serif" render:font-weight="normal" render:font-style="normal" render:text-anchor="start" render:vtext-anchor="top" render:font-size="0">
+                      <render:polygon render:stroke="#000000" render:stroke-width="1" render:fill="ColorDefinition">
+                        <render:listOfElements>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="0" render:y="50%"/>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="15%" render:y="0"/>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="85%" render:y="0"/>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="100%" render:y="50%"/>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="85%" render:y="100%"/>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="15%" render:y="100%"/>
+                        </render:listOfElements>
+                      </render:polygon>
+                    </render:g>
+                  </render:style>
+                  <render:style render:idList="layout_glyph_13">
+                    <render:g render:stroke-width="0" render:fill-rule="nonzero" render:font-family="sans-serif" render:font-weight="normal" render:font-style="normal" render:text-anchor="start" render:vtext-anchor="top" render:font-size="0">
+                      <render:polygon render:stroke="#000000" render:stroke-width="1" render:fill="ColorDefinition_8">
+                        <render:listOfElements>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="0" render:y="50%"/>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="15%" render:y="0"/>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="85%" render:y="0"/>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="100%" render:y="50%"/>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="85%" render:y="100%"/>
+                          <render:element xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="RenderPoint" render:x="15%" render:y="100%"/>
+                        </render:listOfElements>
+                      </render:polygon>
+                    </render:g>
+                  </render:style>
+                </render:listOfStyles>
+              </render:renderInformation>
+            </render:listOfRenderInformation>
+          </annotation>
+              <layout:dimensions layout:height="412" layout:width="1356"/>
+        <layout:listOfSpeciesGlyphs>
+          <layout:speciesGlyph layout:id="layout_glyph_0" layout:species="infected_nontested_0">
+            <layout:boundingBox>
+              <layout:position layout:x="611.015700427532" layout:y="125.138144490624"/>
+              <layout:dimensions layout:height="55" layout:width="312"/>
+            </layout:boundingBox>
+          </layout:speciesGlyph>
+          <layout:speciesGlyph layout:id="layout_glyph_1" layout:species="infected_tested_0">
+            <layout:boundingBox>
+              <layout:position layout:x="634.015700427532" layout:y="235.138144490624"/>
+              <layout:dimensions layout:height="55" layout:width="276"/>
+            </layout:boundingBox>
+          </layout:speciesGlyph>
+          <layout:speciesGlyph layout:id="layout_glyph_2" layout:species="uninfected_nontested_0">
+            <layout:boundingBox>
+              <layout:position layout:x="269.015700427532" layout:y="126.138144490624"/>
+              <layout:dimensions layout:height="52" layout:width="281"/>
+            </layout:boundingBox>
+          </layout:speciesGlyph>
+          <layout:speciesGlyph layout:id="layout_glyph_3" layout:species="uninfected_tested_0">
+            <layout:boundingBox>
+              <layout:position layout:x="312.015700427532" layout:y="234.138144490624"/>
+              <layout:dimensions layout:height="52" layout:width="231"/>
+            </layout:boundingBox>
+          </layout:speciesGlyph>
+          <layout:speciesGlyph layout:id="layout_glyph_4" layout:species="symptoms_tested_0">
+            <layout:boundingBox>
+              <layout:position layout:x="1041.01570042753" layout:y="237.138144490624"/>
+              <layout:dimensions layout:height="53" layout:width="309"/>
+            </layout:boundingBox>
+          </layout:speciesGlyph>
+          <layout:speciesGlyph layout:id="layout_glyph_5" layout:species="symptoms_nontested_0">
+            <layout:boundingBox>
+              <layout:position layout:x="1031.01570042753" layout:y="127.138144490624"/>
+              <layout:dimensions layout:height="53" layout:width="319"/>
+            </layout:boundingBox>
+          </layout:speciesGlyph>
+          <layout:speciesGlyph layout:id="layout_glyph_6" layout:species="recovered_tested_0">
+            <layout:boundingBox>
+              <layout:position layout:x="1049.01570042753" layout:y="349.138144490624"/>
+              <layout:dimensions layout:height="44" layout:width="299"/>
+            </layout:boundingBox>
+          </layout:speciesGlyph>
+          <layout:speciesGlyph layout:id="layout_glyph_7" layout:species="recovered_nontested_0">
+            <layout:boundingBox>
+              <layout:position layout:x="1027.01570042753" layout:y="25.1381444906243"/>
+              <layout:dimensions layout:height="49" layout:width="317"/>
+            </layout:boundingBox>
+          </layout:speciesGlyph>
+          <layout:speciesGlyph layout:id="layout_glyph_8" layout:species="susceptible_0">
+            <layout:boundingBox>
+              <layout:position layout:x="59.0157004275316" layout:y="132.138144490624"/>
+              <layout:dimensions layout:height="45" layout:width="59"/>
+            </layout:boundingBox>
+          </layout:speciesGlyph>
+          <layout:speciesGlyph layout:id="layout_glyph_9">
+            <layout:boundingBox>
+              <layout:position layout:x="27.0157004275316" layout:y="343.138144490624"/>
+              <layout:dimensions layout:height="55" layout:width="492"/>
+            </layout:boundingBox>
+          </layout:speciesGlyph>
+          <layout:speciesGlyph layout:id="layout_glyph_10" layout:species="dead_corona_tested_0">
+            <layout:boundingBox>
+              <layout:position layout:x="607.015700427532" layout:y="354.138144490624"/>
+              <layout:dimensions layout:height="47" layout:width="322"/>
+            </layout:boundingBox>
+          </layout:speciesGlyph>
+          <layout:speciesGlyph layout:id="layout_glyph_11" layout:species="dead_corona_nontested_0">
+            <layout:boundingBox>
+              <layout:position layout:x="598.015700427532" layout:y="32.1381444906243"/>
+              <layout:dimensions layout:height="43" layout:width="338"/>
+            </layout:boundingBox>
+          </layout:speciesGlyph>
+          <layout:speciesGlyph layout:id="layout_glyph_12" layout:species="dead_noncorona_0">
+            <layout:boundingBox>
+              <layout:position layout:x="29.0157004275316" layout:y="240.138144490624"/>
+              <layout:dimensions layout:height="50" layout:width="230"/>
+            </layout:boundingBox>
+          </layout:speciesGlyph>
+          <layout:speciesGlyph layout:id="layout_glyph_13" layout:species="total_population_0">
+            <layout:boundingBox>
+              <layout:position layout:x="70.0157004275316" layout:y="66.1381444906243"/>
+              <layout:dimensions layout:height="39" layout:width="244"/>
+            </layout:boundingBox>
+          </layout:speciesGlyph>
+        </layout:listOfSpeciesGlyphs>
+        <layout:listOfReactionGlyphs>
+          <layout:reactionGlyph layout:id="layout_glyph_14" layout:reaction="re1">
+            <layout:boundingBox>
+              <layout:position layout:x="0" layout:y="0"/>
+              <layout:dimensions layout:height="0" layout:width="0"/>
+            </layout:boundingBox>
+            <layout:curve>
+              <layout:listOfCurveSegments>
+                <layout:curveSegment xsi:type="LineSegment">
+                  <layout:start layout:x="573.015952363238" layout:y="152.326671145835"/>
+                  <layout:end layout:x="588.015448491826" layout:y="152.449617835414"/>
+                </layout:curveSegment>
+              </layout:listOfCurveSegments>
+            </layout:curve>
+            <layout:listOfSpeciesReferenceGlyphs>
+              <layout:speciesReferenceGlyph layout:id="layout_glyph_15" layout:role="substrate" layout:speciesGlyph="layout_glyph_2">
+                <layout:curve>
+                  <layout:listOfCurveSegments>
+                    <layout:curveSegment xsi:type="LineSegment">
+                      <layout:start layout:x="573.015952363238" layout:y="152.326671145835"/>
+                      <layout:end layout:x="550.015700427532" layout:y="152.138144490624"/>
+                    </layout:curveSegment>
+                  </layout:listOfCurveSegments>
+                </layout:curve>
+              </layout:speciesReferenceGlyph>
+              <layout:speciesReferenceGlyph layout:id="layout_glyph_16" layout:role="product" layout:speciesGlyph="layout_glyph_0">
+                <layout:curve>
+                  <layout:listOfCurveSegments>
+                    <layout:curveSegment xsi:type="LineSegment">
+                      <layout:start layout:x="588.015448491826" layout:y="152.449617835414"/>
+                      <layout:end layout:x="611.015700427532" layout:y="152.638144490624"/>
+                    </layout:curveSegment>
+                  </layout:listOfCurveSegments>
+                </layout:curve>
+              </layout:speciesReferenceGlyph>
+              <layout:speciesReferenceGlyph layout:id="layout_glyph_17" layout:role="undefined" layout:speciesGlyph="layout_glyph_9">
+                <layout:curve>
+                  <layout:listOfCurveSegments>
+                    <layout:curveSegment xsi:type="LineSegment">
+                      <layout:start layout:x="27.0157004275316" layout:y="370.638144490624"/>
+                      <layout:end layout:x="9.06966465031392" layout:y="370.638144490624"/>
+                    </layout:curveSegment>
+                    <layout:curveSegment xsi:type="LineSegment">
+                      <layout:start layout:x="9.06966465031392" layout:y="370.638144490624"/>
+                      <layout:end layout:x="9.06966465031392" layout:y="27.4666933513384"/>
+                    </layout:curveSegment>
+                    <layout:curveSegment xsi:type="LineSegment">
+                      <layout:start layout:x="9.06966465031392" layout:y="27.4666933513384"/>
+                      <layout:end layout:x="573.057564415437" layout:y="27.4666933513384"/>
+                    </layout:curveSegment>
+                    <layout:curveSegment xsi:type="LineSegment">
+                      <layout:start layout:x="573.057564415437" layout:y="27.4666933513384"/>
+                      <layout:end layout:x="573.057564415437" layout:y="147.296106560532"/>
+                    </layout:curveSegment>
+                  </layout:listOfCurveSegments>
+                </layout:curve>
+              </layout:speciesReferenceGlyph>
+            </layout:listOfSpeciesReferenceGlyphs>
+          </layout:reactionGlyph>
+          <layout:reactionGlyph layout:id="layout_glyph_18" layout:reaction="re2">
+            <layout:boundingBox>
+              <layout:position layout:x="0" layout:y="0"/>
+              <layout:dimensions layout:height="0" layout:width="0"/>
+            </layout:boundingBox>
+            <layout:curve>
+              <layout:listOfCurveSegments>
+                <layout:curveSegment xsi:type="LineSegment">
+                  <layout:start layout:x="416.220631574433" layout:y="198.997930280985"/>
+                  <layout:end layout:x="420.81076928063" layout:y="213.278358700264"/>
+                </layout:curveSegment>
+              </layout:listOfCurveSegments>
+            </layout:curve>
+            <layout:listOfSpeciesReferenceGlyphs>
+              <layout:speciesReferenceGlyph layout:id="layout_glyph_19" layout:role="substrate" layout:speciesGlyph="layout_glyph_2">
+                <layout:curve>
+                  <layout:listOfCurveSegments>
+                    <layout:curveSegment xsi:type="LineSegment">
+                      <layout:start layout:x="416.220631574433" layout:y="198.997930280985"/>
+                      <layout:end layout:x="409.515700427532" layout:y="178.138144490624"/>
+                    </layout:curveSegment>
+                  </layout:listOfCurveSegments>
+                </layout:curve>
+              </layout:speciesReferenceGlyph>
+              <layout:speciesReferenceGlyph layout:id="layout_glyph_20" layout:role="product" layout:speciesGlyph="layout_glyph_3">
+                <layout:curve>
+                  <layout:listOfCurveSegments>
+                    <layout:curveSegment xsi:type="LineSegment">
+                      <layout:start layout:x="420.81076928063" layout:y="213.278358700264"/>
+                      <layout:end layout:x="427.515700427532" layout:y="234.138144490624"/>
+                    </layout:curveSegment>
+                  </layout:listOfCurveSegments>
+                </layout:curve>
+              </layout:speciesReferenceGlyph>
+            </layout:listOfSpeciesReferenceGlyphs>
+          </layout:reactionGlyph>
+          <layout:reactionGlyph layout:id="layout_glyph_21" layout:reaction="re3">
+            <layout:boundingBox>
+              <layout:position layout:x="0" layout:y="0"/>
+              <layout:dimensions layout:height="0" layout:width="0"/>
+            </layout:boundingBox>
+            <layout:curve>
+              <layout:listOfCurveSegments>
+                <layout:curveSegment xsi:type="LineSegment">
+                  <layout:start layout:x="581.01852910057" layout:y="261.182178245378"/>
+                  <layout:end layout:x="596.012871754493" layout:y="261.594110735871"/>
+                </layout:curveSegment>
+              </layout:listOfCurveSegments>
+            </layout:curve>
+            <layout:listOfSpeciesReferenceGlyphs>
+              <layout:speciesReferenceGlyph layout:id="layout_glyph_22" layout:role="substrate" layout:speciesGlyph="layout_glyph_3">
+                <layout:curve>
+                  <layout:listOfCurveSegments>
+                    <layout:curveSegment xsi:type="LineSegment">
+                      <layout:start layout:x="581.01852910057" layout:y="261.182178245378"/>
+                      <layout:end layout:x="543.015700427532" layout:y="260.138144490624"/>
+                    </layout:curveSegment>
+                  </layout:listOfCurveSegments>
+                </layout:curve>
+              </layout:speciesReferenceGlyph>
+              <layout:speciesReferenceGlyph layout:id="layout_glyph_23" layout:role="product" layout:speciesGlyph="layout_glyph_1">
+                <layout:curve>
+                  <layout:listOfCurveSegments>
+                    <layout:curveSegment xsi:type="LineSegment">
+                      <layout:start layout:x="596.012871754493" layout:y="261.594110735871"/>
+                      <layout:end layout:x="634.015700427532" layout:y="262.638144490624"/>
+                    </layout:curveSegment>
+                  </layout:listOfCurveSegments>
+                </layout:curve>
+              </layout:speciesReferenceGlyph>
+              <layout:speciesReferenceGlyph layout:id="layout_glyph_24" layout:role="undefined" layout:speciesGlyph="layout_glyph_9">
+                <layout:curve>
+                  <layout:listOfCurveSegments>
+                    <layout:curveSegment xsi:type="LineSegment">
+                      <layout:start layout:x="273.015700427532" layout:y="343.138144490624"/>
+                      <layout:end layout:x="273.015700427532" layout:y="310.111860803311"/>
+                    </layout:curveSegment>
+                    <layout:curveSegment xsi:type="LineSegment">
+                      <layout:start layout:x="273.015700427532" layout:y="310.111860803311"/>
+                      <layout:end layout:x="580.888287819297" layout:y="310.111860803311"/>
+                    </layout:curveSegment>
+                    <layout:curveSegment xsi:type="LineSegment">
+                      <layout:start layout:x="580.888287819297" layout:y="310.111860803311"/>
+                      <layout:end layout:x="580.888287819297" layout:y="266.077464703707"/>
+                    </layout:curveSegment>
+                  </layout:listOfCurveSegments>
+                </layout:curve>
+              </layout:speciesReferenceGlyph>
+            </layout:listOfSpeciesReferenceGlyphs>
+          </layout:reactionGlyph>
+          <layout:reactionGlyph layout:id="layout_glyph_25" layout:reaction="re4">
+            <layout:boundingBox>
+              <layout:position layout:x="0" layout:y="0"/>
+              <layout:dimensions layout:height="0" layout:width="0"/>
+            </layout:boundingBox>
+            <layout:curve>
+              <layout:listOfCurveSegments>
+                <layout:curveSegment xsi:type="LineSegment">
+                  <layout:start layout:x="768.836682332213" layout:y="200.168945442117"/>
+                  <layout:end layout:x="770.19471852285" layout:y="215.107343539132"/>
+                </layout:curveSegment>
+              </layout:listOfCurveSegments>
+            </layout:curve>
+            <layout:listOfSpeciesReferenceGlyphs>
+              <layout:speciesReferenceGlyph layout:id="layout_glyph_26" layout:role="substrate" layout:speciesGlyph="layout_glyph_0">
+                <layout:curve>
+                  <layout:listOfCurveSegments>
+                    <layout:curveSegment xsi:type="LineSegment">
+                      <layout:start layout:x="768.836682332213" layout:y="200.168945442117"/>
+                      <layout:end layout:x="767.015700427532" layout:y="180.138144490624"/>
+                    </layout:curveSegment>
+                  </layout:listOfCurveSegments>
+                </layout:curve>
+              </layout:speciesReferenceGlyph>
+              <layout:speciesReferenceGlyph layout:id="layout_glyph_27" layout:role="product" layout:speciesGlyph="layout_glyph_1">
+                <layout:curve>
+                  <layout:listOfCurveSegments>
+                    <layout:curveSegment xsi:type="LineSegment">
+                      <layout:start layout:x="770.19471852285" layout:y="215.107343539132"/>
+                      <layout:end layout:x="772.015700427532" layout:y="235.138144490624"/>
+                    </layout:curveSegment>
+                  </layout:listOfCurveSegments>
+                </layout:curve>
+              </layout:speciesReferenceGlyph>
+            </layout:listOfSpeciesReferenceGlyphs>
+          </layout:reactionGlyph>
+          <layout:reactionGlyph layout:id="layout_glyph_28" layout:reaction="re5">
+            <layout:boundingBox>
+              <layout:position layout:x="0" layout:y="0"/>
+              <layout:dimensions layout:height="0" layout:width="0"/>
+            </layout:boundingBox>
+            <layout:curve>
+              <layout:listOfCurveSegments>
+                <layout:curveSegment xsi:type="LineSegment">
+                  <layout:start layout:x="969.516021908918" layout:y="153.068703022859"/>
+                  <layout:end layout:x="984.515378946145" layout:y="153.207585958389"/>
+                </layout:curveSegment>
+              </layout:listOfCurveSegments>
+            </layout:curve>
+            <layout:listOfSpeciesReferenceGlyphs>
+              <layout:speciesReferenceGlyph layout:id="layout_glyph_29" layout:role="substrate" layout:speciesGlyph="layout_glyph_0">
+                <layout:curve>
+                  <layout:listOfCurveSegments>
+                    <layout:curveSegment xsi:type="LineSegment">
+                      <layout:start layout:x="969.516021908918" layout:y="153.068703022859"/>
+                      <layout:end layout:x="923.015700427532" layout:y="152.638144490624"/>
+                    </layout:curveSegment>
+                  </layout:listOfCurveSegments>
+                </layout:curve>
+              </layout:speciesReferenceGlyph>
+              <layout:speciesReferenceGlyph layout:id="layout_glyph_30" layout:role="product" layout:speciesGlyph="layout_glyph_5">
+                <layout:curve>
+                  <layout:listOfCurveSegments>
+                    <layout:curveSegment xsi:type="LineSegment">
+                      <layout:start layout:x="984.515378946145" layout:y="153.207585958389"/>
+                      <layout:end layout:x="1031.01570042753" layout:y="153.638144490624"/>
+                    </layout:curveSegment>
+                  </layout:listOfCurveSegments>
+                </layout:curve>
+              </layout:speciesReferenceGlyph>
+            </layout:listOfSpeciesReferenceGlyphs>
+          </layout:reactionGlyph>
+          <layout:reactionGlyph layout:id="layout_glyph_31" layout:reaction="re6">
+            <layout:boundingBox>
+              <layout:position layout:x="0" layout:y="0"/>
+              <layout:dimensions layout:height="0" layout:width="0"/>
+            </layout:boundingBox>
+            <layout:curve>
+              <layout:listOfCurveSegments>
+                <layout:curveSegment xsi:type="LineSegment">
+                  <layout:start layout:x="968.015918936716" layout:y="263.080894250236"/>
+                  <layout:end layout:x="983.015481918347" layout:y="263.195394731012"/>
+                </layout:curveSegment>
+              </layout:listOfCurveSegments>
+            </layout:curve>
+            <layout:listOfSpeciesReferenceGlyphs>
+              <layout:speciesReferenceGlyph layout:id="layout_glyph_32" layout:role="substrate" layout:speciesGlyph="layout_glyph_1">
+                <layout:curve>
+                  <layout:listOfCurveSegments>
+                    <layout:curveSegment xsi:type="LineSegment">
+                      <layout:start layout:x="968.015918936716" layout:y="263.080894250236"/>
+                      <layout:end layout:x="910.015700427532" layout:y="262.638144490624"/>
+                    </layout:curveSegment>
+                  </layout:listOfCurveSegments>
+                </layout:curve>
+              </layout:speciesReferenceGlyph>
+              <layout:speciesReferenceGlyph layout:id="layout_glyph_33" layout:role="product" layout:speciesGlyph="layout_glyph_4">
+                <layout:curve>
+                  <layout:listOfCurveSegments>
+                    <layout:curveSegment xsi:type="LineSegment">
+                      <layout:start layout:x="983.015481918347" layout:y="263.195394731012"/>
+                      <layout:end layout:x="1041.01570042753" layout:y="263.638144490624"/>
+                    </layout:curveSegment>
+                  </layout:listOfCurveSegments>
+                </layout:curve>
+              </layout:speciesReferenceGlyph>
+            </layout:listOfSpeciesReferenceGlyphs>
+          </layout:reactionGlyph>
+          <layout:reactionGlyph layout:id="layout_glyph_34" layout:reaction="re7">
+            <layout:boundingBox>
+              <layout:position layout:x="0" layout:y="0"/>
+              <layout:dimensions layout:height="0" layout:width="0"/>
+            </layout:boundingBox>
+            <layout:curve>
+              <layout:listOfCurveSegments>
+                <layout:curveSegment xsi:type="LineSegment">
+                  <layout:start layout:x="1192.36032231967" layout:y="201.166834061005"/>
+                  <layout:end layout:x="1193.67107853539" layout:y="216.109454920244"/>
+                </layout:curveSegment>
+              </layout:listOfCurveSegments>
+            </layout:curve>
+            <layout:listOfSpeciesReferenceGlyphs>
+              <layout:speciesReferenceGlyph layout:id="layout_glyph_35" layout:role="substrate" layout:speciesGlyph="layout_glyph_5">
+                <layout:curve>
+                  <layout:listOfCurveSegments>
+                    <layout:curveSegment xsi:type="LineSegment">
+                      <layout:start layout:x="1192.36032231967" layout:y="201.166834061005"/>
+                      <layout:end layout:x="1190.51570042753" layout:y="180.138144490624"/>
+                    </layout:curveSegment>
+                  </layout:listOfCurveSegments>
+                </layout:curve>
+              </layout:speciesReferenceGlyph>
+              <layout:speciesReferenceGlyph layout:id="layout_glyph_36" layout:role="product" layout:speciesGlyph="layout_glyph_4">
+                <layout:curve>
+                  <layout:listOfCurveSegments>
+                    <layout:curveSegment xsi:type="LineSegment">
+                      <layout:start layout:x="1193.67107853539" layout:y="216.109454920244"/>
+                      <layout:end layout:x="1195.51570042753" layout:y="237.138144490624"/>
+                    </layout:curveSegment>
+                  </layout:listOfCurveSegments>
+                </layout:curve>
+              </layout:speciesReferenceGlyph>
+            </layout:listOfSpeciesReferenceGlyphs>
+          </layout:reactionGlyph>
+          <layout:reactionGlyph layout:id="layout_glyph_37" layout:reaction="re8">
+            <layout:boundingBox>
+              <layout:position layout:x="0" layout:y="0"/>
+              <layout:dimensions layout:height="0" layout:width="0"/>
+            </layout:boundingBox>
+            <layout:curve>
+              <layout:listOfCurveSegments>
+                <layout:curveSegment xsi:type="LineSegment">
+                  <layout:start layout:x="991.527523993465" layout:y="318.417102452948"/>
+                  <layout:end layout:x="978.503876861598" layout:y="325.859186528301"/>
+                </layout:curveSegment>
+              </layout:listOfCurveSegments>
+            </layout:curve>
+            <layout:listOfSpeciesReferenceGlyphs>
+              <layout:speciesReferenceGlyph layout:id="layout_glyph_38" layout:role="substrate" layout:speciesGlyph="layout_glyph_4">
+                <layout:curve>
+                  <layout:listOfCurveSegments>
+                    <layout:curveSegment xsi:type="LineSegment">
+                      <layout:start layout:x="991.527523993465" layout:y="318.417102452948"/>
+                      <layout:end layout:x="1041.01570042753" layout:y="290.138144490624"/>
+                    </layout:curveSegment>
+                  </layout:listOfCurveSegments>
+                </layout:curve>
+              </layout:speciesReferenceGlyph>
+              <layout:speciesReferenceGlyph layout:id="layout_glyph_39" layout:role="product" layout:speciesGlyph="layout_glyph_10">
+                <layout:curve>
+                  <layout:listOfCurveSegments>
+                    <layout:curveSegment xsi:type="LineSegment">
+                      <layout:start layout:x="978.503876861598" layout:y="325.859186528301"/>
+                      <layout:end layout:x="929.015700427532" layout:y="354.138144490624"/>
+                    </layout:curveSegment>
+                  </layout:listOfCurveSegments>
+                </layout:curve>
+              </layout:speciesReferenceGlyph>
+            </layout:listOfSpeciesReferenceGlyphs>
+          </layout:reactionGlyph>
+          <layout:reactionGlyph layout:id="layout_glyph_40" layout:reaction="re9">
+            <layout:boundingBox>
+              <layout:position layout:x="0" layout:y="0"/>
+              <layout:dimensions layout:height="0" layout:width="0"/>
+            </layout:boundingBox>
+            <layout:curve>
+              <layout:listOfCurveSegments>
+                <layout:curveSegment xsi:type="LineSegment">
+                  <layout:start layout:x="1196.63483653243" layout:y="312.147821220337"/>
+                  <layout:end layout:x="1197.39656432263" layout:y="327.128467760912"/>
+                </layout:curveSegment>
+              </layout:listOfCurveSegments>
+            </layout:curve>
+            <layout:listOfSpeciesReferenceGlyphs>
+              <layout:speciesReferenceGlyph layout:id="layout_glyph_41" layout:role="substrate" layout:speciesGlyph="layout_glyph_4">
+                <layout:curve>
+                  <layout:listOfCurveSegments>
+                    <layout:curveSegment xsi:type="LineSegment">
+                      <layout:start layout:x="1196.63483653243" layout:y="312.147821220337"/>
+                      <layout:end layout:x="1195.51570042753" layout:y="290.138144490624"/>
+                    </layout:curveSegment>
+                  </layout:listOfCurveSegments>
+                </layout:curve>
+              </layout:speciesReferenceGlyph>
+              <layout:speciesReferenceGlyph layout:id="layout_glyph_42" layout:role="product" layout:speciesGlyph="layout_glyph_6">
+                <layout:curve>
+                  <layout:listOfCurveSegments>
+                    <layout:curveSegment xsi:type="LineSegment">
+                      <layout:start layout:x="1197.39656432263" layout:y="327.128467760912"/>
+                      <layout:end layout:x="1198.51570042753" layout:y="349.138144490624"/>
+                    </layout:curveSegment>
+                  </layout:listOfCurveSegments>
+                </layout:curve>
+              </layout:speciesReferenceGlyph>
+            </layout:listOfSpeciesReferenceGlyphs>
+          </layout:reactionGlyph>
+          <layout:reactionGlyph layout:id="layout_glyph_43" layout:reaction="re10">
+            <layout:boundingBox>
+              <layout:position layout:x="0" layout:y="0"/>
+              <layout:dimensions layout:height="0" layout:width="0"/>
+            </layout:boundingBox>
+            <layout:curve>
+              <layout:listOfCurveSegments>
+                <layout:curveSegment xsi:type="LineSegment">
+                  <layout:start layout:x="1188.720119887" layout:y="108.10499076098"/>
+                  <layout:end layout:x="1187.31128096806" layout:y="93.1712982202687"/>
+                </layout:curveSegment>
+              </layout:listOfCurveSegments>
+            </layout:curve>
+            <layout:listOfSpeciesReferenceGlyphs>
+              <layout:speciesReferenceGlyph layout:id="layout_glyph_44" layout:role="substrate" layout:speciesGlyph="layout_glyph_5">
+                <layout:curve>
+                  <layout:listOfCurveSegments>
+                    <layout:curveSegment xsi:type="LineSegment">
+                      <layout:start layout:x="1188.720119887" layout:y="108.10499076098"/>
+                      <layout:end layout:x="1190.51570042753" layout:y="127.138144490624"/>
+                    </layout:curveSegment>
+                  </layout:listOfCurveSegments>
+                </layout:curve>
+              </layout:speciesReferenceGlyph>
+              <layout:speciesReferenceGlyph layout:id="layout_glyph_45" layout:role="product" layout:speciesGlyph="layout_glyph_7">
+                <layout:curve>
+                  <layout:listOfCurveSegments>
+                    <layout:curveSegment xsi:type="LineSegment">
+                      <layout:start layout:x="1187.31128096806" layout:y="93.1712982202687"/>
+                      <layout:end layout:x="1185.51570042753" layout:y="74.1381444906243"/>
+                    </layout:curveSegment>
+                  </layout:listOfCurveSegments>
+                </layout:curve>
+              </layout:speciesReferenceGlyph>
+            </layout:listOfSpeciesReferenceGlyphs>
+          </layout:reactionGlyph>
+          <layout:reactionGlyph layout:id="layout_glyph_46" layout:reaction="re11">
+            <layout:boundingBox>
+              <layout:position layout:x="0" layout:y="0"/>
+              <layout:dimensions layout:height="0" layout:width="0"/>
+            </layout:boundingBox>
+            <layout:curve>
+              <layout:listOfCurveSegments>
+                <layout:curveSegment xsi:type="LineSegment">
+                  <layout:start layout:x="186.0167281317" layout:y="153.512299661085"/>
+                  <layout:end layout:x="201.014672723363" layout:y="153.263989320164"/>
+                </layout:curveSegment>
+              </layout:listOfCurveSegments>
+            </layout:curve>
+            <layout:listOfSpeciesReferenceGlyphs>
+              <layout:speciesReferenceGlyph layout:id="layout_glyph_47" layout:role="substrate" layout:speciesGlyph="layout_glyph_8">
+                <layout:curve>
+                  <layout:listOfCurveSegments>
+                    <layout:curveSegment xsi:type="LineSegment">
+                      <layout:start layout:x="186.0167281317" layout:y="153.512299661085"/>
+                      <layout:end layout:x="118.015700427532" layout:y="154.638144490624"/>
+                    </layout:curveSegment>
+                  </layout:listOfCurveSegments>
+                </layout:curve>
+              </layout:speciesReferenceGlyph>
+              <layout:speciesReferenceGlyph layout:id="layout_glyph_48" layout:role="product" layout:speciesGlyph="layout_glyph_2">
+                <layout:curve>
+                  <layout:listOfCurveSegments>
+                    <layout:curveSegment xsi:type="LineSegment">
+                      <layout:start layout:x="201.014672723363" layout:y="153.263989320164"/>
+                      <layout:end layout:x="269.015700427532" layout:y="152.138144490624"/>
+                    </layout:curveSegment>
+                  </layout:listOfCurveSegments>
+                </layout:curve>
+              </layout:speciesReferenceGlyph>
+              <layout:speciesReferenceGlyph layout:id="layout_glyph_49" layout:role="undefined" layout:speciesGlyph="layout_glyph_13">
+                <layout:curve>
+                  <layout:listOfCurveSegments>
+                    <layout:curveSegment xsi:type="LineSegment">
+                      <layout:start layout:x="192.015700427532" layout:y="105.138144490624"/>
+                      <layout:end layout:x="193.515700427532" layout:y="148.388144490624"/>
+                    </layout:curveSegment>
+                  </layout:listOfCurveSegments>
+                </layout:curve>
+              </layout:speciesReferenceGlyph>
+            </layout:listOfSpeciesReferenceGlyphs>
+          </layout:reactionGlyph>
+          <layout:reactionGlyph layout:id="layout_glyph_50" layout:reaction="re12">
+            <layout:boundingBox>
+              <layout:position layout:x="0" layout:y="0"/>
+              <layout:dimensions layout:height="0" layout:width="0"/>
+            </layout:boundingBox>
+            <layout:curve>
+              <layout:listOfCurveSegments>
+                <layout:curveSegment xsi:type="LineSegment">
+                  <layout:start layout:x="213.234620175718" layout:y="205.805560295524"/>
+                  <layout:end layout:x="199.796780679345" layout:y="212.470728685725"/>
+                </layout:curveSegment>
+              </layout:listOfCurveSegments>
+            </layout:curve>
+            <layout:listOfSpeciesReferenceGlyphs>
+              <layout:speciesReferenceGlyph layout:id="layout_glyph_51" layout:role="substrate" layout:speciesGlyph="layout_glyph_2">
+                <layout:curve>
+                  <layout:listOfCurveSegments>
+                    <layout:curveSegment xsi:type="LineSegment">
+                      <layout:start layout:x="213.234620175718" layout:y="205.805560295524"/>
+                      <layout:end layout:x="269.015700427532" layout:y="178.138144490624"/>
+                    </layout:curveSegment>
+                  </layout:listOfCurveSegments>
+                </layout:curve>
+              </layout:speciesReferenceGlyph>
+              <layout:speciesReferenceGlyph layout:id="layout_glyph_52" layout:role="product" layout:speciesGlyph="layout_glyph_12">
+                <layout:curve>
+                  <layout:listOfCurveSegments>
+                    <layout:curveSegment xsi:type="LineSegment">
+                      <layout:start layout:x="199.796780679345" layout:y="212.470728685725"/>
+                      <layout:end layout:x="144.015700427532" layout:y="240.138144490624"/>
+                    </layout:curveSegment>
+                  </layout:listOfCurveSegments>
+                </layout:curve>
+              </layout:speciesReferenceGlyph>
+            </layout:listOfSpeciesReferenceGlyphs>
+          </layout:reactionGlyph>
+          <layout:reactionGlyph layout:id="layout_glyph_53" layout:reaction="re13">
+            <layout:boundingBox>
+              <layout:position layout:x="0" layout:y="0"/>
+              <layout:dimensions layout:height="0" layout:width="0"/>
+            </layout:boundingBox>
+            <layout:curve>
+              <layout:listOfCurveSegments>
+                <layout:curveSegment xsi:type="LineSegment">
+                  <layout:start layout:x="996.504721975779" layout:y="373.982489156761"/>
+                  <layout:end layout:x="981.526678879285" layout:y="374.793799824488"/>
+                </layout:curveSegment>
+              </layout:listOfCurveSegments>
+            </layout:curve>
+            <layout:listOfSpeciesReferenceGlyphs>
+              <layout:speciesReferenceGlyph layout:id="layout_glyph_54" layout:role="substrate" layout:speciesGlyph="layout_glyph_6">
+                <layout:curve>
+                  <layout:listOfCurveSegments>
+                    <layout:curveSegment xsi:type="LineSegment">
+                      <layout:start layout:x="996.504721975779" layout:y="373.982489156761"/>
+                      <layout:end layout:x="1049.01570042753" layout:y="371.138144490624"/>
+                    </layout:curveSegment>
+                  </layout:listOfCurveSegments>
+                </layout:curve>
+              </layout:speciesReferenceGlyph>
+              <layout:speciesReferenceGlyph layout:id="layout_glyph_55" layout:role="product" layout:speciesGlyph="layout_glyph_10">
+                <layout:curve>
+                  <layout:listOfCurveSegments>
+                    <layout:curveSegment xsi:type="LineSegment">
+                      <layout:start layout:x="981.526678879285" layout:y="374.793799824488"/>
+                      <layout:end layout:x="929.015700427532" layout:y="377.638144490624"/>
+                    </layout:curveSegment>
+                  </layout:listOfCurveSegments>
+                </layout:curve>
+              </layout:speciesReferenceGlyph>
+            </layout:listOfSpeciesReferenceGlyphs>
+          </layout:reactionGlyph>
+          <layout:reactionGlyph layout:id="layout_glyph_56" layout:reaction="re14">
+            <layout:boundingBox>
+              <layout:position layout:x="0" layout:y="0"/>
+              <layout:dimensions layout:height="0" layout:width="0"/>
+            </layout:boundingBox>
+            <layout:curve>
+              <layout:listOfCurveSegments>
+                <layout:curveSegment xsi:type="LineSegment">
+                  <layout:start layout:x="989.008465408363" layout:y="51.3087921837746"/>
+                  <layout:end layout:x="974.0229354467" layout:y="51.9674967974741"/>
+                </layout:curveSegment>
+              </layout:listOfCurveSegments>
+            </layout:curve>
+            <layout:listOfSpeciesReferenceGlyphs>
+              <layout:speciesReferenceGlyph layout:id="layout_glyph_57" layout:role="substrate" layout:speciesGlyph="layout_glyph_7">
+                <layout:curve>
+                  <layout:listOfCurveSegments>
+                    <layout:curveSegment xsi:type="LineSegment">
+                      <layout:start layout:x="989.008465408363" layout:y="51.3087921837746"/>
+                      <layout:end layout:x="1027.01570042753" layout:y="49.6381444906243"/>
+                    </layout:curveSegment>
+                  </layout:listOfCurveSegments>
+                </layout:curve>
+              </layout:speciesReferenceGlyph>
+              <layout:speciesReferenceGlyph layout:id="layout_glyph_58" layout:role="product" layout:speciesGlyph="layout_glyph_11">
+                <layout:curve>
+                  <layout:listOfCurveSegments>
+                    <layout:curveSegment xsi:type="LineSegment">
+                      <layout:start layout:x="974.0229354467" layout:y="51.9674967974741"/>
+                      <layout:end layout:x="936.015700427532" layout:y="53.6381444906243"/>
+                    </layout:curveSegment>
+                  </layout:listOfCurveSegments>
+                </layout:curve>
+              </layout:speciesReferenceGlyph>
+            </layout:listOfSpeciesReferenceGlyphs>
+          </layout:reactionGlyph>
+          <layout:reactionGlyph layout:id="layout_glyph_59" layout:reaction="re15">
+            <layout:boundingBox>
+              <layout:position layout:x="0" layout:y="0"/>
+              <layout:dimensions layout:height="0" layout:width="0"/>
+            </layout:boundingBox>
+            <layout:curve>
+              <layout:listOfCurveSegments>
+                <layout:curveSegment xsi:type="LineSegment">
+                  <layout:start layout:x="770.483537573695" layout:y="314.652750152003"/>
+                  <layout:end layout:x="769.547863281368" layout:y="329.623538829246"/>
+                </layout:curveSegment>
+              </layout:listOfCurveSegments>
+            </layout:curve>
+            <layout:listOfSpeciesReferenceGlyphs>
+              <layout:speciesReferenceGlyph layout:id="layout_glyph_60" layout:role="substrate" layout:speciesGlyph="layout_glyph_1">
+                <layout:curve>
+                  <layout:listOfCurveSegments>
+                    <layout:curveSegment xsi:type="LineSegment">
+                      <layout:start layout:x="770.483537573695" layout:y="314.652750152003"/>
+                      <layout:end layout:x="772.015700427532" layout:y="290.138144490624"/>
+                    </layout:curveSegment>
+                  </layout:listOfCurveSegments>
+                </layout:curve>
+              </layout:speciesReferenceGlyph>
+              <layout:speciesReferenceGlyph layout:id="layout_glyph_61" layout:role="product" layout:speciesGlyph="layout_glyph_10">
+                <layout:curve>
+                  <layout:listOfCurveSegments>
+                    <layout:curveSegment xsi:type="LineSegment">
+                      <layout:start layout:x="769.547863281368" layout:y="329.623538829246"/>
+                      <layout:end layout:x="768.015700427532" layout:y="354.138144490624"/>
+                    </layout:curveSegment>
+                  </layout:listOfCurveSegments>
+                </layout:curve>
+              </layout:speciesReferenceGlyph>
+            </layout:listOfSpeciesReferenceGlyphs>
+          </layout:reactionGlyph>
+          <layout:reactionGlyph layout:id="layout_glyph_62" layout:reaction="re16">
+            <layout:boundingBox>
+              <layout:position layout:x="0" layout:y="0"/>
+              <layout:dimensions layout:height="0" layout:width="0"/>
+            </layout:boundingBox>
+            <layout:curve>
+              <layout:listOfCurveSegments>
+                <layout:curveSegment xsi:type="LineSegment">
+                  <layout:start layout:x="767.015700427532" layout:y="107.638144490624"/>
+                  <layout:end layout:x="767.015700427532" layout:y="92.6381444906243"/>
+                </layout:curveSegment>
+              </layout:listOfCurveSegments>
+            </layout:curve>
+            <layout:listOfSpeciesReferenceGlyphs>
+              <layout:speciesReferenceGlyph layout:id="layout_glyph_63" layout:role="substrate" layout:speciesGlyph="layout_glyph_0">
+                <layout:curve>
+                  <layout:listOfCurveSegments>
+                    <layout:curveSegment xsi:type="LineSegment">
+                      <layout:start layout:x="767.015700427532" layout:y="107.638144490624"/>
+                      <layout:end layout:x="767.015700427532" layout:y="125.138144490624"/>
+                    </layout:curveSegment>
+                  </layout:listOfCurveSegments>
+                </layout:curve>
+              </layout:speciesReferenceGlyph>
+              <layout:speciesReferenceGlyph layout:id="layout_glyph_64" layout:role="product" layout:speciesGlyph="layout_glyph_11">
+                <layout:curve>
+                  <layout:listOfCurveSegments>
+                    <layout:curveSegment xsi:type="LineSegment">
+                      <layout:start layout:x="767.015700427532" layout:y="92.6381444906243"/>
+                      <layout:end layout:x="767.015700427532" layout:y="75.1381444906243"/>
+                    </layout:curveSegment>
+                  </layout:listOfCurveSegments>
+                </layout:curve>
+              </layout:speciesReferenceGlyph>
+            </layout:listOfSpeciesReferenceGlyphs>
+          </layout:reactionGlyph>
+          <layout:reactionGlyph layout:id="layout_glyph_65" layout:reaction="re17">
+            <layout:boundingBox>
+              <layout:position layout:x="0" layout:y="0"/>
+              <layout:dimensions layout:height="0" layout:width="0"/>
+            </layout:boundingBox>
+            <layout:curve>
+              <layout:listOfCurveSegments>
+                <layout:curveSegment xsi:type="LineSegment">
+                  <layout:start layout:x="292.982546697887" layout:y="261.933725031157"/>
+                  <layout:end layout:x="278.048854157176" layout:y="263.342563950092"/>
+                </layout:curveSegment>
+              </layout:listOfCurveSegments>
+            </layout:curve>
+            <layout:listOfSpeciesReferenceGlyphs>
+              <layout:speciesReferenceGlyph layout:id="layout_glyph_66" layout:role="substrate" layout:speciesGlyph="layout_glyph_3">
+                <layout:curve>
+                  <layout:listOfCurveSegments>
+                    <layout:curveSegment xsi:type="LineSegment">
+                      <layout:start layout:x="292.982546697887" layout:y="261.933725031157"/>
+                      <layout:end layout:x="312.015700427532" layout:y="260.138144490624"/>
+                    </layout:curveSegment>
+                  </layout:listOfCurveSegments>
+                </layout:curve>
+              </layout:speciesReferenceGlyph>
+              <layout:speciesReferenceGlyph layout:id="layout_glyph_67" layout:role="product" layout:speciesGlyph="layout_glyph_12">
+                <layout:curve>
+                  <layout:listOfCurveSegments>
+                    <layout:curveSegment xsi:type="LineSegment">
+                      <layout:start layout:x="278.048854157176" layout:y="263.342563950092"/>
+                      <layout:end layout:x="259.015700427532" layout:y="265.138144490624"/>
+                    </layout:curveSegment>
+                  </layout:listOfCurveSegments>
+                </layout:curve>
+              </layout:speciesReferenceGlyph>
+            </layout:listOfSpeciesReferenceGlyphs>
+          </layout:reactionGlyph>
+          <layout:reactionGlyph layout:id="layout_glyph_68" layout:reaction="re18">
+            <layout:boundingBox>
+              <layout:position layout:x="0" layout:y="0"/>
+              <layout:dimensions layout:height="0" layout:width="0"/>
+            </layout:boundingBox>
+            <layout:curve>
+              <layout:listOfCurveSegments>
+                <layout:curveSegment xsi:type="LineSegment">
+                  <layout:start layout:x="990.094616945671" layout:y="104.739235637395"/>
+                  <layout:end layout:x="976.936783909392" layout:y="97.5370533438533"/>
+                </layout:curveSegment>
+              </layout:listOfCurveSegments>
+            </layout:curve>
+            <layout:listOfSpeciesReferenceGlyphs>
+              <layout:speciesReferenceGlyph layout:id="layout_glyph_69" layout:role="substrate" layout:speciesGlyph="layout_glyph_5">
+                <layout:curve>
+                  <layout:listOfCurveSegments>
+                    <layout:curveSegment xsi:type="LineSegment">
+                      <layout:start layout:x="990.094616945671" layout:y="104.739235637395"/>
+                      <layout:end layout:x="1031.01570042753" layout:y="127.138144490624"/>
+                    </layout:curveSegment>
+                  </layout:listOfCurveSegments>
+                </layout:curve>
+              </layout:speciesReferenceGlyph>
+              <layout:speciesReferenceGlyph layout:id="layout_glyph_70" layout:role="product" layout:speciesGlyph="layout_glyph_11">
+                <layout:curve>
+                  <layout:listOfCurveSegments>
+                    <layout:curveSegment xsi:type="LineSegment">
+                      <layout:start layout:x="976.936783909392" layout:y="97.5370533438533"/>
+                      <layout:end layout:x="936.015700427532" layout:y="75.1381444906243"/>
+                    </layout:curveSegment>
+                  </layout:listOfCurveSegments>
+                </layout:curve>
+              </layout:speciesReferenceGlyph>
+            </layout:listOfSpeciesReferenceGlyphs>
+          </layout:reactionGlyph>
+        </layout:listOfReactionGlyphs>
+        <layout:listOfTextGlyphs>
+          <layout:textGlyph layout:graphicalObject="layout_glyph_0" layout:id="layout_glyph_71" layout:text="infected-nontested">
+            <layout:boundingBox>
+              <layout:position layout:x="611.015700427532" layout:y="125.138144490624"/>
+              <layout:dimensions layout:height="55" layout:width="312"/>
+            </layout:boundingBox>
+          </layout:textGlyph>
+          <layout:textGlyph layout:graphicalObject="layout_glyph_1" layout:id="layout_glyph_72" layout:text="infected-tested">
+            <layout:boundingBox>
+              <layout:position layout:x="634.015700427532" layout:y="235.138144490624"/>
+              <layout:dimensions layout:height="55" layout:width="276"/>
+            </layout:boundingBox>
+          </layout:textGlyph>
+          <layout:textGlyph layout:graphicalObject="layout_glyph_2" layout:id="layout_glyph_73" layout:text="innocent-nontested">
+            <layout:boundingBox>
+              <layout:position layout:x="269.015700427532" layout:y="126.138144490624"/>
+              <layout:dimensions layout:height="52" layout:width="281"/>
+            </layout:boundingBox>
+          </layout:textGlyph>
+          <layout:textGlyph layout:graphicalObject="layout_glyph_3" layout:id="layout_glyph_74" layout:text="inocent-tested">
+            <layout:boundingBox>
+              <layout:position layout:x="312.015700427532" layout:y="234.138144490624"/>
+              <layout:dimensions layout:height="52" layout:width="231"/>
+            </layout:boundingBox>
+          </layout:textGlyph>
+          <layout:textGlyph layout:graphicalObject="layout_glyph_4" layout:id="layout_glyph_75" layout:text="symptoms-tested">
+            <layout:boundingBox>
+              <layout:position layout:x="1041.01570042753" layout:y="237.138144490624"/>
+              <layout:dimensions layout:height="53" layout:width="309"/>
+            </layout:boundingBox>
+          </layout:textGlyph>
+          <layout:textGlyph layout:graphicalObject="layout_glyph_5" layout:id="layout_glyph_76" layout:text="symptoms-nontested">
+            <layout:boundingBox>
+              <layout:position layout:x="1031.01570042753" layout:y="127.138144490624"/>
+              <layout:dimensions layout:height="53" layout:width="319"/>
+            </layout:boundingBox>
+          </layout:textGlyph>
+          <layout:textGlyph layout:graphicalObject="layout_glyph_6" layout:id="layout_glyph_77" layout:text="recovered-tested">
+            <layout:boundingBox>
+              <layout:position layout:x="1049.01570042753" layout:y="349.138144490624"/>
+              <layout:dimensions layout:height="44" layout:width="299"/>
+            </layout:boundingBox>
+          </layout:textGlyph>
+          <layout:textGlyph layout:graphicalObject="layout_glyph_7" layout:id="layout_glyph_78" layout:text="recovered-nontested">
+            <layout:boundingBox>
+              <layout:position layout:x="1027.01570042753" layout:y="25.1381444906243"/>
+              <layout:dimensions layout:height="49" layout:width="317"/>
+            </layout:boundingBox>
+          </layout:textGlyph>
+          <layout:textGlyph layout:graphicalObject="layout_glyph_8" layout:id="layout_glyph_79" layout:text="S">
+            <layout:boundingBox>
+              <layout:position layout:x="59.0157004275316" layout:y="132.138144490624"/>
+              <layout:dimensions layout:height="45" layout:width="59"/>
+            </layout:boundingBox>
+          </layout:textGlyph>
+          <layout:textGlyph layout:graphicalObject="layout_glyph_9" layout:id="layout_glyph_80" layout:text="contagious coefficient (computed)">
+            <layout:boundingBox>
+              <layout:position layout:x="27.0157004275316" layout:y="343.138144490624"/>
+              <layout:dimensions layout:height="55" layout:width="492"/>
+            </layout:boundingBox>
+          </layout:textGlyph>
+          <layout:textGlyph layout:graphicalObject="layout_glyph_10" layout:id="layout_glyph_81" layout:text="Corona-dead-tested">
+            <layout:boundingBox>
+              <layout:position layout:x="607.015700427532" layout:y="354.138144490624"/>
+              <layout:dimensions layout:height="47" layout:width="322"/>
+            </layout:boundingBox>
+          </layout:textGlyph>
+          <layout:textGlyph layout:graphicalObject="layout_glyph_11" layout:id="layout_glyph_82" layout:text="Corona-dead-nontested">
+            <layout:boundingBox>
+              <layout:position layout:x="598.015700427532" layout:y="32.1381444906243"/>
+              <layout:dimensions layout:height="43" layout:width="338"/>
+            </layout:boundingBox>
+          </layout:textGlyph>
+          <layout:textGlyph layout:graphicalObject="layout_glyph_12" layout:id="layout_glyph_83" layout:text="innocent-dead">
+            <layout:boundingBox>
+              <layout:position layout:x="29.0157004275316" layout:y="240.138144490624"/>
+              <layout:dimensions layout:height="50" layout:width="230"/>
+            </layout:boundingBox>
+          </layout:textGlyph>
+          <layout:textGlyph layout:graphicalObject="layout_glyph_13" layout:id="layout_glyph_84" layout:text="total population">
+            <layout:boundingBox>
+              <layout:position layout:x="70.0157004275316" layout:y="66.1381444906243"/>
+              <layout:dimensions layout:height="39" layout:width="244"/>
+            </layout:boundingBox>
+          </layout:textGlyph>
+        </layout:listOfTextGlyphs>
+      </layout:layout>
+    </layout:listOfLayouts>
+    <listOfFunctionDefinitions>
+      <functionDefinition id="population_growth" metaid="COPASI66" name="population growth">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI66">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2020-03-19T14:05:09Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">        
+          <lambda>
+            <bvar>
+              <ci> S </ci>
+            </bvar>
+            <bvar>
+              <ci> T </ci>
+            </bvar>
+            <bvar>
+              <ci> k </ci>
+            </bvar>
+            <apply>
+              <times/>
+              <ci> S </ci>
+              <ci> T </ci>
+              <ci> k </ci>
+            </apply>
+          </lambda>
+        </math>
+            </functionDefinition>
+    </listOfFunctionDefinitions>
+    <listOfUnitDefinitions>
+      <unitDefinition id="length" name="length">
+        <listOfUnits>
+          <unit exponent="1" kind="metre" multiplier="1" scale="0"/>
+        </listOfUnits>
+      </unitDefinition>
+      <unitDefinition id="area" name="area">
+        <listOfUnits>
+          <unit exponent="2" kind="metre" multiplier="1" scale="0"/>
+        </listOfUnits>
+      </unitDefinition>
+      <unitDefinition id="volume" name="volume">
+        <listOfUnits>
+          <unit exponent="1" kind="litre" multiplier="1" scale="-3"/>
+        </listOfUnits>
+      </unitDefinition>
+      <unitDefinition id="time" name="time">
+        <listOfUnits>
+          <unit exponent="1" kind="second" multiplier="86400" scale="0"/>
+        </listOfUnits>
+      </unitDefinition>
+      <unitDefinition id="substance" name="substance">
+        <listOfUnits>
+          <unit exponent="1" kind="item" multiplier="1" scale="0"/>
+        </listOfUnits>
+      </unitDefinition>
+      <unitDefinition id="unit_0" name="d">
+        <listOfUnits>
+          <unit exponent="1" kind="second" multiplier="86400" scale="0"/>
+        </listOfUnits>
+      </unitDefinition>
+      <unitDefinition id="unit_1" name="1">
+        <listOfUnits>
+          <unit exponent="0" kind="dimensionless" multiplier="1" scale="0"/>
+        </listOfUnits>
+      </unitDefinition>
+    </listOfUnitDefinitions>
+    <listOfCompartments>
+      <compartment constant="true" id="default" metaid="COPASI1" name="default" size="1" spatialDimensions="3" units="volume">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI1">
+	<bqbiol:is>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/ncit/C48156"/>
+	</rdf:Bag>
+	</bqbiol:is>
+	</rdf:Description>
+	
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI1">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2020-11-06T09:45:17Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:is rdf:resource="urn:miriam:ncit:C48156"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+            </compartment>
+    </listOfCompartments>
+    <listOfSpecies>
+      <species boundaryCondition="false" compartment="default" constant="false" hasOnlySubstanceUnits="false" id="infected_nontested_0" initialConcentration="2" metaid="COPASI2" name="infected_nontested" substanceUnits="substance">
+        <annotation>
+          <celldesigner:extension xmlns:celldesigner="http://www.sbml.org/2001/ns/celldesigner">
+            <celldesigner:positionToCompartment>inside</celldesigner:positionToCompartment>
+            <celldesigner:speciesIdentity>
+              <celldesigner:class>PHENOTYPE</celldesigner:class>
+              <celldesigner:name>infected-nontested</celldesigner:name>
+            </celldesigner:speciesIdentity>
+          </celldesigner:extension>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI2">
+              <bqbiol:is>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/ido/0000511"/>
+	</rdf:Bag>
+	</bqbiol:is>
+	<bqbiol:is>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/ncit/C171133"/>
+	</rdf:Bag>
+	</bqbiol:is>
+	
+	<bqbiol:hasProperty>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/ncit/C101887"/>
+	</rdf:Bag>
+	</bqbiol:hasProperty>
+	</rdf:Description>
+	
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI2">
+                <bqbiol:hasProperty rdf:resource="urn:miriam:ncit:C101887"/>
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2020-03-19T13:59:56Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:is rdf:resource="urn:miriam:ido:0000511"/>
+                <CopasiMT:is rdf:resource="urn:miriam:ncit:C171133"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+            </species>
+      <species boundaryCondition="false" compartment="default" constant="false" hasOnlySubstanceUnits="false" id="infected_tested_0" initialConcentration="1" metaid="COPASI3" name="infected_tested" substanceUnits="substance">
+        <annotation>
+          <celldesigner:extension xmlns:celldesigner="http://www.sbml.org/2001/ns/celldesigner">
+            <celldesigner:positionToCompartment>inside</celldesigner:positionToCompartment>
+            <celldesigner:speciesIdentity>
+              <celldesigner:class>PHENOTYPE</celldesigner:class>
+              <celldesigner:name>infected-tested</celldesigner:name>
+            </celldesigner:speciesIdentity>
+          </celldesigner:extension>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI3">
+              <bqbiol:is>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/ido/0000511"/>
+	</rdf:Bag>
+	</bqbiol:is>
+	<bqbiol:is>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/ncit/C171133"/>
+	</rdf:Bag>
+	</bqbiol:is>
+	
+	<bqbiol:hasProperty>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/ncit/C47891"/>
+	</rdf:Bag>
+	</bqbiol:hasProperty>
+	</rdf:Description>
+	
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI3">
+                <bqbiol:hasProperty rdf:resource="urn:miriam:ncit:C47891"/>
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2020-03-19T14:00:03Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:is rdf:resource="urn:miriam:ido:0000511"/>
+                <CopasiMT:is rdf:resource="urn:miriam:ncit:C171133"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+            </species>
+      <species boundaryCondition="false" compartment="default" constant="false" hasOnlySubstanceUnits="false" id="uninfected_nontested_0" initialConcentration="630000" metaid="COPASI4" name="uninfected_nontested" substanceUnits="substance">
+        <annotation>
+          <celldesigner:extension xmlns:celldesigner="http://www.sbml.org/2001/ns/celldesigner">
+            <celldesigner:positionToCompartment>inside</celldesigner:positionToCompartment>
+            <celldesigner:speciesIdentity>
+              <celldesigner:class>PHENOTYPE</celldesigner:class>
+              <celldesigner:name>innocent-nontested</celldesigner:name>
+            </celldesigner:speciesIdentity>
+          </celldesigner:extension>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI4">
+              <bqbiol:is>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/efo/0001460"/>
+	</rdf:Bag>
+	</bqbiol:is>
+	
+	<bqbiol:hasProperty>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/ncit/C101887"/>
+	</rdf:Bag>
+	</bqbiol:hasProperty>
+	</rdf:Description>
+	
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI4">
+                <bqbiol:hasProperty rdf:resource="urn:miriam:ncit:C101887"/>
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2020-03-19T14:00:12Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:is rdf:resource="urn:miriam:efo:0001460"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+            </species>
+      <species boundaryCondition="false" compartment="default" constant="false" hasOnlySubstanceUnits="false" id="uninfected_tested_0" initialConcentration="0" metaid="COPASI5" name="uninfected_tested" substanceUnits="substance">
+        <annotation>
+          <celldesigner:extension xmlns:celldesigner="http://www.sbml.org/2001/ns/celldesigner">
+            <celldesigner:positionToCompartment>inside</celldesigner:positionToCompartment>
+            <celldesigner:speciesIdentity>
+              <celldesigner:class>PHENOTYPE</celldesigner:class>
+              <celldesigner:name>inocent-tested</celldesigner:name>
+            </celldesigner:speciesIdentity>
+          </celldesigner:extension>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI5">
+              <bqbiol:is>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/efo/0001460"/>
+	</rdf:Bag>
+	</bqbiol:is>
+	
+	<bqbiol:hasProperty>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/ncit/C47891"/>
+	</rdf:Bag>
+	</bqbiol:hasProperty>
+	</rdf:Description>
+	
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI5">
+                <bqbiol:hasProperty rdf:resource="urn:miriam:ncit:C47891"/>
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2020-03-19T14:00:17Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:is rdf:resource="urn:miriam:efo:0001460"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+            </species>
+      <species boundaryCondition="false" compartment="default" constant="false" hasOnlySubstanceUnits="false" id="symptoms_tested_0" initialConcentration="0" metaid="COPASI6" name="symptoms_tested" substanceUnits="substance">
+        <annotation>
+          <celldesigner:extension xmlns:celldesigner="http://www.sbml.org/2001/ns/celldesigner">
+            <celldesigner:positionToCompartment>inside</celldesigner:positionToCompartment>
+            <celldesigner:speciesIdentity>
+              <celldesigner:class>PHENOTYPE</celldesigner:class>
+              <celldesigner:name>symptoms-tested</celldesigner:name>
+            </celldesigner:speciesIdentity>
+          </celldesigner:extension>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI6">
+              <bqbiol:is>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/ido/0000511"/>
+	</rdf:Bag>
+	</bqbiol:is>
+	<bqbiol:is>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/ncit/C171133"/>
+	</rdf:Bag>
+	</bqbiol:is>
+	<bqbiol:hasProperty>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/ncit/C47891"/>
+	</rdf:Bag>
+	</bqbiol:hasProperty>
+	
+	<bqbiol:hasProperty>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/ncit/C173069"/>
+	</rdf:Bag>
+	</bqbiol:hasProperty>
+	</rdf:Description>
+	
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI6">
+                <bqbiol:hasProperty rdf:resource="urn:miriam:ncit:C173069"/>
+                <bqbiol:hasProperty rdf:resource="urn:miriam:ncit:C47891"/>
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2020-03-19T14:01:48Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:is rdf:resource="urn:miriam:ido:0000511"/>
+                <CopasiMT:is rdf:resource="urn:miriam:ncit:C171133"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+            </species>
+      <species boundaryCondition="false" compartment="default" constant="false" hasOnlySubstanceUnits="false" id="symptoms_nontested_0" initialConcentration="0" metaid="COPASI7" name="symptoms_nontested" substanceUnits="substance">
+        <annotation>
+          <celldesigner:extension xmlns:celldesigner="http://www.sbml.org/2001/ns/celldesigner">
+            <celldesigner:positionToCompartment>inside</celldesigner:positionToCompartment>
+            <celldesigner:speciesIdentity>
+              <celldesigner:class>PHENOTYPE</celldesigner:class>
+              <celldesigner:name>symptoms-nontested</celldesigner:name>
+            </celldesigner:speciesIdentity>
+          </celldesigner:extension>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI7">
+              <bqbiol:is>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/ido/0000511"/>
+	</rdf:Bag>
+	</bqbiol:is>
+	<bqbiol:is>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/ncit/C171133"/>
+	</rdf:Bag>
+	</bqbiol:is>
+	<bqbiol:hasProperty>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/ncit/C101887"/>
+	</rdf:Bag>
+	</bqbiol:hasProperty>
+	
+	<bqbiol:hasProperty>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/ncit/C173069"/>
+	</rdf:Bag>
+	</bqbiol:hasProperty>
+	</rdf:Description>
+	
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI7">
+                <bqbiol:hasProperty rdf:resource="urn:miriam:ncit:C101887"/>
+                <bqbiol:hasProperty rdf:resource="urn:miriam:ncit:C173069"/>
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2020-03-19T14:01:44Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:is rdf:resource="urn:miriam:ido:0000511"/>
+                <CopasiMT:is rdf:resource="urn:miriam:ido:C171133"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+            </species>
+      <species boundaryCondition="false" compartment="default" constant="false" hasOnlySubstanceUnits="false" id="recovered_tested_0" initialConcentration="0" metaid="COPASI8" name="recovered_tested" substanceUnits="substance">
+        <annotation>
+          <celldesigner:extension xmlns:celldesigner="http://www.sbml.org/2001/ns/celldesigner">
+            <celldesigner:positionToCompartment>inside</celldesigner:positionToCompartment>
+            <celldesigner:speciesIdentity>
+              <celldesigner:class>PHENOTYPE</celldesigner:class>
+              <celldesigner:name>recovered-tested</celldesigner:name>
+            </celldesigner:speciesIdentity>
+          </celldesigner:extension>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI8">
+              <bqbiol:hasProperty>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/ido/0000621"/>
+	</rdf:Bag>
+	</bqbiol:hasProperty>
+	
+	<bqbiol:hasProperty>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/ncit/C47891"/>
+	</rdf:Bag>
+	</bqbiol:hasProperty>
+	</rdf:Description>
+	
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI8">
+                <bqbiol:hasProperty rdf:resource="urn:miriam:ido:0000621"/>
+                <bqbiol:hasProperty rdf:resource="urn:miriam:ncit:C47891"/>
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2020-03-19T15:00:24Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+            </species>
+      <species boundaryCondition="false" compartment="default" constant="false" hasOnlySubstanceUnits="false" id="recovered_nontested_0" initialConcentration="0" metaid="COPASI9" name="recovered_nontested" substanceUnits="substance">
+        <annotation>
+          <celldesigner:extension xmlns:celldesigner="http://www.sbml.org/2001/ns/celldesigner">
+            <celldesigner:positionToCompartment>inside</celldesigner:positionToCompartment>
+            <celldesigner:speciesIdentity>
+              <celldesigner:class>PHENOTYPE</celldesigner:class>
+              <celldesigner:name>recovered-nontested</celldesigner:name>
+            </celldesigner:speciesIdentity>
+          </celldesigner:extension>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI9">
+              <bqbiol:hasProperty>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/ncit/C101887"/>
+	</rdf:Bag>
+	</bqbiol:hasProperty>
+	
+	<bqbiol:hasProperty>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/ncit/C101887"/>
+	</rdf:Bag>
+	</bqbiol:hasProperty>
+	</rdf:Description>
+	
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI9">
+                <bqbiol:hasProperty rdf:resource="urn:miriam:ido:C101887"/>
+                <bqbiol:hasProperty rdf:resource="urn:miriam:ncit:C101887"/>
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2020-03-19T14:19:22Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+            </species>
+      <species boundaryCondition="true" compartment="default" constant="true" hasOnlySubstanceUnits="false" id="susceptible_0" initialConcentration="1" metaid="COPASI10" name="susceptible" substanceUnits="substance">
+        <annotation>
+          <celldesigner:extension xmlns:celldesigner="http://www.sbml.org/2001/ns/celldesigner">
+            <celldesigner:positionToCompartment>inside</celldesigner:positionToCompartment>
+            <celldesigner:speciesIdentity>
+              <celldesigner:class>PROTEIN</celldesigner:class>
+              <celldesigner:proteinReference>pr1</celldesigner:proteinReference>
+            </celldesigner:speciesIdentity>
+          </celldesigner:extension>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI10">
+	<bqbiol:is>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/ido/0000514"/>
+	</rdf:Bag>
+	</bqbiol:is>
+	</rdf:Description>
+	
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI10">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2020-03-19T14:01:13Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:is rdf:resource="urn:miriam:ido:0000514"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+            </species>
+      <species boundaryCondition="false" compartment="default" constant="false" hasOnlySubstanceUnits="false" id="dead_corona_tested_0" initialConcentration="0" metaid="COPASI11" name="dead_corona_tested" substanceUnits="substance">
+        <annotation>
+          <celldesigner:extension xmlns:celldesigner="http://www.sbml.org/2001/ns/celldesigner">
+            <celldesigner:positionToCompartment>inside</celldesigner:positionToCompartment>
+            <celldesigner:speciesIdentity>
+              <celldesigner:class>PHENOTYPE</celldesigner:class>
+              <celldesigner:name>Corona-dead-tested</celldesigner:name>
+            </celldesigner:speciesIdentity>
+          </celldesigner:extension>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI11">
+              <bqbiol:is>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/ncit/C171133"/>
+	</rdf:Bag>
+	</bqbiol:is>
+	<bqbiol:is>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/ncit/C28554"/>
+	</rdf:Bag>
+	</bqbiol:is>
+	
+	<bqbiol:hasProperty>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/ncit/C47891"/>
+	</rdf:Bag>
+	</bqbiol:hasProperty>
+	</rdf:Description>
+	
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI11">
+                <bqbiol:hasProperty rdf:resource="urn:miriam:ncit:C47891"/>
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2020-03-19T13:59:51Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:is rdf:resource="urn:miriam:ncit:C171133"/>
+                <CopasiMT:is rdf:resource="urn:miriam:ncit:C28554"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+            </species>
+      <species boundaryCondition="false" compartment="default" constant="false" hasOnlySubstanceUnits="false" id="dead_corona_nontested_0" initialConcentration="0" metaid="COPASI12" name="dead_corona_nontested" substanceUnits="substance">
+        <annotation>
+          <celldesigner:extension xmlns:celldesigner="http://www.sbml.org/2001/ns/celldesigner">
+            <celldesigner:positionToCompartment>inside</celldesigner:positionToCompartment>
+            <celldesigner:speciesIdentity>
+              <celldesigner:class>PHENOTYPE</celldesigner:class>
+              <celldesigner:name>Corona-dead-nontested</celldesigner:name>
+            </celldesigner:speciesIdentity>
+          </celldesigner:extension>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI12">
+              <bqbiol:is>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/ncit/C171133"/>
+	</rdf:Bag>
+	</bqbiol:is>
+	<bqbiol:is>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/ncit/C28554"/>
+	</rdf:Bag>
+	</bqbiol:is>
+	
+	<bqbiol:hasProperty>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/ncit/C101887"/>
+	</rdf:Bag>
+	</bqbiol:hasProperty>
+	</rdf:Description>
+	
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI12">
+                <bqbiol:hasProperty rdf:resource="urn:miriam:ncit:C101887"/>
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2020-03-19T13:59:45Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:is rdf:resource="urn:miriam:ncit:C171133"/>
+                <CopasiMT:is rdf:resource="urn:miriam:ncit:C28554"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+            </species>
+      <species boundaryCondition="false" compartment="default" constant="false" hasOnlySubstanceUnits="false" id="dead_noncorona_0" initialConcentration="0" metaid="COPASI13" name="dead_noncorona" substanceUnits="substance">
+        <annotation>
+          <celldesigner:extension xmlns:celldesigner="http://www.sbml.org/2001/ns/celldesigner">
+            <celldesigner:positionToCompartment>inside</celldesigner:positionToCompartment>
+            <celldesigner:speciesIdentity>
+              <celldesigner:class>PHENOTYPE</celldesigner:class>
+              <celldesigner:name>innocent-dead</celldesigner:name>
+            </celldesigner:speciesIdentity>
+          </celldesigner:extension>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI13">
+	<bqbiol:is>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/ncit/C28554"/>
+	</rdf:Bag>
+	</bqbiol:is>
+	</rdf:Description>
+	
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI13">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2020-03-19T14:00:06Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:is rdf:resource="urn:miriam:ncit:C28554"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+            </species>
+      <species boundaryCondition="true" compartment="default" constant="false" hasOnlySubstanceUnits="false" id="total_population_0" initialConcentration="630003" metaid="COPASI14" name="total_population" substanceUnits="substance">
+        <annotation>
+          <celldesigner:extension xmlns:celldesigner="http://www.sbml.org/2001/ns/celldesigner">
+            <celldesigner:positionToCompartment>inside</celldesigner:positionToCompartment>
+            <celldesigner:speciesIdentity>
+              <celldesigner:class>PHENOTYPE</celldesigner:class>
+              <celldesigner:name>total population</celldesigner:name>
+            </celldesigner:speciesIdentity>
+            <celldesigner:listOfCatalyzedReactions>
+              <celldesigner:catalyzed reaction="re11"/>
+            </celldesigner:listOfCatalyzedReactions>
+          </celldesigner:extension>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI14">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2020-03-19T14:01:52Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+            </species>
+      <species boundaryCondition="true" compartment="default" constant="false" hasOnlySubstanceUnits="false" id="registered_corona_0" initialConcentration="1" metaid="COPASI15" name="registered_corona" substanceUnits="substance">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI15">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2020-03-19T22:32:31Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+            </species>
+      <species boundaryCondition="true" compartment="default" constant="false" hasOnlySubstanceUnits="false" id="dead_corona_perc_0" initialConcentration="0" metaid="COPASI16" name="dead_corona_perc" substanceUnits="substance">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI16">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2020-03-21T16:04:05Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+            </species>
+      <species boundaryCondition="true" compartment="default" constant="false" hasOnlySubstanceUnits="false" id="recovered_corona_perc_0" initialConcentration="0" metaid="COPASI17" name="recovered_corona_perc" substanceUnits="substance">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI17">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2020-03-21T19:49:34Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+            </species>
+      <species boundaryCondition="true" compartment="default" constant="false" hasOnlySubstanceUnits="false" id="dead_noncorona_perc_0" initialConcentration="0" metaid="COPASI18" name="dead_noncorona_perc" substanceUnits="substance">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI18">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2020-03-22T16:14:49Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+            </species>
+      <species boundaryCondition="true" compartment="default" constant="false" hasOnlySubstanceUnits="false" id="frac_coronaDeadOfAllDead_0" metaid="COPASI19" name="frac_coronaDeadOfAllDead" substanceUnits="substance">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI19">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2020-03-22T16:18:29Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+            </species>
+      <species boundaryCondition="true" compartment="default" constant="false" hasOnlySubstanceUnits="false" id="epidemic_extinguished_bool_0" initialConcentration="0" metaid="COPASI20" name="epidemic_extinguished_bool" substanceUnits="substance">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI20">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2020-03-22T17:09:11Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+            </species>
+      <species boundaryCondition="true" compartment="default" constant="false" hasOnlySubstanceUnits="false" id="infected_tested_div10" initialConcentration="0.1" metaid="COPASI21" name="infected_tested_div10" substanceUnits="substance">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI21">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2021-01-18T12:33:03Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+            </species>
+    </listOfSpecies>
+    <listOfParameters>
+      <parameter constant="true" id="Testing_Randome" metaid="COPASI22" name="test_random" value="0.0008">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI22">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2020-03-19T15:04:45Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+            </parameter>
+      <parameter constant="false" id="Total_Infection_coefficient" metaid="COPASI23" name="infection_rate" value="1.94688610435758E-6">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI23">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2020-03-19T19:24:09Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+            </parameter>
+      <parameter constant="true" id="Normal_death_rate_constant_0" metaid="COPASI24" name="death_rate_natural" value="3.29E-5">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI24">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2020-03-19T19:24:49Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+            </parameter>
+      <parameter constant="true" id="Corona_death_rate_constant" metaid="COPASI25" name="death_rate_corona" value="0.002">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI25">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2020-03-19T19:26:22Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+            </parameter>
+      <parameter constant="true" id="Birth_rate" metaid="COPASI26" name="birth_rate" value="3.29E-5">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI26">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2020-03-19T19:26:46Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+            </parameter>
+      <parameter constant="true" id="Testing_for_Symptoms" metaid="COPASI27" name="test_symptoms" value="500">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI27">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2020-03-19T19:50:28Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+            </parameter>
+      <parameter constant="true" id="Corona_recover" metaid="COPASI28" name="recovery_rate" value="0.067">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI28">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2020-03-19T20:55:36Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+            </parameter>
+      <parameter constant="true" id="Symptoms_appear" metaid="COPASI29" name="symptoms_rate" value="0.30165">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI29">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2020-03-19T21:37:54Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+            </parameter>
+      <parameter constant="true" id="Infection_from_non_tested_no_symptoms_0" metaid="COPASI30" name="iota_ntns" value="0.508">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <pre>Infection_from_non-tested_no-symptoms</pre>
+          </body>
+        </notes>
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI30">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2020-03-19T22:07:46Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+            </parameter>
+      <parameter constant="true" id="Infection_from_non_tested_symptoms" metaid="COPASI31" name="iota_nts" value="0.25">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <pre>Infection_from_non-tested_symptoms</pre>
+          </body>
+        </notes>
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI31">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2020-03-19T22:08:21Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+            </parameter>
+      <parameter constant="true" id="Infection_from_tested_no_symptoms_0" metaid="COPASI32" name="iota_tns" value="0.025">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <pre>Infection_from_tested_no-symptoms</pre>
+          </body>
+        </notes>
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI32">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2020-03-19T22:08:41Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+            </parameter>
+      <parameter constant="true" id="Infection_from_tested_symptoms" metaid="COPASI33" name="iota_ts" value="0.025">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <pre>Infection_from_tested_symptoms</pre>
+          </body>
+        </notes>
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI33">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2020-03-19T22:08:59Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+            </parameter>
+      <parameter constant="false" id="Social_Distance" metaid="COPASI34" name="social_distance" value="534700">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI34">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2020-03-19T22:17:57Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+            </parameter>
+      <parameter constant="false" id="Government_induced_isolation_factor_0" metaid="COPASI35" name="lockdown_severity" value="10">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI35">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2020-03-19T23:37:26Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+            </parameter>
+      <parameter constant="true" id="Time_government_action_0" metaid="COPASI36" name="t_government_action" value="15">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI36">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2020-03-20T12:39:32Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+            </parameter>
+      <parameter constant="true" id="lockdown_duration" metaid="COPASI37" name="t_lockdown" units="unit_0" value="7">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI37">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2020-03-21T11:26:07Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+            </parameter>
+      <parameter constant="true" id="lockdownPause_duration_0" metaid="COPASI38" name="t_lockdown_pause" units="unit_0" value="7">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI38">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2020-03-21T11:29:34Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+            </parameter>
+      <parameter constant="false" id="n_lockdowns" metaid="COPASI39" name="n_lockdowns" units="unit_1" value="0">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI39">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2020-03-21T11:39:06Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+            </parameter>
+      <parameter constant="true" id="n_pauses" metaid="COPASI40" name="n_pauses" units="unit_1" value="0">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI40">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2020-03-21T11:39:36Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+            </parameter>
+      <parameter constant="false" id="intermittent_time" metaid="COPASI41" name="t_intermittent" units="unit_0" value="0">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI41">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2020-03-21T14:50:50Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+            </parameter>
+      <parameter constant="true" id="timeFraction_lockdown_0" metaid="COPASI42" name="t_lockdown_effective" value="0.55">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI42">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2020-03-21T21:09:31Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+            </parameter>
+      <parameter constant="true" id="number_cutoff" metaid="COPASI43" name="number_cutoff" units="unit_1" value="0">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI43">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2020-03-22T14:25:52Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+            </parameter>
+      <parameter constant="true" id="symptomatic_numberTolerance_0" metaid="COPASI44" name="symptoms_tolerance" value="141">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI44">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2020-03-22T19:19:37Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+            </parameter>
+      <parameter constant="true" id="governmentResponseFactorToDiagnosedInfected_0" metaid="COPASI45" name="bool_adaptive_lockdown" value="0">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <pre>governmentResponseFactorToDiagnosedInfected in article</pre>
+          </body>
+        </notes>
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI45">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2020-03-22T20:34:41Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+            </parameter>
+      <parameter constant="true" id="social_distancing_factor" metaid="COPASI46" name="social_distancing_factor" value="10">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI46">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2020-11-06T09:48:16Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+            </parameter>
+      <parameter constant="true" id="Social_Distance_base" metaid="COPASI47" name="social_distance_base" value="534700">
+        <annotation>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI47">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2020-11-06T13:01:36Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+            </parameter>
+    </listOfParameters>
+    <listOfRules>
+      <assignmentRule variable="infected_tested_div10">
+        <math xmlns="http://www.w3.org/1998/Math/MathML">        
+          <apply>
+            <divide/>
+            <apply>
+              <times/>
+              <ci> infected_tested_0 </ci>
+              <ci> default </ci>
+            </apply>
+            <cn> 10 </cn>
+          </apply>
+        </math>
+            </assignmentRule>
+      <assignmentRule variable="total_population_0">
+        <math xmlns="http://www.w3.org/1998/Math/MathML">        
+          <apply>
+            <plus/>
+            <ci> infected_nontested_0 </ci>
+            <ci> infected_tested_0 </ci>
+            <ci> uninfected_nontested_0 </ci>
+            <ci> uninfected_tested_0 </ci>
+            <ci> recovered_nontested_0 </ci>
+            <ci> recovered_tested_0 </ci>
+            <ci> symptoms_nontested_0 </ci>
+            <ci> symptoms_tested_0 </ci>
+          </apply>
+        </math>
+            </assignmentRule>
+      <assignmentRule variable="recovered_corona_perc_0">
+        <math xmlns="http://www.w3.org/1998/Math/MathML">        
+          <apply>
+            <divide/>
+            <apply>
+              <times/>
+              <apply>
+                <plus/>
+                <ci> recovered_nontested_0 </ci>
+                <ci> recovered_tested_0 </ci>
+              </apply>
+              <cn> 100 </cn>
+            </apply>
+            <ci> total_population_0 </ci>
+          </apply>
+        </math>
+            </assignmentRule>
+      <assignmentRule variable="registered_corona_0">
+        <math xmlns="http://www.w3.org/1998/Math/MathML">        
+          <apply>
+            <plus/>
+            <ci> infected_tested_0 </ci>
+            <ci> symptoms_tested_0 </ci>
+            <ci> recovered_tested_0 </ci>
+            <ci> dead_corona_tested_0 </ci>
+          </apply>
+        </math>
+            </assignmentRule>
+      <assignmentRule variable="dead_corona_perc_0">
+        <math xmlns="http://www.w3.org/1998/Math/MathML">        
+          <apply>
+            <divide/>
+            <apply>
+              <times/>
+              <apply>
+                <plus/>
+                <ci> dead_corona_nontested_0 </ci>
+                <ci> dead_corona_tested_0 </ci>
+              </apply>
+              <cn> 100 </cn>
+            </apply>
+            <ci> total_population_0 </ci>
+          </apply>
+        </math>
+            </assignmentRule>
+      <assignmentRule variable="dead_noncorona_perc_0">
+        <math xmlns="http://www.w3.org/1998/Math/MathML">        
+          <apply>
+            <divide/>
+            <apply>
+              <times/>
+              <ci> dead_noncorona_0 </ci>
+              <cn> 100 </cn>
+            </apply>
+            <ci> total_population_0 </ci>
+          </apply>
+        </math>
+            </assignmentRule>
+      <assignmentRule variable="frac_coronaDeadOfAllDead_0">
+        <math xmlns="http://www.w3.org/1998/Math/MathML">        
+          <apply>
+            <divide/>
+            <apply>
+              <times/>
+              <cn type="integer"> 100 </cn>
+              <ci> dead_corona_perc_0 </ci>
+            </apply>
+            <apply>
+              <max/>
+              <cn type="e-notation">1 <sep/> -15 </cn>
+              <apply>
+                <plus/>
+                <ci> dead_corona_perc_0 </ci>
+                <ci> dead_noncorona_perc_0 </ci>
+              </apply>
+            </apply>
+          </apply>
+        </math>
+            </assignmentRule>
+      <assignmentRule variable="epidemic_extinguished_bool_0">
+        <math xmlns="http://www.w3.org/1998/Math/MathML">        
+          <piecewise>
+            <piece>
+              <cn> 1 </cn>
+              <apply>
+                <lt/>
+                <apply>
+                  <plus/>
+                  <ci> infected_nontested_0 </ci>
+                  <ci> infected_tested_0 </ci>
+                  <ci> symptoms_nontested_0 </ci>
+                  <ci> symptoms_tested_0 </ci>
+                </apply>
+                <ci> number_cutoff </ci>
+              </apply>
+            </piece>
+            <otherwise>
+              <cn> 0 </cn>
+            </otherwise>
+          </piecewise>
+        </math>
+            </assignmentRule>
+      <assignmentRule variable="n_lockdowns">
+        <math xmlns="http://www.w3.org/1998/Math/MathML">        
+          <apply>
+            <plus/>
+            <piecewise>
+              <piece>
+                <cn> 1 </cn>
+                <apply>
+                  <gt/>
+                  <apply>
+                    <minus/>
+                    <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/time"> time </csymbol>
+                    <ci> Time_government_action_0 </ci>
+                  </apply>
+                  <apply>
+                    <times/>
+                    <cn> 0 </cn>
+                    <ci> lockdown_duration </ci>
+                  </apply>
+                </apply>
+              </piece>
+              <otherwise>
+                <cn> 0 </cn>
+              </otherwise>
+            </piecewise>
+            <piecewise>
+              <piece>
+                <cn> 1 </cn>
+                <apply>
+                  <gt/>
+                  <apply>
+                    <minus/>
+                    <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/time"> time </csymbol>
+                    <ci> Time_government_action_0 </ci>
+                  </apply>
+                  <apply>
+                    <times/>
+                    <cn> 1 </cn>
+                    <ci> lockdown_duration </ci>
+                  </apply>
+                </apply>
+              </piece>
+              <otherwise>
+                <cn> 0 </cn>
+              </otherwise>
+            </piecewise>
+            <piecewise>
+              <piece>
+                <cn> 1 </cn>
+                <apply>
+                  <gt/>
+                  <apply>
+                    <minus/>
+                    <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/time"> time </csymbol>
+                    <ci> Time_government_action_0 </ci>
+                  </apply>
+                  <apply>
+                    <times/>
+                    <cn> 2 </cn>
+                    <ci> lockdown_duration </ci>
+                  </apply>
+                </apply>
+              </piece>
+              <otherwise>
+                <cn> 0 </cn>
+              </otherwise>
+            </piecewise>
+            <piecewise>
+              <piece>
+                <cn> 1 </cn>
+                <apply>
+                  <gt/>
+                  <apply>
+                    <minus/>
+                    <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/time"> time </csymbol>
+                    <ci> Time_government_action_0 </ci>
+                  </apply>
+                  <apply>
+                    <times/>
+                    <cn> 3 </cn>
+                    <ci> lockdown_duration </ci>
+                  </apply>
+                </apply>
+              </piece>
+              <otherwise>
+                <cn> 0 </cn>
+              </otherwise>
+            </piecewise>
+            <piecewise>
+              <piece>
+                <cn> 1 </cn>
+                <apply>
+                  <gt/>
+                  <apply>
+                    <minus/>
+                    <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/time"> time </csymbol>
+                    <ci> Time_government_action_0 </ci>
+                  </apply>
+                  <apply>
+                    <times/>
+                    <cn> 4 </cn>
+                    <ci> lockdown_duration </ci>
+                  </apply>
+                </apply>
+              </piece>
+              <otherwise>
+                <cn> 0 </cn>
+              </otherwise>
+            </piecewise>
+            <piecewise>
+              <piece>
+                <cn> 1 </cn>
+                <apply>
+                  <gt/>
+                  <apply>
+                    <minus/>
+                    <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/time"> time </csymbol>
+                    <ci> Time_government_action_0 </ci>
+                  </apply>
+                  <apply>
+                    <times/>
+                    <cn> 5 </cn>
+                    <ci> lockdown_duration </ci>
+                  </apply>
+                </apply>
+              </piece>
+              <otherwise>
+                <cn> 0 </cn>
+              </otherwise>
+            </piecewise>
+            <piecewise>
+              <piece>
+                <cn> 1 </cn>
+                <apply>
+                  <gt/>
+                  <apply>
+                    <minus/>
+                    <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/time"> time </csymbol>
+                    <ci> Time_government_action_0 </ci>
+                  </apply>
+                  <apply>
+                    <times/>
+                    <cn> 6 </cn>
+                    <ci> lockdown_duration </ci>
+                  </apply>
+                </apply>
+              </piece>
+              <otherwise>
+                <cn> 0 </cn>
+              </otherwise>
+            </piecewise>
+            <piecewise>
+              <piece>
+                <cn> 1 </cn>
+                <apply>
+                  <gt/>
+                  <apply>
+                    <minus/>
+                    <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/time"> time </csymbol>
+                    <ci> Time_government_action_0 </ci>
+                  </apply>
+                  <apply>
+                    <times/>
+                    <cn> 7 </cn>
+                    <ci> lockdown_duration </ci>
+                  </apply>
+                </apply>
+              </piece>
+              <otherwise>
+                <cn> 0 </cn>
+              </otherwise>
+            </piecewise>
+            <piecewise>
+              <piece>
+                <cn> 1 </cn>
+                <apply>
+                  <gt/>
+                  <apply>
+                    <minus/>
+                    <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/time"> time </csymbol>
+                    <ci> Time_government_action_0 </ci>
+                  </apply>
+                  <apply>
+                    <times/>
+                    <cn> 8 </cn>
+                    <ci> lockdown_duration </ci>
+                  </apply>
+                </apply>
+              </piece>
+              <otherwise>
+                <cn> 0 </cn>
+              </otherwise>
+            </piecewise>
+            <piecewise>
+              <piece>
+                <cn> 1 </cn>
+                <apply>
+                  <gt/>
+                  <apply>
+                    <minus/>
+                    <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/time"> time </csymbol>
+                    <ci> Time_government_action_0 </ci>
+                  </apply>
+                  <apply>
+                    <times/>
+                    <cn> 9 </cn>
+                    <ci> lockdown_duration </ci>
+                  </apply>
+                </apply>
+              </piece>
+              <otherwise>
+                <cn> 0 </cn>
+              </otherwise>
+            </piecewise>
+            <piecewise>
+              <piece>
+                <cn> 1 </cn>
+                <apply>
+                  <gt/>
+                  <apply>
+                    <minus/>
+                    <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/time"> time </csymbol>
+                    <ci> Time_government_action_0 </ci>
+                  </apply>
+                  <apply>
+                    <times/>
+                    <cn> 10 </cn>
+                    <ci> lockdown_duration </ci>
+                  </apply>
+                </apply>
+              </piece>
+              <otherwise>
+                <cn> 0 </cn>
+              </otherwise>
+            </piecewise>
+            <piecewise>
+              <piece>
+                <cn> 1 </cn>
+                <apply>
+                  <gt/>
+                  <apply>
+                    <minus/>
+                    <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/time"> time </csymbol>
+                    <ci> Time_government_action_0 </ci>
+                  </apply>
+                  <apply>
+                    <times/>
+                    <cn> 11 </cn>
+                    <ci> lockdown_duration </ci>
+                  </apply>
+                </apply>
+              </piece>
+              <otherwise>
+                <cn> 0 </cn>
+              </otherwise>
+            </piecewise>
+            <piecewise>
+              <piece>
+                <cn> 1 </cn>
+                <apply>
+                  <gt/>
+                  <apply>
+                    <minus/>
+                    <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/time"> time </csymbol>
+                    <ci> Time_government_action_0 </ci>
+                  </apply>
+                  <apply>
+                    <times/>
+                    <cn> 12 </cn>
+                    <ci> lockdown_duration </ci>
+                  </apply>
+                </apply>
+              </piece>
+              <otherwise>
+                <cn> 0 </cn>
+              </otherwise>
+            </piecewise>
+            <piecewise>
+              <piece>
+                <cn> 1 </cn>
+                <apply>
+                  <gt/>
+                  <apply>
+                    <minus/>
+                    <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/time"> time </csymbol>
+                    <ci> Time_government_action_0 </ci>
+                  </apply>
+                  <apply>
+                    <times/>
+                    <cn> 13 </cn>
+                    <ci> lockdown_duration </ci>
+                  </apply>
+                </apply>
+              </piece>
+              <otherwise>
+                <cn> 0 </cn>
+              </otherwise>
+            </piecewise>
+            <piecewise>
+              <piece>
+                <cn> 1 </cn>
+                <apply>
+                  <gt/>
+                  <apply>
+                    <minus/>
+                    <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/time"> time </csymbol>
+                    <ci> Time_government_action_0 </ci>
+                  </apply>
+                  <apply>
+                    <times/>
+                    <cn> 14 </cn>
+                    <ci> lockdown_duration </ci>
+                  </apply>
+                </apply>
+              </piece>
+              <otherwise>
+                <cn> 0 </cn>
+              </otherwise>
+            </piecewise>
+            <piecewise>
+              <piece>
+                <cn> 1 </cn>
+                <apply>
+                  <gt/>
+                  <apply>
+                    <minus/>
+                    <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/time"> time </csymbol>
+                    <ci> Time_government_action_0 </ci>
+                  </apply>
+                  <apply>
+                    <times/>
+                    <cn> 15 </cn>
+                    <ci> lockdown_duration </ci>
+                  </apply>
+                </apply>
+              </piece>
+              <otherwise>
+                <cn> 0 </cn>
+              </otherwise>
+            </piecewise>
+            <piecewise>
+              <piece>
+                <cn> 1 </cn>
+                <apply>
+                  <gt/>
+                  <apply>
+                    <minus/>
+                    <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/time"> time </csymbol>
+                    <ci> Time_government_action_0 </ci>
+                  </apply>
+                  <apply>
+                    <times/>
+                    <cn> 16 </cn>
+                    <ci> lockdown_duration </ci>
+                  </apply>
+                </apply>
+              </piece>
+              <otherwise>
+                <cn> 0 </cn>
+              </otherwise>
+            </piecewise>
+            <piecewise>
+              <piece>
+                <cn> 1 </cn>
+                <apply>
+                  <gt/>
+                  <apply>
+                    <minus/>
+                    <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/time"> time </csymbol>
+                    <ci> Time_government_action_0 </ci>
+                  </apply>
+                  <apply>
+                    <times/>
+                    <cn> 17 </cn>
+                    <ci> lockdown_duration </ci>
+                  </apply>
+                </apply>
+              </piece>
+              <otherwise>
+                <cn> 0 </cn>
+              </otherwise>
+            </piecewise>
+            <piecewise>
+              <piece>
+                <cn> 1 </cn>
+                <apply>
+                  <gt/>
+                  <apply>
+                    <minus/>
+                    <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/time"> time </csymbol>
+                    <ci> Time_government_action_0 </ci>
+                  </apply>
+                  <apply>
+                    <times/>
+                    <cn> 18 </cn>
+                    <ci> lockdown_duration </ci>
+                  </apply>
+                </apply>
+              </piece>
+              <otherwise>
+                <cn> 0 </cn>
+              </otherwise>
+            </piecewise>
+            <piecewise>
+              <piece>
+                <cn> 1 </cn>
+                <apply>
+                  <gt/>
+                  <apply>
+                    <minus/>
+                    <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/time"> time </csymbol>
+                    <ci> Time_government_action_0 </ci>
+                  </apply>
+                  <apply>
+                    <times/>
+                    <cn> 19 </cn>
+                    <ci> lockdown_duration </ci>
+                  </apply>
+                </apply>
+              </piece>
+              <otherwise>
+                <cn> 0 </cn>
+              </otherwise>
+            </piecewise>
+            <piecewise>
+              <piece>
+                <cn> 1 </cn>
+                <apply>
+                  <gt/>
+                  <apply>
+                    <minus/>
+                    <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/time"> time </csymbol>
+                    <ci> Time_government_action_0 </ci>
+                  </apply>
+                  <apply>
+                    <times/>
+                    <cn> 20 </cn>
+                    <ci> lockdown_duration </ci>
+                  </apply>
+                </apply>
+              </piece>
+              <otherwise>
+                <cn> 0 </cn>
+              </otherwise>
+            </piecewise>
+            <piecewise>
+              <piece>
+                <cn> 1 </cn>
+                <apply>
+                  <gt/>
+                  <apply>
+                    <minus/>
+                    <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/time"> time </csymbol>
+                    <ci> Time_government_action_0 </ci>
+                  </apply>
+                  <apply>
+                    <times/>
+                    <cn> 21 </cn>
+                    <ci> lockdown_duration </ci>
+                  </apply>
+                </apply>
+              </piece>
+              <otherwise>
+                <cn> 0 </cn>
+              </otherwise>
+            </piecewise>
+            <piecewise>
+              <piece>
+                <cn> 1 </cn>
+                <apply>
+                  <gt/>
+                  <apply>
+                    <minus/>
+                    <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/time"> time </csymbol>
+                    <ci> Time_government_action_0 </ci>
+                  </apply>
+                  <apply>
+                    <times/>
+                    <cn> 22 </cn>
+                    <ci> lockdown_duration </ci>
+                  </apply>
+                </apply>
+              </piece>
+              <otherwise>
+                <cn> 0 </cn>
+              </otherwise>
+            </piecewise>
+            <piecewise>
+              <piece>
+                <cn> 1 </cn>
+                <apply>
+                  <gt/>
+                  <apply>
+                    <minus/>
+                    <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/time"> time </csymbol>
+                    <ci> Time_government_action_0 </ci>
+                  </apply>
+                  <apply>
+                    <times/>
+                    <cn> 23 </cn>
+                    <ci> lockdown_duration </ci>
+                  </apply>
+                </apply>
+              </piece>
+              <otherwise>
+                <cn> 0 </cn>
+              </otherwise>
+            </piecewise>
+            <piecewise>
+              <piece>
+                <cn> 1 </cn>
+                <apply>
+                  <gt/>
+                  <apply>
+                    <minus/>
+                    <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/time"> time </csymbol>
+                    <ci> Time_government_action_0 </ci>
+                  </apply>
+                  <apply>
+                    <times/>
+                    <cn> 24 </cn>
+                    <ci> lockdown_duration </ci>
+                  </apply>
+                </apply>
+              </piece>
+              <otherwise>
+                <cn> 0 </cn>
+              </otherwise>
+            </piecewise>
+            <piecewise>
+              <piece>
+                <cn> 1 </cn>
+                <apply>
+                  <gt/>
+                  <apply>
+                    <minus/>
+                    <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/time"> time </csymbol>
+                    <ci> Time_government_action_0 </ci>
+                  </apply>
+                  <apply>
+                    <times/>
+                    <cn> 25 </cn>
+                    <ci> lockdown_duration </ci>
+                  </apply>
+                </apply>
+              </piece>
+              <otherwise>
+                <cn> 0 </cn>
+              </otherwise>
+            </piecewise>
+            <piecewise>
+              <piece>
+                <cn> 1 </cn>
+                <apply>
+                  <gt/>
+                  <apply>
+                    <minus/>
+                    <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/time"> time </csymbol>
+                    <ci> Time_government_action_0 </ci>
+                  </apply>
+                  <apply>
+                    <times/>
+                    <cn> 26 </cn>
+                    <ci> lockdown_duration </ci>
+                  </apply>
+                </apply>
+              </piece>
+              <otherwise>
+                <cn> 0 </cn>
+              </otherwise>
+            </piecewise>
+            <piecewise>
+              <piece>
+                <cn> 1 </cn>
+                <apply>
+                  <gt/>
+                  <apply>
+                    <minus/>
+                    <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/time"> time </csymbol>
+                    <ci> Time_government_action_0 </ci>
+                  </apply>
+                  <apply>
+                    <times/>
+                    <cn> 27 </cn>
+                    <ci> lockdown_duration </ci>
+                  </apply>
+                </apply>
+              </piece>
+              <otherwise>
+                <cn> 0 </cn>
+              </otherwise>
+            </piecewise>
+            <piecewise>
+              <piece>
+                <cn> 1 </cn>
+                <apply>
+                  <gt/>
+                  <apply>
+                    <minus/>
+                    <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/time"> time </csymbol>
+                    <ci> Time_government_action_0 </ci>
+                  </apply>
+                  <apply>
+                    <times/>
+                    <cn> 28 </cn>
+                    <ci> lockdown_duration </ci>
+                  </apply>
+                </apply>
+              </piece>
+              <otherwise>
+                <cn> 0 </cn>
+              </otherwise>
+            </piecewise>
+            <piecewise>
+              <piece>
+                <cn> 1 </cn>
+                <apply>
+                  <gt/>
+                  <apply>
+                    <minus/>
+                    <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/time"> time </csymbol>
+                    <ci> Time_government_action_0 </ci>
+                  </apply>
+                  <apply>
+                    <times/>
+                    <cn> 29 </cn>
+                    <ci> lockdown_duration </ci>
+                  </apply>
+                </apply>
+              </piece>
+              <otherwise>
+                <cn> 0 </cn>
+              </otherwise>
+            </piecewise>
+            <piecewise>
+              <piece>
+                <cn> 1 </cn>
+                <apply>
+                  <gt/>
+                  <apply>
+                    <minus/>
+                    <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/time"> time </csymbol>
+                    <ci> Time_government_action_0 </ci>
+                  </apply>
+                  <apply>
+                    <times/>
+                    <cn> 30 </cn>
+                    <ci> lockdown_duration </ci>
+                  </apply>
+                </apply>
+              </piece>
+              <otherwise>
+                <cn> 0 </cn>
+              </otherwise>
+            </piecewise>
+            <piecewise>
+              <piece>
+                <cn> 1 </cn>
+                <apply>
+                  <gt/>
+                  <apply>
+                    <minus/>
+                    <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/time"> time </csymbol>
+                    <ci> Time_government_action_0 </ci>
+                  </apply>
+                  <apply>
+                    <times/>
+                    <cn> 31 </cn>
+                    <ci> lockdown_duration </ci>
+                  </apply>
+                </apply>
+              </piece>
+              <otherwise>
+                <cn> 0 </cn>
+              </otherwise>
+            </piecewise>
+            <piecewise>
+              <piece>
+                <cn> 1 </cn>
+                <apply>
+                  <gt/>
+                  <apply>
+                    <minus/>
+                    <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/time"> time </csymbol>
+                    <ci> Time_government_action_0 </ci>
+                  </apply>
+                  <apply>
+                    <times/>
+                    <cn> 32 </cn>
+                    <ci> lockdown_duration </ci>
+                  </apply>
+                </apply>
+              </piece>
+              <otherwise>
+                <cn> 0 </cn>
+              </otherwise>
+            </piecewise>
+            <piecewise>
+              <piece>
+                <cn> 1 </cn>
+                <apply>
+                  <gt/>
+                  <apply>
+                    <minus/>
+                    <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/time"> time </csymbol>
+                    <ci> Time_government_action_0 </ci>
+                  </apply>
+                  <apply>
+                    <times/>
+                    <cn> 33 </cn>
+                    <ci> lockdown_duration </ci>
+                  </apply>
+                </apply>
+              </piece>
+              <otherwise>
+                <cn> 0 </cn>
+              </otherwise>
+            </piecewise>
+            <piecewise>
+              <piece>
+                <cn> 1 </cn>
+                <apply>
+                  <gt/>
+                  <apply>
+                    <minus/>
+                    <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/time"> time </csymbol>
+                    <ci> Time_government_action_0 </ci>
+                  </apply>
+                  <apply>
+                    <times/>
+                    <cn> 34 </cn>
+                    <ci> lockdown_duration </ci>
+                  </apply>
+                </apply>
+              </piece>
+              <otherwise>
+                <cn> 0 </cn>
+              </otherwise>
+            </piecewise>
+            <piecewise>
+              <piece>
+                <cn> 1 </cn>
+                <apply>
+                  <gt/>
+                  <apply>
+                    <minus/>
+                    <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/time"> time </csymbol>
+                    <ci> Time_government_action_0 </ci>
+                  </apply>
+                  <apply>
+                    <times/>
+                    <cn> 35 </cn>
+                    <ci> lockdown_duration </ci>
+                  </apply>
+                </apply>
+              </piece>
+              <otherwise>
+                <cn> 0 </cn>
+              </otherwise>
+            </piecewise>
+            <piecewise>
+              <piece>
+                <cn> 1 </cn>
+                <apply>
+                  <gt/>
+                  <apply>
+                    <minus/>
+                    <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/time"> time </csymbol>
+                    <ci> Time_government_action_0 </ci>
+                  </apply>
+                  <apply>
+                    <times/>
+                    <cn> 36 </cn>
+                    <ci> lockdown_duration </ci>
+                  </apply>
+                </apply>
+              </piece>
+              <otherwise>
+                <cn> 0 </cn>
+              </otherwise>
+            </piecewise>
+            <piecewise>
+              <piece>
+                <cn> 1 </cn>
+                <apply>
+                  <gt/>
+                  <apply>
+                    <minus/>
+                    <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/time"> time </csymbol>
+                    <ci> Time_government_action_0 </ci>
+                  </apply>
+                  <apply>
+                    <times/>
+                    <cn> 37 </cn>
+                    <ci> lockdown_duration </ci>
+                  </apply>
+                </apply>
+              </piece>
+              <otherwise>
+                <cn> 0 </cn>
+              </otherwise>
+            </piecewise>
+            <piecewise>
+              <piece>
+                <cn> 1 </cn>
+                <apply>
+                  <gt/>
+                  <apply>
+                    <minus/>
+                    <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/time"> time </csymbol>
+                    <ci> Time_government_action_0 </ci>
+                  </apply>
+                  <apply>
+                    <times/>
+                    <cn> 38 </cn>
+                    <ci> lockdown_duration </ci>
+                  </apply>
+                </apply>
+              </piece>
+              <otherwise>
+                <cn> 0 </cn>
+              </otherwise>
+            </piecewise>
+            <piecewise>
+              <piece>
+                <cn> 1 </cn>
+                <apply>
+                  <gt/>
+                  <apply>
+                    <minus/>
+                    <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/time"> time </csymbol>
+                    <ci> Time_government_action_0 </ci>
+                  </apply>
+                  <apply>
+                    <times/>
+                    <cn> 39 </cn>
+                    <ci> lockdown_duration </ci>
+                  </apply>
+                </apply>
+              </piece>
+              <otherwise>
+                <cn> 0 </cn>
+              </otherwise>
+            </piecewise>
+            <piecewise>
+              <piece>
+                <cn> 1 </cn>
+                <apply>
+                  <gt/>
+                  <apply>
+                    <minus/>
+                    <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/time"> time </csymbol>
+                    <ci> Time_government_action_0 </ci>
+                  </apply>
+                  <apply>
+                    <times/>
+                    <cn> 40 </cn>
+                    <ci> lockdown_duration </ci>
+                  </apply>
+                </apply>
+              </piece>
+              <otherwise>
+                <cn> 0 </cn>
+              </otherwise>
+            </piecewise>
+            <piecewise>
+              <piece>
+                <cn> 1 </cn>
+                <apply>
+                  <gt/>
+                  <apply>
+                    <minus/>
+                    <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/time"> time </csymbol>
+                    <ci> Time_government_action_0 </ci>
+                  </apply>
+                  <apply>
+                    <times/>
+                    <cn> 41 </cn>
+                    <ci> lockdown_duration </ci>
+                  </apply>
+                </apply>
+              </piece>
+              <otherwise>
+                <cn> 0 </cn>
+              </otherwise>
+            </piecewise>
+            <piecewise>
+              <piece>
+                <cn> 1 </cn>
+                <apply>
+                  <gt/>
+                  <apply>
+                    <minus/>
+                    <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/time"> time </csymbol>
+                    <ci> Time_government_action_0 </ci>
+                  </apply>
+                  <apply>
+                    <times/>
+                    <cn> 42 </cn>
+                    <ci> lockdown_duration </ci>
+                  </apply>
+                </apply>
+              </piece>
+              <otherwise>
+                <cn> 0 </cn>
+              </otherwise>
+            </piecewise>
+            <piecewise>
+              <piece>
+                <cn> 1 </cn>
+                <apply>
+                  <gt/>
+                  <apply>
+                    <minus/>
+                    <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/time"> time </csymbol>
+                    <ci> Time_government_action_0 </ci>
+                  </apply>
+                  <apply>
+                    <times/>
+                    <cn> 43 </cn>
+                    <ci> lockdown_duration </ci>
+                  </apply>
+                </apply>
+              </piece>
+              <otherwise>
+                <cn> 0 </cn>
+              </otherwise>
+            </piecewise>
+            <piecewise>
+              <piece>
+                <cn> 1 </cn>
+                <apply>
+                  <gt/>
+                  <apply>
+                    <minus/>
+                    <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/time"> time </csymbol>
+                    <ci> Time_government_action_0 </ci>
+                  </apply>
+                  <apply>
+                    <times/>
+                    <cn> 44 </cn>
+                    <ci> lockdown_duration </ci>
+                  </apply>
+                </apply>
+              </piece>
+              <otherwise>
+                <cn> 0 </cn>
+              </otherwise>
+            </piecewise>
+            <piecewise>
+              <piece>
+                <cn> 1 </cn>
+                <apply>
+                  <gt/>
+                  <apply>
+                    <minus/>
+                    <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/time"> time </csymbol>
+                    <ci> Time_government_action_0 </ci>
+                  </apply>
+                  <apply>
+                    <times/>
+                    <cn> 45 </cn>
+                    <ci> lockdown_duration </ci>
+                  </apply>
+                </apply>
+              </piece>
+              <otherwise>
+                <cn> 0 </cn>
+              </otherwise>
+            </piecewise>
+            <piecewise>
+              <piece>
+                <cn> 1 </cn>
+                <apply>
+                  <gt/>
+                  <apply>
+                    <minus/>
+                    <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/time"> time </csymbol>
+                    <ci> Time_government_action_0 </ci>
+                  </apply>
+                  <apply>
+                    <times/>
+                    <cn> 46 </cn>
+                    <ci> lockdown_duration </ci>
+                  </apply>
+                </apply>
+              </piece>
+              <otherwise>
+                <cn> 0 </cn>
+              </otherwise>
+            </piecewise>
+            <piecewise>
+              <piece>
+                <cn> 1 </cn>
+                <apply>
+                  <gt/>
+                  <apply>
+                    <minus/>
+                    <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/time"> time </csymbol>
+                    <ci> Time_government_action_0 </ci>
+                  </apply>
+                  <apply>
+                    <times/>
+                    <cn> 47 </cn>
+                    <ci> lockdown_duration </ci>
+                  </apply>
+                </apply>
+              </piece>
+              <otherwise>
+                <cn> 0 </cn>
+              </otherwise>
+            </piecewise>
+            <piecewise>
+              <piece>
+                <cn> 1 </cn>
+                <apply>
+                  <gt/>
+                  <apply>
+                    <minus/>
+                    <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/time"> time </csymbol>
+                    <ci> Time_government_action_0 </ci>
+                  </apply>
+                  <apply>
+                    <times/>
+                    <cn> 48 </cn>
+                    <ci> lockdown_duration </ci>
+                  </apply>
+                </apply>
+              </piece>
+              <otherwise>
+                <cn> 0 </cn>
+              </otherwise>
+            </piecewise>
+            <piecewise>
+              <piece>
+                <cn> 1 </cn>
+                <apply>
+                  <gt/>
+                  <apply>
+                    <minus/>
+                    <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/time"> time </csymbol>
+                    <ci> Time_government_action_0 </ci>
+                  </apply>
+                  <apply>
+                    <times/>
+                    <cn> 49 </cn>
+                    <ci> lockdown_duration </ci>
+                  </apply>
+                </apply>
+              </piece>
+              <otherwise>
+                <cn> 0 </cn>
+              </otherwise>
+            </piecewise>
+            <piecewise>
+              <piece>
+                <cn> 1 </cn>
+                <apply>
+                  <gt/>
+                  <apply>
+                    <minus/>
+                    <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/time"> time </csymbol>
+                    <ci> Time_government_action_0 </ci>
+                  </apply>
+                  <apply>
+                    <times/>
+                    <cn> 50 </cn>
+                    <ci> lockdown_duration </ci>
+                  </apply>
+                </apply>
+              </piece>
+              <otherwise>
+                <cn> 0 </cn>
+              </otherwise>
+            </piecewise>
+            <piecewise>
+              <piece>
+                <cn> 1 </cn>
+                <apply>
+                  <gt/>
+                  <apply>
+                    <minus/>
+                    <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/time"> time </csymbol>
+                    <ci> Time_government_action_0 </ci>
+                  </apply>
+                  <apply>
+                    <times/>
+                    <cn> 51 </cn>
+                    <ci> lockdown_duration </ci>
+                  </apply>
+                </apply>
+              </piece>
+              <otherwise>
+                <cn> 0 </cn>
+              </otherwise>
+            </piecewise>
+          </apply>
+        </math>
+            </assignmentRule>
+      <assignmentRule variable="intermittent_time">
+        <math xmlns="http://www.w3.org/1998/Math/MathML">        
+          <apply>
+            <minus/>
+            <apply>
+              <minus/>
+              <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/time"> time </csymbol>
+              <apply>
+                <times/>
+                <ci> n_lockdowns </ci>
+                <ci> lockdown_duration </ci>
+              </apply>
+            </apply>
+            <apply>
+              <times/>
+              <ci> n_pauses </ci>
+              <ci> lockdownPause_duration_0 </ci>
+            </apply>
+          </apply>
+        </math>
+            </assignmentRule>
+      <assignmentRule variable="Government_induced_isolation_factor_0">
+        <math xmlns="http://www.w3.org/1998/Math/MathML">        
+          <apply>
+            <times/>
+            <ci> social_distancing_factor </ci>
+            <apply>
+              <plus/>
+              <cn> 1 </cn>
+              <apply>
+                <times/>
+                <apply>
+                  <divide/>
+                  <apply>
+                    <times/>
+                    <cn> 2.5 </cn>
+                    <ci> symptoms_tested_0 </ci>
+                  </apply>
+                  <ci> symptomatic_numberTolerance_0 </ci>
+                </apply>
+                <piecewise>
+                  <piece>
+                    <cn> 0 </cn>
+                    <apply>
+                      <lt/>
+                      <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/time"> time </csymbol>
+                      <ci> Time_government_action_0 </ci>
+                    </apply>
+                  </piece>
+                  <otherwise>
+                    <ci> governmentResponseFactorToDiagnosedInfected_0 </ci>
+                  </otherwise>
+                </piecewise>
+              </apply>
+            </apply>
+          </apply>
+        </math>
+            </assignmentRule>
+      <assignmentRule variable="Social_Distance">
+        <math xmlns="http://www.w3.org/1998/Math/MathML">        
+          <piecewise>
+            <piece>
+              <apply>
+                <times/>
+                <ci> Social_Distance_base </ci>
+                <ci> Government_induced_isolation_factor_0 </ci>
+              </apply>
+              <apply>
+                <and/>
+                <apply>
+                  <gt/>
+                  <csymbol encoding="text" definitionURL="http://www.sbml.org/sbml/symbols/time"> time </csymbol>
+                  <ci> Time_government_action_0 </ci>
+                </apply>
+                <apply>
+                  <lt/>
+                  <ci> intermittent_time </ci>
+                  <apply>
+                    <minus/>
+                    <ci> Time_government_action_0 </ci>
+                    <apply>
+                      <times/>
+                      <ci> lockdown_duration </ci>
+                      <apply>
+                        <minus/>
+                        <cn> 1 </cn>
+                        <ci> timeFraction_lockdown_0 </ci>
+                      </apply>
+                    </apply>
+                  </apply>
+                </apply>
+              </apply>
+            </piece>
+            <otherwise>
+              <ci> Social_Distance_base </ci>
+            </otherwise>
+          </piecewise>
+        </math>
+            </assignmentRule>
+      <assignmentRule variable="Total_Infection_coefficient">
+        <math xmlns="http://www.w3.org/1998/Math/MathML">        
+          <apply>
+            <divide/>
+            <apply>
+              <times/>
+              <apply>
+                <plus/>
+                <apply>
+                  <times/>
+                  <ci> infected_nontested_0 </ci>
+                  <ci> Infection_from_non_tested_no_symptoms_0 </ci>
+                </apply>
+                <apply>
+                  <times/>
+                  <ci> symptoms_nontested_0 </ci>
+                  <ci> Infection_from_non_tested_symptoms </ci>
+                </apply>
+                <apply>
+                  <times/>
+                  <ci> infected_tested_0 </ci>
+                  <ci> Infection_from_tested_no_symptoms_0 </ci>
+                </apply>
+                <apply>
+                  <times/>
+                  <ci> symptoms_tested_0 </ci>
+                  <ci> Infection_from_tested_symptoms </ci>
+                </apply>
+              </apply>
+              <apply>
+                <minus/>
+                <cn> 1 </cn>
+                <ci> epidemic_extinguished_bool_0 </ci>
+              </apply>
+            </apply>
+            <ci> Social_Distance </ci>
+          </apply>
+        </math>
+            </assignmentRule>
+    </listOfRules>
+    <listOfReactions>
+      <reaction id="re1" metaid="COPASI48" name="infection_uninfected_nt" reversible="false">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <pre>re1 in article</pre>
+          </body>
+        </notes>
+        <annotation>
+          <celldesigner:extension xmlns:celldesigner="http://www.sbml.org/2001/ns/celldesigner">
+            <celldesigner:reactionType>STATE_TRANSITION</celldesigner:reactionType>
+            <celldesigner:baseReactants>
+              <celldesigner:baseReactant species="s6" alias="sa3">
+                <celldesigner:linkAnchor position="E"/>
+              </celldesigner:baseReactant>
+            </celldesigner:baseReactants>
+            <celldesigner:baseProducts>
+              <celldesigner:baseProduct species="s4" alias="sa1">
+                <celldesigner:linkAnchor position="W"/>
+              </celldesigner:baseProduct>
+            </celldesigner:baseProducts>
+            <celldesigner:connectScheme connectPolicy="direct" rectangleIndex="0">
+              <celldesigner:listOfLineDirection>
+                <celldesigner:lineDirection index="0" value="unknown"/>
+              </celldesigner:listOfLineDirection>
+            </celldesigner:connectScheme>
+            <celldesigner:line width="1.0" color="ff000000"/>
+            <celldesigner:listOfModification>
+              <celldesigner:modification type="CATALYSIS" modifiers="s22" aliases="sa10" targetLineIndex="-1,4" editPoints="-0.02817442596291808,-0.011469491956719868 0.19116888845642027,-0.5502790570088124 1.0771813241170358,-0.1895933586475348">
+                <celldesigner:connectScheme connectPolicy="square">
+                  <celldesigner:listOfLineDirection>
+                    <celldesigner:lineDirection index="0" value="horizontal"/>
+                    <celldesigner:lineDirection index="1" value="vertical"/>
+                    <celldesigner:lineDirection index="2" value="horizontal"/>
+                    <celldesigner:lineDirection index="3" value="vertical"/>
+                  </celldesigner:listOfLineDirection>
+                </celldesigner:connectScheme>
+                <celldesigner:linkTarget species="s22" alias="sa10">
+                  <celldesigner:linkAnchor position="W"/>
+                </celldesigner:linkTarget>
+                <celldesigner:line width="3.0" color="ffff6699"/>
+              </celldesigner:modification>
+            </celldesigner:listOfModification>
+          </celldesigner:extension>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI48">
+              <bqbiol:is>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/ncit/C171133"/>
+	</rdf:Bag>
+	</bqbiol:is>
+	<bqbiol:is>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/ncit/C128320"/>
+	</rdf:Bag>
+	</bqbiol:is>
+	
+	<bqbiol:hasProperty>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/ncit/C101887"/>
+	</rdf:Bag>
+	</bqbiol:hasProperty>
+	</rdf:Description>
+	
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI48">
+                <bqbiol:hasProperty rdf:resource="urn:miriam:ncit:C101887"/>
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2020-03-19T13:58:17Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:is rdf:resource="urn:miriam:ncit:C128320"/>
+                <CopasiMT:is rdf:resource="urn:miriam:ncit:C171133"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+              <listOfReactants>
+          <speciesReference constant="true" species="uninfected_nontested_0" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference constant="true" species="infected_nontested_0" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw>
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <times/>
+              <ci> default </ci>
+              <ci> Total_Infection_coefficient </ci>
+              <ci> uninfected_nontested_0 </ci>
+            </apply>
+          </math>
+                </kineticLaw>
+      </reaction>
+      <reaction id="re2" metaid="COPASI49" name="test_uninfected" reversible="false">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <pre>re3 in article</pre>
+          </body>
+        </notes>
+        <annotation>
+          <celldesigner:extension xmlns:celldesigner="http://www.sbml.org/2001/ns/celldesigner">
+            <celldesigner:reactionType>STATE_TRANSITION</celldesigner:reactionType>
+            <celldesigner:baseReactants>
+              <celldesigner:baseReactant species="s6" alias="sa3">
+                <celldesigner:linkAnchor position="S"/>
+              </celldesigner:baseReactant>
+            </celldesigner:baseReactants>
+            <celldesigner:baseProducts>
+              <celldesigner:baseProduct species="s7" alias="sa4">
+                <celldesigner:linkAnchor position="N"/>
+              </celldesigner:baseProduct>
+            </celldesigner:baseProducts>
+            <celldesigner:connectScheme connectPolicy="direct" rectangleIndex="0">
+              <celldesigner:listOfLineDirection>
+                <celldesigner:lineDirection index="0" value="unknown"/>
+              </celldesigner:listOfLineDirection>
+            </celldesigner:connectScheme>
+            <celldesigner:line width="1.0" color="ff000000"/>
+          </celldesigner:extension>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI49">
+              <bqbiol:is>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/efo/0001460"/>
+	</rdf:Bag>
+	</bqbiol:is>
+	
+	<bqbiol:is>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/ncit/C47891"/>
+	</rdf:Bag>
+	</bqbiol:is>
+	</rdf:Description>
+	
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI49">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2020-03-19T14:20:36Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:is rdf:resource="urn:miriam:efo:0001460"/>
+                <CopasiMT:is rdf:resource="urn:miriam:ncit:C47891"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+              <listOfReactants>
+          <speciesReference constant="true" species="uninfected_nontested_0" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference constant="true" species="uninfected_tested_0" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw>
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <times/>
+              <ci> default </ci>
+              <ci> Testing_Randome </ci>
+              <ci> uninfected_nontested_0 </ci>
+            </apply>
+          </math>
+                </kineticLaw>
+      </reaction>
+      <reaction id="re3" metaid="COPASI50" name="infection_uninfected_t" reversible="false">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <pre>re3 in article</pre>
+          </body>
+        </notes>
+        <annotation>
+          <celldesigner:extension xmlns:celldesigner="http://www.sbml.org/2001/ns/celldesigner">
+            <celldesigner:reactionType>STATE_TRANSITION</celldesigner:reactionType>
+            <celldesigner:baseReactants>
+              <celldesigner:baseReactant species="s7" alias="sa4">
+                <celldesigner:linkAnchor position="E"/>
+              </celldesigner:baseReactant>
+            </celldesigner:baseReactants>
+            <celldesigner:baseProducts>
+              <celldesigner:baseProduct species="s5" alias="sa2">
+                <celldesigner:linkAnchor position="W"/>
+              </celldesigner:baseProduct>
+            </celldesigner:baseProducts>
+            <celldesigner:connectScheme connectPolicy="direct" rectangleIndex="0">
+              <celldesigner:listOfLineDirection>
+                <celldesigner:lineDirection index="0" value="unknown"/>
+              </celldesigner:listOfLineDirection>
+            </celldesigner:connectScheme>
+            <celldesigner:line width="1.0" color="ff000000"/>
+            <celldesigner:listOfModification>
+              <celldesigner:modification type="CATALYSIS" modifiers="s22" aliases="sa10" targetLineIndex="-1,6" editPoints="0.025021622992395853,-0.1010096438712007 0.9672065065557284,0.1323838623539768">
+                <celldesigner:connectScheme connectPolicy="square">
+                  <celldesigner:listOfLineDirection>
+                    <celldesigner:lineDirection index="0" value="vertical"/>
+                    <celldesigner:lineDirection index="1" value="horizontal"/>
+                    <celldesigner:lineDirection index="2" value="vertical"/>
+                  </celldesigner:listOfLineDirection>
+                </celldesigner:connectScheme>
+                <celldesigner:linkTarget species="s22" alias="sa10">
+                  <celldesigner:linkAnchor position="N"/>
+                </celldesigner:linkTarget>
+                <celldesigner:line width="3.0" color="ffff6699"/>
+              </celldesigner:modification>
+            </celldesigner:listOfModification>
+          </celldesigner:extension>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI50">
+              <bqbiol:is>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/ncit/C171133"/>
+	</rdf:Bag>
+	</bqbiol:is>
+	<bqbiol:is>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/ncit/C128320"/>
+	</rdf:Bag>
+	</bqbiol:is>
+	
+	<bqbiol:hasProperty>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/ncit/C47891"/>
+	</rdf:Bag>
+	</bqbiol:hasProperty>
+	</rdf:Description>
+	
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI50">
+                <bqbiol:hasProperty rdf:resource="urn:miriam:ncit:C47891"/>
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2020-03-19T14:20:41Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:is rdf:resource="urn:miriam:ncit:C128320"/>
+                <CopasiMT:is rdf:resource="urn:miriam:ncit:C171133"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+              <listOfReactants>
+          <speciesReference constant="true" species="uninfected_tested_0" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference constant="true" species="infected_nontested_0" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw>
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <times/>
+              <ci> default </ci>
+              <ci> Total_Infection_coefficient </ci>
+              <ci> uninfected_tested_0 </ci>
+            </apply>
+          </math>
+                </kineticLaw>
+      </reaction>
+      <reaction id="re4" metaid="COPASI51" name="test_infected" reversible="false">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <pre>re4 in article</pre>
+          </body>
+        </notes>
+        <annotation>
+          <celldesigner:extension xmlns:celldesigner="http://www.sbml.org/2001/ns/celldesigner">
+            <celldesigner:reactionType>STATE_TRANSITION</celldesigner:reactionType>
+            <celldesigner:baseReactants>
+              <celldesigner:baseReactant species="s4" alias="sa1">
+                <celldesigner:linkAnchor position="S"/>
+              </celldesigner:baseReactant>
+            </celldesigner:baseReactants>
+            <celldesigner:baseProducts>
+              <celldesigner:baseProduct species="s5" alias="sa2">
+                <celldesigner:linkAnchor position="N"/>
+              </celldesigner:baseProduct>
+            </celldesigner:baseProducts>
+            <celldesigner:connectScheme connectPolicy="direct" rectangleIndex="0">
+              <celldesigner:listOfLineDirection>
+                <celldesigner:lineDirection index="0" value="unknown"/>
+              </celldesigner:listOfLineDirection>
+            </celldesigner:connectScheme>
+            <celldesigner:line width="1.0" color="ff000000"/>
+          </celldesigner:extension>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI51">
+              <bqbiol:is>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/ncit/C47891"/>
+	</rdf:Bag>
+	</bqbiol:is>
+	
+	<bqbiol:is>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/ncit/C128320"/>
+	</rdf:Bag>
+	</bqbiol:is>
+	</rdf:Description>
+	
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI51">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2020-03-19T14:20:45Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:is rdf:resource="urn:miriam:ncit:C128320"/>
+                <CopasiMT:is rdf:resource="urn:miriam:ncit:C47891"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+              <listOfReactants>
+          <speciesReference constant="true" species="infected_nontested_0" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference constant="true" species="infected_tested_0" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw>
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <times/>
+              <ci> default </ci>
+              <ci> Testing_Randome </ci>
+              <ci> infected_nontested_0 </ci>
+            </apply>
+          </math>
+                </kineticLaw>
+      </reaction>
+      <reaction id="re5" metaid="COPASI52" name="symptoms_infected_nt" reversible="false">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <pre>re5 in article</pre>
+          </body>
+        </notes>
+        <annotation>
+          <celldesigner:extension xmlns:celldesigner="http://www.sbml.org/2001/ns/celldesigner">
+            <celldesigner:reactionType>STATE_TRANSITION</celldesigner:reactionType>
+            <celldesigner:baseReactants>
+              <celldesigner:baseReactant species="s4" alias="sa1">
+                <celldesigner:linkAnchor position="E"/>
+              </celldesigner:baseReactant>
+            </celldesigner:baseReactants>
+            <celldesigner:baseProducts>
+              <celldesigner:baseProduct species="s9" alias="sa6">
+                <celldesigner:linkAnchor position="W"/>
+              </celldesigner:baseProduct>
+            </celldesigner:baseProducts>
+            <celldesigner:connectScheme connectPolicy="direct" rectangleIndex="0">
+              <celldesigner:listOfLineDirection>
+                <celldesigner:lineDirection index="0" value="unknown"/>
+              </celldesigner:listOfLineDirection>
+            </celldesigner:connectScheme>
+            <celldesigner:line width="1.0" color="ff000000"/>
+          </celldesigner:extension>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI52">
+              <bqbiol:is>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/ncit/C171133"/>
+	</rdf:Bag>
+	</bqbiol:is>
+	<bqbiol:is>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/ncit/C173069"/>
+	</rdf:Bag>
+	</bqbiol:is>
+	
+	<bqbiol:hasProperty>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/ncit/C101887"/>
+	</rdf:Bag>
+	</bqbiol:hasProperty>
+	</rdf:Description>
+	
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI52">
+                <bqbiol:hasProperty rdf:resource="urn:miriam:ncit:C101887"/>
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2020-03-19T14:20:50Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:is rdf:resource="urn:miriam:ncit:C171133"/>
+                <CopasiMT:is rdf:resource="urn:miriam:ncit:C173069"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+              <listOfReactants>
+          <speciesReference constant="true" species="infected_nontested_0" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference constant="true" species="symptoms_nontested_0" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw>
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <times/>
+              <ci> default </ci>
+              <ci> Symptoms_appear </ci>
+              <ci> infected_nontested_0 </ci>
+            </apply>
+          </math>
+                </kineticLaw>
+      </reaction>
+      <reaction id="re6" metaid="COPASI53" name="symptoms_infected_t" reversible="false">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <pre>re6 in article</pre>
+          </body>
+        </notes>
+        <annotation>
+          <celldesigner:extension xmlns:celldesigner="http://www.sbml.org/2001/ns/celldesigner">
+            <celldesigner:reactionType>STATE_TRANSITION</celldesigner:reactionType>
+            <celldesigner:baseReactants>
+              <celldesigner:baseReactant species="s5" alias="sa2">
+                <celldesigner:linkAnchor position="E"/>
+              </celldesigner:baseReactant>
+            </celldesigner:baseReactants>
+            <celldesigner:baseProducts>
+              <celldesigner:baseProduct species="s8" alias="sa5">
+                <celldesigner:linkAnchor position="W"/>
+              </celldesigner:baseProduct>
+            </celldesigner:baseProducts>
+            <celldesigner:connectScheme connectPolicy="direct" rectangleIndex="0">
+              <celldesigner:listOfLineDirection>
+                <celldesigner:lineDirection index="0" value="unknown"/>
+              </celldesigner:listOfLineDirection>
+            </celldesigner:connectScheme>
+            <celldesigner:line width="1.0" color="ff000000"/>
+          </celldesigner:extension>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI53">
+              <bqbiol:is>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/ncit/C173069"/>
+	</rdf:Bag>
+	</bqbiol:is>
+	<bqbiol:is>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/ncit/C171133"/>
+	</rdf:Bag>
+	</bqbiol:is>
+	
+	<bqbiol:hasProperty>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/ncit/C47891"/>
+	</rdf:Bag>
+	</bqbiol:hasProperty>
+	</rdf:Description>
+	
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI53">
+                <bqbiol:hasProperty rdf:resource="urn:miriam:ncit:C47891"/>
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2020-03-19T14:20:54Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:is rdf:resource="urn:miriam:ncit:C171133"/>
+                <CopasiMT:is rdf:resource="urn:miriam:ncit:C173069"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+              <listOfReactants>
+          <speciesReference constant="true" species="infected_tested_0" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference constant="true" species="symptoms_tested_0" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw>
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <times/>
+              <ci> default </ci>
+              <ci> Symptoms_appear </ci>
+              <ci> infected_tested_0 </ci>
+            </apply>
+          </math>
+                </kineticLaw>
+      </reaction>
+      <reaction id="re7" metaid="COPASI54" name="test_symptoms" reversible="false">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <pre>re7 in article</pre>
+          </body>
+        </notes>
+        <annotation>
+          <celldesigner:extension xmlns:celldesigner="http://www.sbml.org/2001/ns/celldesigner">
+            <celldesigner:reactionType>STATE_TRANSITION</celldesigner:reactionType>
+            <celldesigner:baseReactants>
+              <celldesigner:baseReactant species="s9" alias="sa6">
+                <celldesigner:linkAnchor position="S"/>
+              </celldesigner:baseReactant>
+            </celldesigner:baseReactants>
+            <celldesigner:baseProducts>
+              <celldesigner:baseProduct species="s8" alias="sa5">
+                <celldesigner:linkAnchor position="N"/>
+              </celldesigner:baseProduct>
+            </celldesigner:baseProducts>
+            <celldesigner:connectScheme connectPolicy="direct" rectangleIndex="0">
+              <celldesigner:listOfLineDirection>
+                <celldesigner:lineDirection index="0" value="unknown"/>
+              </celldesigner:listOfLineDirection>
+            </celldesigner:connectScheme>
+            <celldesigner:line width="1.0" color="ff000000"/>
+          </celldesigner:extension>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI54">
+              <bqbiol:is>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/ncit/C47891"/>
+	</rdf:Bag>
+	</bqbiol:is>
+	
+	<bqbiol:is>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/ncit/C173069"/>
+	</rdf:Bag>
+	</bqbiol:is>
+	</rdf:Description>
+	
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI54">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2020-03-19T14:20:58Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:is rdf:resource="urn:miriam:ncit:C173069"/>
+                <CopasiMT:is rdf:resource="urn:miriam:ncit:C47891"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+              <listOfReactants>
+          <speciesReference constant="true" species="symptoms_nontested_0" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference constant="true" species="symptoms_tested_0" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw>
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <times/>
+              <ci> default </ci>
+              <ci> Testing_for_Symptoms </ci>
+              <ci> symptoms_nontested_0 </ci>
+            </apply>
+          </math>
+                </kineticLaw>
+      </reaction>
+      <reaction id="re8" metaid="COPASI55" name="death_c_symptoms_t" reversible="false">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <pre>re8 in article</pre>
+          </body>
+        </notes>
+        <annotation>
+          <celldesigner:extension xmlns:celldesigner="http://www.sbml.org/2001/ns/celldesigner">
+            <celldesigner:reactionType>STATE_TRANSITION</celldesigner:reactionType>
+            <celldesigner:baseReactants>
+              <celldesigner:baseReactant species="s8" alias="sa5">
+                <celldesigner:linkAnchor position="SW"/>
+              </celldesigner:baseReactant>
+            </celldesigner:baseReactants>
+            <celldesigner:baseProducts>
+              <celldesigner:baseProduct species="s13" alias="sa11">
+                <celldesigner:linkAnchor position="NE"/>
+              </celldesigner:baseProduct>
+            </celldesigner:baseProducts>
+            <celldesigner:connectScheme connectPolicy="direct" rectangleIndex="0">
+              <celldesigner:listOfLineDirection>
+                <celldesigner:lineDirection index="0" value="unknown"/>
+              </celldesigner:listOfLineDirection>
+            </celldesigner:connectScheme>
+            <celldesigner:line width="1.0" color="ff000000"/>
+          </celldesigner:extension>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI55">
+	<bqbiol:is>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/ncit/C28554"/>
+	</rdf:Bag>
+	</bqbiol:is>
+	</rdf:Description>
+	
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI55">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2020-03-19T14:21:02Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:is rdf:resource="urn:miriam:ncit:C28554"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+              <listOfReactants>
+          <speciesReference constant="true" species="symptoms_tested_0" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference constant="true" species="dead_corona_tested_0" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw>
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <times/>
+              <ci> default </ci>
+              <ci> Corona_death_rate_constant </ci>
+              <ci> symptoms_tested_0 </ci>
+            </apply>
+          </math>
+                </kineticLaw>
+      </reaction>
+      <reaction id="re9" metaid="COPASI56" name="recovery_symptoms_t" reversible="false">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <pre>re9 in article</pre>
+          </body>
+        </notes>
+        <annotation>
+          <celldesigner:extension xmlns:celldesigner="http://www.sbml.org/2001/ns/celldesigner">
+            <celldesigner:reactionType>STATE_TRANSITION</celldesigner:reactionType>
+            <celldesigner:baseReactants>
+              <celldesigner:baseReactant species="s8" alias="sa5">
+                <celldesigner:linkAnchor position="S"/>
+              </celldesigner:baseReactant>
+            </celldesigner:baseReactants>
+            <celldesigner:baseProducts>
+              <celldesigner:baseProduct species="s14" alias="sa7">
+                <celldesigner:linkAnchor position="N"/>
+              </celldesigner:baseProduct>
+            </celldesigner:baseProducts>
+            <celldesigner:connectScheme connectPolicy="direct" rectangleIndex="0">
+              <celldesigner:listOfLineDirection>
+                <celldesigner:lineDirection index="0" value="unknown"/>
+              </celldesigner:listOfLineDirection>
+            </celldesigner:connectScheme>
+            <celldesigner:line width="1.0" color="ff000000"/>
+          </celldesigner:extension>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI56">
+              <bqbiol:is>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/ncit/C25746"/>
+	</rdf:Bag>
+	</bqbiol:is>
+	<bqbiol:hasProperty>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/ncit/C47891"/>
+	</rdf:Bag>
+	</bqbiol:hasProperty>
+	
+	<bqbiol:hasProperty>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/ncit/C173069"/>
+	</rdf:Bag>
+	</bqbiol:hasProperty>
+	</rdf:Description>
+	
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI56">
+                <bqbiol:hasProperty rdf:resource="urn:miriam:ncit:C173069"/>
+                <bqbiol:hasProperty rdf:resource="urn:miriam:ncit:C47891"/>
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2020-03-19T13:58:29Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:is rdf:resource="urn:miriam:ncit:C25746"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+              <listOfReactants>
+          <speciesReference constant="true" species="symptoms_tested_0" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference constant="true" species="recovered_tested_0" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw>
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <times/>
+              <ci> default </ci>
+              <ci> Corona_recover </ci>
+              <ci> symptoms_tested_0 </ci>
+            </apply>
+          </math>
+                </kineticLaw>
+      </reaction>
+      <reaction id="re10" metaid="COPASI57" name="recovery_symptoms_nt" reversible="false">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <pre>re10 in article</pre>
+          </body>
+        </notes>
+        <annotation>
+          <celldesigner:extension xmlns:celldesigner="http://www.sbml.org/2001/ns/celldesigner">
+            <celldesigner:reactionType>STATE_TRANSITION</celldesigner:reactionType>
+            <celldesigner:baseReactants>
+              <celldesigner:baseReactant species="s9" alias="sa6">
+                <celldesigner:linkAnchor position="N"/>
+              </celldesigner:baseReactant>
+            </celldesigner:baseReactants>
+            <celldesigner:baseProducts>
+              <celldesigner:baseProduct species="s15" alias="sa8">
+                <celldesigner:linkAnchor position="S"/>
+              </celldesigner:baseProduct>
+            </celldesigner:baseProducts>
+            <celldesigner:connectScheme connectPolicy="direct" rectangleIndex="0">
+              <celldesigner:listOfLineDirection>
+                <celldesigner:lineDirection index="0" value="unknown"/>
+              </celldesigner:listOfLineDirection>
+            </celldesigner:connectScheme>
+            <celldesigner:line width="1.0" color="ff000000"/>
+          </celldesigner:extension>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI57">
+              <bqbiol:is>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/ncit/C25746"/>
+	</rdf:Bag>
+	</bqbiol:is>
+	<bqbiol:hasProperty>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/ncit/C101887"/>
+	</rdf:Bag>
+	</bqbiol:hasProperty>
+	
+	<bqbiol:hasProperty>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/ncit/C173069"/>
+	</rdf:Bag>
+	</bqbiol:hasProperty>
+	</rdf:Description>
+	
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI57">
+                <bqbiol:hasProperty rdf:resource="urn:miriam:ncit:C101887"/>
+                <bqbiol:hasProperty rdf:resource="urn:miriam:ncit:C173069"/>
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2020-03-19T13:58:25Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:is rdf:resource="urn:miriam:ncit:C25746"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+              <listOfReactants>
+          <speciesReference constant="true" species="symptoms_nontested_0" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference constant="true" species="recovered_nontested_0" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw>
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <times/>
+              <ci> default </ci>
+              <ci> Corona_recover </ci>
+              <ci> symptoms_nontested_0 </ci>
+            </apply>
+          </math>
+                </kineticLaw>
+      </reaction>
+      <reaction id="re11" metaid="COPASI58" name="population_growth" reversible="false">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <pre>re11 in article</pre>
+          </body>
+        </notes>
+        <annotation>
+          <celldesigner:extension xmlns:celldesigner="http://www.sbml.org/2001/ns/celldesigner">
+            <celldesigner:reactionType>STATE_TRANSITION</celldesigner:reactionType>
+            <celldesigner:baseReactants>
+              <celldesigner:baseReactant species="s16" alias="sa9">
+                <celldesigner:linkAnchor position="E"/>
+              </celldesigner:baseReactant>
+            </celldesigner:baseReactants>
+            <celldesigner:baseProducts>
+              <celldesigner:baseProduct species="s6" alias="sa3">
+                <celldesigner:linkAnchor position="W"/>
+              </celldesigner:baseProduct>
+            </celldesigner:baseProducts>
+            <celldesigner:connectScheme connectPolicy="direct" rectangleIndex="0">
+              <celldesigner:listOfLineDirection>
+                <celldesigner:lineDirection index="0" value="unknown"/>
+              </celldesigner:listOfLineDirection>
+            </celldesigner:connectScheme>
+            <celldesigner:line width="5.0" color="ff000000"/>
+            <celldesigner:listOfModification>
+              <celldesigner:modification type="CATALYSIS" modifiers="s29" aliases="sa14" targetLineIndex="-1,2">
+                <celldesigner:connectScheme connectPolicy="direct">
+                  <celldesigner:listOfLineDirection>
+                    <celldesigner:lineDirection index="0" value="unknown"/>
+                  </celldesigner:listOfLineDirection>
+                </celldesigner:connectScheme>
+                <celldesigner:linkTarget species="s29" alias="sa14">
+                  <celldesigner:linkAnchor position="S"/>
+                </celldesigner:linkTarget>
+                <celldesigner:line width="3.0" color="ffff3366"/>
+              </celldesigner:modification>
+            </celldesigner:listOfModification>
+          </celldesigner:extension>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI58">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2020-03-19T14:04:23Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+              <listOfReactants>
+          <speciesReference constant="true" species="susceptible_0" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference constant="true" species="uninfected_nontested_0" stoichiometry="1"/>
+        </listOfProducts>
+        <listOfModifiers>
+          <modifierSpeciesReference species="total_population_0"/>
+        </listOfModifiers>
+        <kineticLaw>
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <times/>
+              <ci> default </ci>
+              <apply>
+                <ci> population_growth </ci>
+                <ci> susceptible_0 </ci>
+                <ci> total_population_0 </ci>
+                <ci> Birth_rate </ci>
+              </apply>
+            </apply>
+          </math>
+                </kineticLaw>
+      </reaction>
+      <reaction id="re12" metaid="COPASI59" name="death_nc_uninfected_nt" reversible="false">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <pre>re12 in article</pre>
+          </body>
+        </notes>
+        <annotation>
+          <celldesigner:extension xmlns:celldesigner="http://www.sbml.org/2001/ns/celldesigner">
+            <celldesigner:reactionType>STATE_TRANSITION</celldesigner:reactionType>
+            <celldesigner:baseReactants>
+              <celldesigner:baseReactant species="s6" alias="sa3">
+                <celldesigner:linkAnchor position="SW"/>
+              </celldesigner:baseReactant>
+            </celldesigner:baseReactants>
+            <celldesigner:baseProducts>
+              <celldesigner:baseProduct species="s25" alias="sa13">
+                <celldesigner:linkAnchor position="N"/>
+              </celldesigner:baseProduct>
+            </celldesigner:baseProducts>
+            <celldesigner:connectScheme connectPolicy="direct" rectangleIndex="0">
+              <celldesigner:listOfLineDirection>
+                <celldesigner:lineDirection index="0" value="unknown"/>
+              </celldesigner:listOfLineDirection>
+            </celldesigner:connectScheme>
+            <celldesigner:line width="5.0" color="ff000000"/>
+          </celldesigner:extension>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI59">
+	<bqbiol:is>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/ncit/C28554"/>
+	</rdf:Bag>
+	</bqbiol:is>
+	</rdf:Description>
+	
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI59">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2020-03-19T13:58:27Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:is rdf:resource="urn:miriam:ncit:C28554"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+              <listOfReactants>
+          <speciesReference constant="true" species="uninfected_nontested_0" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference constant="true" species="dead_noncorona_0" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw>
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <times/>
+              <ci> default </ci>
+              <ci> Normal_death_rate_constant_0 </ci>
+              <ci> uninfected_nontested_0 </ci>
+            </apply>
+          </math>
+                </kineticLaw>
+      </reaction>
+      <reaction id="re13" metaid="COPASI60" name="death_recovered_t" reversible="false">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <pre>re13 in article</pre>
+          </body>
+        </notes>
+        <annotation>
+          <celldesigner:extension xmlns:celldesigner="http://www.sbml.org/2001/ns/celldesigner">
+            <celldesigner:reactionType>STATE_TRANSITION</celldesigner:reactionType>
+            <celldesigner:baseReactants>
+              <celldesigner:baseReactant species="s14" alias="sa7">
+                <celldesigner:linkAnchor position="W"/>
+              </celldesigner:baseReactant>
+            </celldesigner:baseReactants>
+            <celldesigner:baseProducts>
+              <celldesigner:baseProduct species="s13" alias="sa11">
+                <celldesigner:linkAnchor position="E"/>
+              </celldesigner:baseProduct>
+            </celldesigner:baseProducts>
+            <celldesigner:connectScheme connectPolicy="direct" rectangleIndex="0">
+              <celldesigner:listOfLineDirection>
+                <celldesigner:lineDirection index="0" value="unknown"/>
+              </celldesigner:listOfLineDirection>
+            </celldesigner:connectScheme>
+            <celldesigner:line width="1.0" color="ff000000"/>
+          </celldesigner:extension>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI60">
+	<bqbiol:is>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/ncit/C28554"/>
+	</rdf:Bag>
+	</bqbiol:is>
+	</rdf:Description>
+	
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI60">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2020-03-19T14:20:08Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:is rdf:resource="urn:miriam:ncit:C28554"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+              <listOfReactants>
+          <speciesReference constant="true" species="recovered_tested_0" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference constant="true" species="dead_noncorona_0" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw>
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <times/>
+              <ci> default </ci>
+              <ci> Normal_death_rate_constant_0 </ci>
+              <ci> recovered_tested_0 </ci>
+            </apply>
+          </math>
+                </kineticLaw>
+      </reaction>
+      <reaction id="re14" metaid="COPASI61" name="death_nc_recovered_nt" reversible="false">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <pre>re14 in article</pre>
+          </body>
+        </notes>
+        <annotation>
+          <celldesigner:extension xmlns:celldesigner="http://www.sbml.org/2001/ns/celldesigner">
+            <celldesigner:reactionType>STATE_TRANSITION</celldesigner:reactionType>
+            <celldesigner:baseReactants>
+              <celldesigner:baseReactant species="s15" alias="sa8">
+                <celldesigner:linkAnchor position="W"/>
+              </celldesigner:baseReactant>
+            </celldesigner:baseReactants>
+            <celldesigner:baseProducts>
+              <celldesigner:baseProduct species="s18" alias="sa12">
+                <celldesigner:linkAnchor position="E"/>
+              </celldesigner:baseProduct>
+            </celldesigner:baseProducts>
+            <celldesigner:connectScheme connectPolicy="direct" rectangleIndex="0">
+              <celldesigner:listOfLineDirection>
+                <celldesigner:lineDirection index="0" value="unknown"/>
+              </celldesigner:listOfLineDirection>
+            </celldesigner:connectScheme>
+            <celldesigner:line width="1.0" color="ff000000"/>
+          </celldesigner:extension>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI61">
+	<bqbiol:is>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/ncit/C28554"/>
+	</rdf:Bag>
+	</bqbiol:is>
+	</rdf:Description>
+	
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI61">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2020-03-19T14:20:13Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:is rdf:resource="urn:miriam:ncit:C28554"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+              <listOfReactants>
+          <speciesReference constant="true" species="recovered_nontested_0" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference constant="true" species="dead_noncorona_0" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw>
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <times/>
+              <ci> default </ci>
+              <ci> Normal_death_rate_constant_0 </ci>
+              <ci> recovered_nontested_0 </ci>
+            </apply>
+          </math>
+                </kineticLaw>
+      </reaction>
+      <reaction id="re15" metaid="COPASI62" name="death_c_infected_t" reversible="false">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <pre>re15  in article</pre>
+          </body>
+        </notes>
+        <annotation>
+          <celldesigner:extension xmlns:celldesigner="http://www.sbml.org/2001/ns/celldesigner">
+            <celldesigner:reactionType>STATE_TRANSITION</celldesigner:reactionType>
+            <celldesigner:baseReactants>
+              <celldesigner:baseReactant species="s5" alias="sa2">
+                <celldesigner:linkAnchor position="S"/>
+              </celldesigner:baseReactant>
+            </celldesigner:baseReactants>
+            <celldesigner:baseProducts>
+              <celldesigner:baseProduct species="s13" alias="sa11">
+                <celldesigner:linkAnchor position="N"/>
+              </celldesigner:baseProduct>
+            </celldesigner:baseProducts>
+            <celldesigner:connectScheme connectPolicy="direct" rectangleIndex="0">
+              <celldesigner:listOfLineDirection>
+                <celldesigner:lineDirection index="0" value="unknown"/>
+              </celldesigner:listOfLineDirection>
+            </celldesigner:connectScheme>
+            <celldesigner:line width="1.0" color="ff000000"/>
+          </celldesigner:extension>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI62">
+	<bqbiol:is>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/ncit/C28554"/>
+	</rdf:Bag>
+	</bqbiol:is>
+	</rdf:Description>
+	
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI62">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2020-03-19T14:20:18Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:is rdf:resource="urn:miriam:ncit:C28554"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+              <listOfReactants>
+          <speciesReference constant="true" species="infected_tested_0" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference constant="true" species="dead_corona_tested_0" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw>
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <times/>
+              <ci> default </ci>
+              <ci> Corona_death_rate_constant </ci>
+              <ci> infected_tested_0 </ci>
+            </apply>
+          </math>
+                </kineticLaw>
+      </reaction>
+      <reaction id="re16" metaid="COPASI63" name="death_c_infected_nt" reversible="false">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <pre>re16 in article</pre>
+          </body>
+        </notes>
+        <annotation>
+          <celldesigner:extension xmlns:celldesigner="http://www.sbml.org/2001/ns/celldesigner">
+            <celldesigner:reactionType>STATE_TRANSITION</celldesigner:reactionType>
+            <celldesigner:baseReactants>
+              <celldesigner:baseReactant species="s4" alias="sa1">
+                <celldesigner:linkAnchor position="N"/>
+              </celldesigner:baseReactant>
+            </celldesigner:baseReactants>
+            <celldesigner:baseProducts>
+              <celldesigner:baseProduct species="s18" alias="sa12">
+                <celldesigner:linkAnchor position="S"/>
+              </celldesigner:baseProduct>
+            </celldesigner:baseProducts>
+            <celldesigner:connectScheme connectPolicy="direct" rectangleIndex="0">
+              <celldesigner:listOfLineDirection>
+                <celldesigner:lineDirection index="0" value="unknown"/>
+              </celldesigner:listOfLineDirection>
+            </celldesigner:connectScheme>
+            <celldesigner:line width="1.0" color="ff000000"/>
+          </celldesigner:extension>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI63">
+	<bqbiol:is>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/ncit/C28554"/>
+	</rdf:Bag>
+	</bqbiol:is>
+	</rdf:Description>
+	
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI63">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2020-03-19T14:20:23Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:is rdf:resource="urn:miriam:ncit:C28554"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+              <listOfReactants>
+          <speciesReference constant="true" species="infected_nontested_0" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference constant="true" species="dead_corona_nontested_0" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw>
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <times/>
+              <ci> default </ci>
+              <ci> Corona_death_rate_constant </ci>
+              <ci> infected_nontested_0 </ci>
+            </apply>
+          </math>
+                </kineticLaw>
+      </reaction>
+      <reaction id="re17" metaid="COPASI64" name="death_nc_uninfected_t" reversible="false">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <pre>re17 in article</pre>
+          </body>
+        </notes>
+        <annotation>
+          <celldesigner:extension xmlns:celldesigner="http://www.sbml.org/2001/ns/celldesigner">
+            <celldesigner:reactionType>STATE_TRANSITION</celldesigner:reactionType>
+            <celldesigner:baseReactants>
+              <celldesigner:baseReactant species="s7" alias="sa4">
+                <celldesigner:linkAnchor position="W"/>
+              </celldesigner:baseReactant>
+            </celldesigner:baseReactants>
+            <celldesigner:baseProducts>
+              <celldesigner:baseProduct species="s25" alias="sa13">
+                <celldesigner:linkAnchor position="E"/>
+              </celldesigner:baseProduct>
+            </celldesigner:baseProducts>
+            <celldesigner:connectScheme connectPolicy="direct" rectangleIndex="0">
+              <celldesigner:listOfLineDirection>
+                <celldesigner:lineDirection index="0" value="unknown"/>
+              </celldesigner:listOfLineDirection>
+            </celldesigner:connectScheme>
+            <celldesigner:line width="1.0" color="ff000000"/>
+          </celldesigner:extension>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI64">
+	<bqbiol:is>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/ncit/C28554"/>
+	</rdf:Bag>
+	</bqbiol:is>
+	</rdf:Description>
+	
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI64">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2020-03-19T14:20:28Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:is rdf:resource="urn:miriam:ncit:C28554"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+              <listOfReactants>
+          <speciesReference constant="true" species="uninfected_tested_0" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference constant="true" species="dead_noncorona_0" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw>
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <times/>
+              <ci> default </ci>
+              <ci> Normal_death_rate_constant_0 </ci>
+              <ci> uninfected_tested_0 </ci>
+            </apply>
+          </math>
+                </kineticLaw>
+      </reaction>
+      <reaction id="re18" metaid="COPASI65" name="death_c_symptoms_nt" reversible="false">
+        <notes>
+          <body xmlns="http://www.w3.org/1999/xhtml">
+            <pre>re18 in article</pre>
+          </body>
+        </notes>
+        <annotation>
+          <celldesigner:extension xmlns:celldesigner="http://www.sbml.org/2001/ns/celldesigner">
+            <celldesigner:reactionType>STATE_TRANSITION</celldesigner:reactionType>
+            <celldesigner:baseReactants>
+              <celldesigner:baseReactant species="s9" alias="sa6">
+                <celldesigner:linkAnchor position="NW"/>
+              </celldesigner:baseReactant>
+            </celldesigner:baseReactants>
+            <celldesigner:baseProducts>
+              <celldesigner:baseProduct species="s18" alias="sa12">
+                <celldesigner:linkAnchor position="SE"/>
+              </celldesigner:baseProduct>
+            </celldesigner:baseProducts>
+            <celldesigner:connectScheme connectPolicy="direct" rectangleIndex="0">
+              <celldesigner:listOfLineDirection>
+                <celldesigner:lineDirection index="0" value="unknown"/>
+              </celldesigner:listOfLineDirection>
+            </celldesigner:connectScheme>
+            <celldesigner:line width="1.0" color="ff000000"/>
+          </celldesigner:extension>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/" xmlns:bqmodel="http://biomodels.net/model-qualifiers/">
+            <rdf:Description rdf:about="#COPASI65">
+	<bqbiol:is>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/ncit/C28554"/>
+	</rdf:Bag>
+	</bqbiol:is>
+	</rdf:Description>
+	
+          </rdf:RDF>
+          <COPASI xmlns="http://www.copasi.org/static/sbml">
+            <rdf:RDF xmlns:CopasiMT="http://www.copasi.org/RDF/MiriamTerms#" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+              <rdf:Description rdf:about="#COPASI65">
+                <dcterms:created>
+                  <rdf:Description>
+                    <dcterms:W3CDTF>2020-03-19T14:20:32Z</dcterms:W3CDTF>
+                  </rdf:Description>
+                </dcterms:created>
+                <CopasiMT:is rdf:resource="urn:miriam:ncit:C28554"/>
+              </rdf:Description>
+            </rdf:RDF>
+          </COPASI>
+        </annotation>
+              <listOfReactants>
+          <speciesReference constant="true" species="symptoms_nontested_0" stoichiometry="1"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference constant="true" species="dead_corona_nontested_0" stoichiometry="1"/>
+        </listOfProducts>
+        <kineticLaw>
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <times/>
+              <ci> default </ci>
+              <ci> Corona_death_rate_constant </ci>
+              <ci> symptoms_nontested_0 </ci>
+            </apply>
+          </math>
+                </kineticLaw>
+      </reaction>
+    </listOfReactions>
+  </model>
+</sbml>

--- a/src/sbml/packages/layout/extension/LayoutSBMLDocumentPlugin.cpp
+++ b/src/sbml/packages/layout/extension/LayoutSBMLDocumentPlugin.cpp
@@ -115,6 +115,10 @@ LayoutSBMLDocumentPlugin::readAttributes (const XMLAttributes& attributes,
 {
   // for now don't read the required flag for L2 models 
   if (getSBMLDocument() != NULL && getSBMLDocument()->getLevel() < 3) return;
+
+  // skip reading the required flag for L2 layout on l3 models where we would remove it before writing
+  if (mURI == LayoutExtension::getXmlnsL2() && getSBMLDocument() != NULL && getSBMLDocument()->getLevel() > 2) 
+    return;
   
   unsigned int numErrs = getErrorLog()->getNumErrors();
   XMLTriple tripleRequired("required", mURI, getPrefix());

--- a/src/sbml/packages/layout/sbml/Layout.cpp
+++ b/src/sbml/packages/layout/sbml/Layout.cpp
@@ -2049,7 +2049,7 @@ ListOfLayouts::writeXMLNS (XMLOutputStream& stream) const
     {
       xmlns.add(LayoutExtension::getXmlnsL3V1V1(),prefix);
     }
-    if (thisxmlns && thisxmlns->hasURI(LayoutExtension::getXmlnsL2()))
+    else if (thisxmlns && thisxmlns->hasURI(LayoutExtension::getXmlnsL2()))
     {
       xmlns.add(LayoutExtension::getXmlnsL2(),prefix);
     }


### PR DESCRIPTION
## Description
the sbml document removes all L2 namespaces of packages from the document. However, the required flag was still written out. The commit does not read the required flag for L2 annotations. 

## Motivation and Context
fixes #417 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Change in documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have updated all documentation necessary.
- [ ] I have checked spelling in (new) comments.

## Testing
- [X] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested -->

