### PR TITLE
Add html/markdown translators.

### DIFF
--- a/.github/workflows/brief.yml
+++ b/.github/workflows/brief.yml
@@ -30,7 +30,7 @@ jobs:
         package_option: ["-DWITH_ALL_PACKAGES=ON"]
         language_bindings:
           [ "-DWITH_JAVA=True -DWITH_CSHARP=True"]
-        cpp_standard: [11, 20]
+        cpp_standard: [98, 20]
     runs-on: ${{ matrix.platform }}
 
     steps:
@@ -190,7 +190,7 @@ jobs:
         strict: ["True"]
         with_examples: ["True"]
         package_option: ["-DWITH_STABLE_PACKAGES=ON"]
-        cpp_standard: [11, 20]
+        cpp_standard: [98, 20]
         language_bindings:
           ["-DWITH_JAVA=True -DWITH_PYTHON=True"]
         container: ["quay.io/pypa/manylinux_2_28_x86_64"]

--- a/.github/workflows/brief.yml
+++ b/.github/workflows/brief.yml
@@ -30,7 +30,7 @@ jobs:
         package_option: ["-DWITH_ALL_PACKAGES=ON"]
         language_bindings:
           [ "-DWITH_JAVA=True -DWITH_CSHARP=True"]
-        cpp_standard: [98, 20]
+        cpp_standard: [11, 20]
     runs-on: ${{ matrix.platform }}
 
     steps:
@@ -190,7 +190,7 @@ jobs:
         strict: ["True"]
         with_examples: ["True"]
         package_option: ["-DWITH_STABLE_PACKAGES=ON"]
-        cpp_standard: [98, 20]
+        cpp_standard: [11, 20]
         language_bindings:
           ["-DWITH_JAVA=True -DWITH_PYTHON=True"]
         container: ["quay.io/pypa/manylinux_2_28_x86_64"]

--- a/.github/workflows/brief.yml
+++ b/.github/workflows/brief.yml
@@ -160,7 +160,7 @@ jobs:
       - name: Build
         working-directory: ${{runner.workspace}}/build
         shell: bash
-        run: cmake --build . --config $BUILD_TYPE
+        run: cmake --build VERBOSE=1 . --config $BUILD_TYPE
 
       ### run tests ###
       - name: Test

--- a/.github/workflows/brief.yml
+++ b/.github/workflows/brief.yml
@@ -160,7 +160,7 @@ jobs:
       - name: Build
         working-directory: ${{runner.workspace}}/build
         shell: bash
-        run: cmake --build --verbose . --config $BUILD_TYPE
+        run: cmake --build . --config $BUILD_TYPE --verbose
 
       ### run tests ###
       - name: Test

--- a/.github/workflows/brief.yml
+++ b/.github/workflows/brief.yml
@@ -160,7 +160,7 @@ jobs:
       - name: Build
         working-directory: ${{runner.workspace}}/build
         shell: bash
-        run: cmake --build VERBOSE=1 . --config $BUILD_TYPE
+        run: cmake --build --verbose . --config $BUILD_TYPE
 
       ### run tests ###
       - name: Test

--- a/.github/workflows/store-artefact.yml
+++ b/.github/workflows/store-artefact.yml
@@ -118,7 +118,7 @@ jobs:
           -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
           -DCMAKE_C_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} \
           -DCMAKE_CXX_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} \
-          -DCMAKE_CXX_STANDARD=11 \
+          -DCMAKE_CXX_STANDARD=98 \
           -DWITH_CHECK=True \
           -DWITH_CPP_NAMESPACE=${{matrix.with_namespace}} \
           -DLIBSBML_USE_STRICT_INCLUDES=${{matrix.strict}} \
@@ -235,7 +235,7 @@ jobs:
         strict: ["True"]
         with_examples: ["True"]
         package_option: ["-DWITH_ALL_PACKAGES=ON", "-DWITH_STABLE_PACKAGES=ON"]
-        cpp_standard: [11]
+        cpp_standard: [98]
         language_bindings:
           ["-DWITH_JAVA=True -DWITH_PYTHON=True"]
         container: ["quay.io/pypa/manylinux_2_28_x86_64"]

--- a/.github/workflows/store-artefact.yml
+++ b/.github/workflows/store-artefact.yml
@@ -118,7 +118,7 @@ jobs:
           -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
           -DCMAKE_C_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} \
           -DCMAKE_CXX_COMPILER_LAUNCHER=${COMPILER_LAUNCHER} \
-          -DCMAKE_CXX_STANDARD=98 \
+          -DCMAKE_CXX_STANDARD=11 \
           -DWITH_CHECK=True \
           -DWITH_CPP_NAMESPACE=${{matrix.with_namespace}} \
           -DLIBSBML_USE_STRICT_INCLUDES=${{matrix.strict}} \
@@ -235,7 +235,7 @@ jobs:
         strict: ["True"]
         with_examples: ["True"]
         package_option: ["-DWITH_ALL_PACKAGES=ON", "-DWITH_STABLE_PACKAGES=ON"]
-        cpp_standard: [98]
+        cpp_standard: [11]
         language_bindings:
           ["-DWITH_JAVA=True -DWITH_PYTHON=True"]
         container: ["quay.io/pypa/manylinux_2_28_x86_64"]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@
 #
 ###############################################################################
 
-cmake_minimum_required(VERSION 2.8.12...3.19)
+cmake_minimum_required(VERSION 3.1...3.19)
 project(libsbml)
 
 set(LIBSBML_ROOT_SOURCE_DIR "${CMAKE_CURRENT_SOURCE_DIR}" CACHE PATH

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -463,6 +463,9 @@ if (NOT LIBSBML_SKIP_SHARED_LIBRARY)
 
 add_library (${LIBSBML_LIBRARY} SHARED ${LIBSBML_SOURCES} )
 
+# When we included the 'maddy' library, we needed features added in c++11.
+target_compile_features(${LIBSBML_LIBRARY} PUBLIC cxx_std_11)
+
 if (LIBSBML_SHARED_VERSION)
   SET_TARGET_PROPERTIES(${LIBSBML_LIBRARY} PROPERTIES
                         SOVERSION ${LIBSBML_VERSION_MAJOR}
@@ -511,6 +514,9 @@ endif()
 
 if (NOT LIBSBML_SKIP_STATIC_LIBRARY)
 add_library (${LIBSBML_LIBRARY}-static STATIC ${LIBSBML_SOURCES} )
+
+# When we included the 'maddy' library, we needed features added in c++11.
+target_compile_features(${LIBSBML_LIBRARY}-static PUBLIC cxx_std_11)
 
 if (WIN32 AND NOT CYGWIN)
     # don't decorate static library 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -196,7 +196,7 @@ configure_file (
 # mark header files for installation
 #
 
-foreach(dir annotation common compress conversion extension math units util validator xml  )
+foreach(dir annotation common compress conversion extension html2md maddy math units util validator xml  )
 
     file(GLOB header_files "${CMAKE_CURRENT_SOURCE_DIR}/sbml/${dir}/*.h")
     install(FILES ${header_files} DESTINATION include/sbml/${dir})
@@ -284,7 +284,7 @@ macro(ADD_FUNCTION directory)
 
 endmacro(ADD_FUNCTION)
 
-foreach (directory annotation common conversion extension sbml math
+foreach (directory annotation common conversion extension sbml html2md maddy math
                    units util validator validator/constraints)
 
 	ADD_FUNCTION(${directory})

--- a/src/bindings/swig/libsbml.h
+++ b/src/bindings/swig/libsbml.h
@@ -141,6 +141,7 @@
 #include <sbml/extension/SBMLExtensionRegistry.h>
 
 #include <sbml/util/CallbackRegistry.h>
+#include <sbml/util/util.h>
 
 #include "ListWrapper.h"
 

--- a/src/bindings/swig/libsbml.i
+++ b/src/bindings/swig/libsbml.i
@@ -783,6 +783,7 @@ as a comment in the output stream.
 %include <sbml/util/IdList.h>
 %include <sbml/util/IdentifierTransformer.h>
 %include <sbml/util/ElementFilter.h>
+%include <sbml/util/util.h>
 
 %include <sbml/SBMLReader.h>
 %include sbml/SBMLWriter.h

--- a/src/sbml/Constraint.cpp
+++ b/src/sbml/Constraint.cpp
@@ -56,9 +56,6 @@
 
 #include <sbml/util/util.h>
 
-#include <sbml/maddy/parser.h>
-#include <sbml/html2md/html2md.h>
-
 
 /** @cond doxygenIgnored */
 using namespace std;
@@ -206,7 +203,7 @@ Constraint::getMessageString () const
 std::string
 Constraint::getMessageMarkdown() const
 {
-    string ret = html2md::Convert(getMessageString());
+    string ret = util_html_to_markdown(getMessageString());
     while (ret.size() && ret[ret.size() - 1] == '\n') {
         ret.pop_back();
     }
@@ -378,20 +375,11 @@ Constraint::setMessage (const std::string& message,
 int
 Constraint::setMessageFromMarkdown(const std::string& markdown)
 {
-    std::stringstream markdownInput(markdown);
-
-    // If we want to use the maddy config:
-    //std::shared_ptr<maddy::ParserConfig> config = std::make_shared<maddy::ParserConfig>();
-    //config->enabledParsers &= ~maddy::types::EMPHASIZED_PARSER; // disable emphasized parser
-    //config->enabledParsers |= maddy::types::HTML_PARSER; // do not wrap HTML in paragraph
-    //std::shared_ptr<maddy::Parser> parser = std::make_shared<maddy::Parser>(config);
-
-    maddy::Parser parser;
-    std::string htmlOutput = parser.Parse(markdownInput);
+    std::string htmlOutput = util_markdown_to_html(markdown);
     if (setMessage(htmlOutput, true) == LIBSBML_OPERATION_SUCCESS) {
         return LIBSBML_OPERATION_SUCCESS;
     }
-    htmlOutput = "<body  xmlns=\"http://www.w3.org/1999/xhtml\" >\n" + htmlOutput + "\n</body>";
+    htmlOutput = "<body xmlns=\"http://www.w3.org/1999/xhtml\">\n" + htmlOutput + "\n</body>";
     return setMessage(htmlOutput, true);
 }
 

--- a/src/sbml/Constraint.cpp
+++ b/src/sbml/Constraint.cpp
@@ -56,6 +56,10 @@
 
 #include <sbml/util/util.h>
 
+#include <sbml/maddy/parser.h>
+#include <sbml/html2md/html2md.h>
+
+
 /** @cond doxygenIgnored */
 using namespace std;
 /** @endcond */
@@ -193,6 +197,20 @@ Constraint::getMessageString () const
   {
     return "";
   }
+}
+
+
+/*
+ * @return the message for this Constraint.
+ */
+std::string
+Constraint::getMessageMarkdown() const
+{
+    string ret = html2md::Convert(getMessageString());
+    while (ret.size() && ret[ret.size() - 1] == '\n') {
+        ret.pop_back();
+    }
+    return ret;
 }
 
 
@@ -357,6 +375,25 @@ Constraint::setMessage (const std::string& message,
   return success;
 }
 
+int
+Constraint::setMessageFromMarkdown(const std::string& markdown)
+{
+    std::stringstream markdownInput(markdown);
+
+    // If we want to use the maddy config:
+    //std::shared_ptr<maddy::ParserConfig> config = std::make_shared<maddy::ParserConfig>();
+    //config->enabledParsers &= ~maddy::types::EMPHASIZED_PARSER; // disable emphasized parser
+    //config->enabledParsers |= maddy::types::HTML_PARSER; // do not wrap HTML in paragraph
+    //std::shared_ptr<maddy::Parser> parser = std::make_shared<maddy::Parser>(config);
+
+    maddy::Parser parser;
+    std::string htmlOutput = parser.Parse(markdownInput);
+    if (setMessage(htmlOutput, true) == LIBSBML_OPERATION_SUCCESS) {
+        return LIBSBML_OPERATION_SUCCESS;
+    }
+    htmlOutput = "<body  xmlns=\"http://www.w3.org/1999/xhtml\" >\n" + htmlOutput + "\n</body>";
+    return setMessage(htmlOutput, true);
+}
 
 /*
  * Sets the math of this Constraint to a copy of the given
@@ -1186,6 +1223,15 @@ Constraint_getMessageString (const Constraint_t *c)
 
 
 LIBSBML_EXTERN
+char*
+Constraint_getMessageMarkdown(const Constraint_t* c)
+{
+    return (c != NULL && c->isSetMessage()) ?
+        safe_strdup(c->getMessageMarkdown().c_str()) : NULL;
+}
+
+
+LIBSBML_EXTERN
 const ASTNode_t *
 Constraint_getMath (const Constraint_t *c)
 {
@@ -1221,6 +1267,36 @@ Constraint_setMessage (Constraint_t *c, const XMLNode_t *xhtml)
   {
     return LIBSBML_INVALID_OBJECT;
   }
+}
+
+
+LIBSBML_EXTERN
+int
+Constraint_setMessageString(Constraint_t* c, const char* message)
+{
+    if (c != NULL)
+    {
+        return c->setMessage(message);
+    }
+    else
+    {
+        return LIBSBML_INVALID_OBJECT;
+    }
+}
+
+
+LIBSBML_EXTERN
+int
+Constraint_setMessageFromMarkdown(Constraint_t* c, const char* markdown)
+{
+    if (c != NULL)
+    {
+        return c->setMessageFromMarkdown(markdown);
+    }
+    else
+    {
+        return LIBSBML_INVALID_OBJECT;
+    }
 }
 
 

--- a/src/sbml/Constraint.h
+++ b/src/sbml/Constraint.h
@@ -250,6 +250,14 @@ public:
    */
   virtual std::string getMessageString () const;
 
+  /**
+   * Get the message string, if any, associated with this Constraint, in markdown form
+   *
+   * @return the message for this Constraint, as a markdown string,
+   * as translated by html2md (https://github.com/tim-gromeyer/html2md/)
+   */
+  std::string getMessageMarkdown() const;
+
 
   /**
    * Get the mathematical expression of this Constraint
@@ -310,6 +318,21 @@ public:
    */
   virtual int setMessage (const std::string& message, bool addXHTMLMarkup = false);
 
+  /**
+   * Sets the message of this Constraint from markdown input.
+   * 
+   * The markdown input is translated using the 'maddy' library.  A
+   * description of how the text is translated to HTML can be found at
+   * https://github.com/progsource/maddy/blob/master/docs/definitions.md
+   *
+   * @param markdown a markdown-formatted string that is to be used as the content of the
+   * "message" subelement of this object.
+   *
+   * @copydetails doc_returns_success_code
+   * @li @sbmlconstant{LIBSBML_OPERATION_SUCCESS, OperationReturnValues_t}
+   * @li @sbmlconstant{LIBSBML_INVALID_OBJECT, OperationReturnValues_t}
+   */
+  int setMessageFromMarkdown(const std::string& markdown);
 
   /**
    * Sets the mathematical expression of this Constraint to a copy of the
@@ -986,6 +1009,23 @@ Constraint_getMessageString (const Constraint_t *c);
 
 
 /**
+ * Get the message string, if any, associated with this Constraint_t, in markdown form
+ *
+ * @param c the Constraint_t structure.
+ *
+ * @return the message for this Constraint_t, as a markdown-formatted string (char*).
+ * @c NULL is returned if the message is not set.
+ *
+ * @note returned char* should be freed with safe_free() by the caller.
+ *
+ * @memberof Constraint_t
+ */
+LIBSBML_EXTERN
+char*
+Constraint_getMessageMarkdown(const Constraint_t* c);
+
+
+/**
  * Get the mathematical expression of this Constraint_t
  *
  * @param c the Constraint_t structure.
@@ -1047,6 +1087,42 @@ Constraint_isSetMath (const Constraint_t *c);
 LIBSBML_EXTERN
 int
 Constraint_setMessage (Constraint_t *c, const XMLNode_t* xhtml);
+
+
+/**
+ * Sets the message of this Constraint_t.
+ *
+ * @param c the Constraint_t structure.
+ *
+ * @param message a string containing XHTML content.
+ *
+ * @copydetails doc_returns_success_code
+ * @li @sbmlconstant{LIBSBML_OPERATION_SUCCESS, OperationReturnValues_t}
+ * @li @sbmlconstant{LIBSBML_INVALID_OBJECT, OperationReturnValues_t}
+ *
+ * @memberof Constraint_t
+ */
+LIBSBML_EXTERN
+int
+Constraint_setMessageString(Constraint_t* c, const char* message);
+
+
+/**
+ * Sets the message of this Constraint_t from a markdown-formatted string.
+ *
+ * @param c the Constraint_t structure.
+ *
+ * @param markdown a string containing the message in markdown format.
+ *
+ * @copydetails doc_returns_success_code
+ * @li @sbmlconstant{LIBSBML_OPERATION_SUCCESS, OperationReturnValues_t}
+ * @li @sbmlconstant{LIBSBML_INVALID_OBJECT, OperationReturnValues_t}
+ *
+ * @memberof Constraint_t
+ */
+LIBSBML_EXTERN
+int
+Constraint_setMessageFromMarkdown(Constraint_t* c, const char* markdown);
 
 
 /**

--- a/src/sbml/Constraint.h
+++ b/src/sbml/Constraint.h
@@ -994,6 +994,9 @@ Constraint_getMessage (const Constraint_t *c);
 /**
  * Get the message string, if any, associated with this Constraint_t
  *
+ * The string is owned by the caller and should be freed
+ * (with free()) when no longer needed.
+ *
  * @param c the Constraint_t structure.
  * 
  * @return the message for this Constraint_t, as a string (char*).
@@ -1009,8 +1012,12 @@ Constraint_getMessageString (const Constraint_t *c);
 
 
 /**
- * Get the message string, if any, associated with this Constraint_t, in markdown form
+ * Get the message string, if any, associated with this Constraint_t, in markdown form.
  *
+ * The string is owned by the caller and should be freed
+ * (with free()) when no longer needed.  The HTML is translated
+ * by 'html2md', https://github.com/tim-gromeyer/html2md/
+ * 
  * @param c the Constraint_t structure.
  *
  * @return the message for this Constraint_t, as a markdown-formatted string (char*).
@@ -1109,6 +1116,8 @@ Constraint_setMessageString(Constraint_t* c, const char* message);
 
 /**
  * Sets the message of this Constraint_t from a markdown-formatted string.
+ *
+ * Markdown parser is 'maddy' (https://github.com/progsource/maddy).
  *
  * @param c the Constraint_t structure.
  *

--- a/src/sbml/SBase.cpp
+++ b/src/sbml/SBase.cpp
@@ -70,8 +70,6 @@
 #include <sbml/extension/SBMLExtensionException.h>
 #include <sbml/util/CallbackRegistry.h>
 
-#include <sbml/maddy/parser.h>
-#include <sbml/html2md/html2md.h>
 
 /** @cond doxygenIgnored */
 using namespace std;
@@ -788,7 +786,7 @@ SBase::getNotesString() const
 std::string
 SBase::getNotesMarkdown() const
 {
-    string ret = html2md::Convert(getNotesString());
+    string ret = util_html_to_markdown(getNotesString());
     while (ret.size() && ret[ret.size() - 1] == '\n') {
         ret.pop_back();
     }
@@ -1930,20 +1928,11 @@ SBase::setNotes(const std::string& notes, bool addXHTMLMarkup)
 
 int SBase::setNotesFromMarkdown(const std::string& markdown)
 {
-    std::stringstream markdownInput(markdown);
-
-    // If we want to use the maddy config:
-    //std::shared_ptr<maddy::ParserConfig> config = std::make_shared<maddy::ParserConfig>();
-    //config->enabledParsers &= ~maddy::types::EMPHASIZED_PARSER; // disable emphasized parser
-    //config->enabledParsers |= maddy::types::HTML_PARSER; // do not wrap HTML in paragraph
-    //std::shared_ptr<maddy::Parser> parser = std::make_shared<maddy::Parser>(config);
-
-    maddy::Parser parser;
-    std::string htmlOutput = parser.Parse(markdownInput);
+    std::string htmlOutput = util_markdown_to_html(markdown);
     if (setNotes(htmlOutput, true) == LIBSBML_OPERATION_SUCCESS) {
         return LIBSBML_OPERATION_SUCCESS;
     }
-    htmlOutput = "<body  xmlns=\"http://www.w3.org/1999/xhtml\" >\n" + htmlOutput + "\n</body>";
+    htmlOutput = "<body xmlns=\"http://www.w3.org/1999/xhtml\">\n" + htmlOutput + "\n</body>";
     return setNotes(htmlOutput, true);
 }
 

--- a/src/sbml/SBase.cpp
+++ b/src/sbml/SBase.cpp
@@ -40,6 +40,7 @@
  * ---------------------------------------------------------------------- -->*/
 
 #include <sstream>
+#include <memory>
 
 #include <sbml/xml/XMLError.h>
 #include <sbml/xml/XMLErrorLog.h>
@@ -68,6 +69,9 @@
 #include <sbml/extension/SBMLExtensionRegistry.h>
 #include <sbml/extension/SBMLExtensionException.h>
 #include <sbml/util/CallbackRegistry.h>
+
+#include <sbml/maddy/parser.h>
+#include <sbml/html2md/html2md.h>
 
 /** @cond doxygenIgnored */
 using namespace std;
@@ -778,6 +782,17 @@ std::string
 SBase::getNotesString() const
 {
   return XMLNode::convertXMLNodeToString(mNotes);
+}
+
+
+std::string
+SBase::getNotesMarkdown() const
+{
+    string ret = html2md::Convert(getNotesString());
+    while (ret.size() && ret[ret.size() - 1] == '\n') {
+        ret.pop_back();
+    }
+    return ret;
 }
 
 
@@ -1911,6 +1926,25 @@ SBase::setNotes(const std::string& notes, bool addXHTMLMarkup)
     }
   }
   return success;
+}
+
+int SBase::setNotesFromMarkdown(const std::string& markdown)
+{
+    std::stringstream markdownInput(markdown);
+
+    // If we want to use the maddy config:
+    //std::shared_ptr<maddy::ParserConfig> config = std::make_shared<maddy::ParserConfig>();
+    //config->enabledParsers &= ~maddy::types::EMPHASIZED_PARSER; // disable emphasized parser
+    //config->enabledParsers |= maddy::types::HTML_PARSER; // do not wrap HTML in paragraph
+    //std::shared_ptr<maddy::Parser> parser = std::make_shared<maddy::Parser>(config);
+
+    maddy::Parser parser;
+    std::string htmlOutput = parser.Parse(markdownInput);
+    if (setNotes(htmlOutput, true) == LIBSBML_OPERATION_SUCCESS) {
+        return LIBSBML_OPERATION_SUCCESS;
+    }
+    htmlOutput = "<body  xmlns=\"http://www.w3.org/1999/xhtml\" >\n" + htmlOutput + "\n</body>";
+    return setNotes(htmlOutput, true);
 }
 
 
@@ -7575,6 +7609,12 @@ SBase_getNotesString (SBase_t *sb)
 }
 
 
+char* SBase_getNotesMarkdown(SBase_t* sb)
+{
+    return (sb != NULL && sb->isSetNotes()) ?
+        safe_strdup(sb->getNotesMarkdown().c_str()) : NULL;
+}
+
 LIBSBML_EXTERN
 XMLNode_t *
 SBase_getAnnotation (SBase_t *sb)
@@ -7714,6 +7754,17 @@ SBase_setNotes (SBase_t *sb, const XMLNode_t *notes)
     return sb->setNotes(notes);
   else
     return LIBSBML_INVALID_OBJECT;
+}
+
+
+LIBSBML_EXTERN
+int
+SBase_setNotesFromMarkdown(SBase_t* sb, const char* markdown)
+{
+    if (sb != NULL)
+        return sb->setNotesFromMarkdown(markdown);
+    else
+        return LIBSBML_INVALID_OBJECT;
 }
 
 

--- a/src/sbml/SBase.cpp
+++ b/src/sbml/SBase.cpp
@@ -40,7 +40,6 @@
  * ---------------------------------------------------------------------- -->*/
 
 #include <sstream>
-#include <memory>
 
 #include <sbml/xml/XMLError.h>
 #include <sbml/xml/XMLErrorLog.h>
@@ -69,7 +68,6 @@
 #include <sbml/extension/SBMLExtensionRegistry.h>
 #include <sbml/extension/SBMLExtensionException.h>
 #include <sbml/util/CallbackRegistry.h>
-
 
 /** @cond doxygenIgnored */
 using namespace std;

--- a/src/sbml/SBase.h
+++ b/src/sbml/SBase.h
@@ -4556,7 +4556,9 @@ SBase_setNotes (SBase_t *sb, const XMLNode_t *notes);
  *
  * @memberof SBase_t
  */
-int SBase_setNotesFromMarkdown(SBase_t* sb, const char* markdown);
+LIBSBML_EXTERN
+int 
+SBase_setNotesFromMarkdown(SBase_t* sb, const char* markdown);
 
 
 /**

--- a/src/sbml/SBase.h
+++ b/src/sbml/SBase.h
@@ -504,9 +504,11 @@ public:
    * tree structure composed of XMLNode objects.
    *
    * @see getNotesString()
+   * @see getNotesMarkdown()
    * @see isSetNotes()
    * @see setNotes(const XMLNode* notes)
    * @see setNotes(const std::string& notes, bool addXHTMLMarkup)
+   * @see setNotesFromMarkdown(const std::string& markdown)
    * @see appendNotes(const XMLNode* notes)
    * @see appendNotes(const std::string& notes)
    * @see unsetNotes()
@@ -532,9 +534,11 @@ public:
    * tree structure composed of XMLNode objects.
    *
    * @see getNotesString()
+   * @see getNotesMarkdown()
    * @see isSetNotes()
    * @see setNotes(const XMLNode* notes)
    * @see setNotes(const std::string& notes, bool addXHTMLMarkup)
+   * @see setNotesFromMarkdown(const std::string& markdown)
    * @see appendNotes(const XMLNode* notes)
    * @see appendNotes(const std::string& notes)
    * @see unsetNotes()
@@ -558,9 +562,11 @@ public:
    * string.
    *
    * @see getNotes()
+   * @see getNotesMarkdown()
    * @see isSetNotes()
    * @see setNotes(const XMLNode* notes)
    * @see setNotes(const std::string& notes, bool addXHTMLMarkup)
+   * @see setNotesFromMarkdown(const std::string& markdown)
    * @see appendNotes(const XMLNode* notes)
    * @see appendNotes(const std::string& notes)
    * @see unsetNotes()
@@ -584,6 +590,34 @@ public:
    * string.
    *
    * @see getNotes()
+   * @see getNotesMarkdown()
+   * @see isSetNotes()
+   * @see setNotes(const XMLNode* notes)
+   * @see setNotes(const std::string& notes, bool addXHTMLMarkup)
+   * @see setNotesFromMarkdown(const std::string& markdown)
+   * @see appendNotes(const XMLNode* notes)
+   * @see appendNotes(const std::string& notes)
+   * @see unsetNotes()
+   * @see SyntaxChecker::hasExpectedXHTMLSyntax(@if java XMLNode@endif)
+   */
+  std::string getNotesString () const;
+
+  /**
+   * Returns the markdown version of the "notes" subelement of this object.
+   * The HTML is translated by 'html2md', https://github.com/tim-gromeyer/html2md/
+   *
+   * @copydetails doc_what_are_notes
+   *
+   * For an alternative method of accessing the notes, see getNotes(),
+   * which returns the content as an XMLNode tree structure.  Depending on
+   * an application's needs, one or the other method may be more
+   * convenient.
+   *
+   * @return the string (char*) representing the markdown version of the notes 
+   * from this structure.
+   *
+   * @see getNotes()
+   * @see getNotesString()
    * @see isSetNotes()
    * @see setNotes(const XMLNode* notes)
    * @see setNotes(const std::string& notes, bool addXHTMLMarkup)
@@ -592,7 +626,7 @@ public:
    * @see unsetNotes()
    * @see SyntaxChecker::hasExpectedXHTMLSyntax(@if java XMLNode@endif)
    */
-  std::string getNotesString () const;
+  std::string getNotesMarkdown() const;
 
 
   /**
@@ -1129,8 +1163,10 @@ public:
    * 
    * @see getNotes()
    * @see getNotesString()
+   * @see getNotesMarkdown()
    * @see setNotes(const XMLNode* notes)
    * @see setNotes(const std::string& notes, bool addXHTMLMarkup)
+   * @see setNotesFromMarkdown(const std::string& markdown)
    * @see appendNotes(const XMLNode* notes)
    * @see appendNotes(const std::string& notes)
    * @see unsetNotes()
@@ -1565,8 +1601,10 @@ public:
    * @li @sbmlconstant{LIBSBML_INVALID_OBJECT, OperationReturnValues_t}
    *
    * @see getNotesString()
+   * @see getNotesMarkdown()
    * @see isSetNotes()
    * @see setNotes(const std::string& notes, bool addXHTMLMarkup)
+   * @see setNotesFromMarkdown(const std::string& markdown)
    * @see appendNotes(const XMLNode* notes)
    * @see appendNotes(const std::string& notes)
    * @see unsetNotes()
@@ -1656,14 +1694,39 @@ s.setNotes("<body xmlns='http://www.w3.org/1999/xhtml'><p>here is my note</p></b
    * @li @sbmlconstant{LIBSBML_OPERATION_FAILED, OperationReturnValues_t}
    *
    * @see getNotesString()
+   * @see getNotesMarkdown()
    * @see isSetNotes()
    * @see setNotes(const XMLNode* notes)
+   * @see setNotesFromMarkdown(const std::string& markdown)
    * @see appendNotes(const XMLNode* notes)
    * @see appendNotes(const std::string& notes)
    * @see unsetNotes()
    * @see SyntaxChecker::hasExpectedXHTMLSyntax(@if java XMLNode@endif)
    */
   int setNotes(const std::string& notes, bool addXHTMLMarkup = false);
+
+
+  /**
+   * Sets the value of the "notes" subelement of this SBML object using a 
+   * markdown-formatted string.
+   *
+   * The content of @p notes is translated to HTML, and any existing 
+   * content of this object's "notes" subelement is deleted.
+   *
+   * The optional SBML element named "notes", present on every major SBML
+   * component type, is intended as a place for storing optional
+   * information intended to be seen by humans.  An example use of the
+   * "notes" element would be to contain formatted user comments about the
+   * model element in which the "notes" element is enclosed.  Every object
+   * derived directly or indirectly from type SBase can have a separate
+   * value for "notes", allowing users considerable freedom when adding
+   * comments to their models.
+   *
+   * The markdown input is translated using the 'maddy' library.  A
+   * description of how the text is translated to HTML can be found at
+   * https://github.com/progsource/maddy/blob/master/docs/definitions.md
+   */
+int setNotesFromMarkdown(const std::string& markdown);
 
 
   /**
@@ -1700,9 +1763,11 @@ s.setNotes("<body xmlns='http://www.w3.org/1999/xhtml'><p>here is my note</p></b
    * @li @sbmlconstant{LIBSBML_OPERATION_FAILED, OperationReturnValues_t}
    *
    * @see getNotesString()
+   * @see getNotesMarkdown()
    * @see isSetNotes()
    * @see setNotes(const XMLNode* notes)
    * @see setNotes(const std::string& notes, bool addXHTMLMarkup)
+   * @see setNotesFromMarkdown(const std::string& markdown)
    * @see appendNotes(const std::string& notes)
    * @see unsetNotes()
    * @see SyntaxChecker::hasExpectedXHTMLSyntax(@if java XMLNode@endif)
@@ -1744,9 +1809,11 @@ s.setNotes("<body xmlns='http://www.w3.org/1999/xhtml'><p>here is my note</p></b
    * @li @sbmlconstant{LIBSBML_OPERATION_FAILED, OperationReturnValues_t}
    *
    * @see getNotesString()
+   * @see getNotesMarkdown()
    * @see isSetNotes()
    * @see setNotes(const XMLNode* notes)
    * @see setNotes(const std::string& notes, bool addXHTMLMarkup)
+   * @see setNotesFromMarkdown(const std::string& markdown)
    * @see appendNotes(const XMLNode* notes)
    * @see unsetNotes()
    * @see SyntaxChecker::hasExpectedXHTMLSyntax(@if java XMLNode@endif)
@@ -1979,9 +2046,11 @@ s.setNotes("<body xmlns='http://www.w3.org/1999/xhtml'><p>here is my note</p></b
    * @li @sbmlconstant{LIBSBML_OPERATION_SUCCESS, OperationReturnValues_t}
    *
    * @see getNotesString()
+   * @see getNotesMarkdown()
    * @see isSetNotes()
    * @see setNotes(const XMLNode* notes)
    * @see setNotes(const std::string& notes, bool addXHTMLMarkup)
+   * @see setNotesFromMarkdown(const std::string& markdown)
    * @see appendNotes(const XMLNode* notes)
    * @see appendNotes(const std::string& notes)
    * @see SyntaxChecker::hasExpectedXHTMLSyntax(@if java XMLNode@endif)
@@ -4171,6 +4240,23 @@ SBase_getNotesString (SBase_t *sb);
 
 
 /**
+ * Returns the markdown version of the notes string from given SBML structure.
+ * The string is owned by the caller and should be freed
+ * (with free()) when no longer needed.  The HTML is translated
+ * by 'html2md', https://github.com/tim-gromeyer/html2md/
+ *
+ * @param sb the given SBML structure.
+ *
+ * @return the string (char*) representing the markdown version of the notes from this structure.
+ *
+ * @memberof SBase_t
+ */
+LIBSBML_EXTERN
+char*
+SBase_getNotesMarkdown(SBase_t* sb);
+
+
+/**
  * Returns the annotation from given SBML structure.
  *
  * @param sb the given SBML structure.
@@ -4455,6 +4541,22 @@ SBase_setNamespaces (SBase_t *sb, XMLNamespaces_t *xmlns);
 LIBSBML_EXTERN
 int
 SBase_setNotes (SBase_t *sb, const XMLNode_t *notes);
+
+/**
+ * Sets the notes for the given SBML structure from markdown input.
+ *
+ * Markdown parser is 'maddy' (https://github.com/progsource/maddy).
+ * 
+ * @param sb the given SBML structure.
+ * @param markdown the markdown version of the notes.
+ *
+ * @copydetails doc_returns_success_code
+ * @li @sbmlconstant{LIBSBML_OPERATION_SUCCESS, OperationReturnValues_t}
+ * @li @sbmlconstant{LIBSBML_INVALID_OBJECT, OperationReturnValues_t}
+ *
+ * @memberof SBase_t
+ */
+int SBase_setNotesFromMarkdown(SBase_t* sb, const char* markdown);
 
 
 /**

--- a/src/sbml/html2md/COPYING
+++ b/src/sbml/html2md/COPYING
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 Tim Gromeyer
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/sbml/html2md/README.md
+++ b/src/sbml/html2md/README.md
@@ -1,0 +1,110 @@
+# html2md
+
+Transform your HTML into clean, easy-to-read markdown with html2md
+
+## Table of Contents
+
+- [What does it do](#what-does-it-do)
+- [How to use this library](#how-to-use-this-library)
+- [Supported Tags](#supported-tags)
+- [Bindings](#bindings)
+- [Requirements](#requirements)
+- [License](#license)
+
+
+## What does it do
+
+html2md is a fast and reliable C++ library for converting HTML content into markdown. It offers support for a wide range of HTML tags, including those for formatting text, creating lists, and inserting images and links. In addition, html2md is the only HTML to markdown converter that offers support for **table formatting**, making it a valuable tool for users who need to convert HTML tables into markdown.
+
+
+## How to use this library
+
+### CMake
+
+Install html2md. Use eighter the prebild packages from [GitHub releases](https://github.com/tim-gromeyer/html2md/releases) or build and install it yourself.
+
+Afterwards:
+
+```cmake
+find_package(html2md)
+target_link_library(your_target PRIVATE html2md)
+```
+
+### Manually
+
+To use html2md, follow these steps:
+
+1. Clone the library: `git clone https://github.com/tim-gromeyer/html2md`
+2. Add the files `include/html2md.h` and `src/html2md.cpp` to your project
+3. Include the `html2md.h` header in your code
+4. Use the `html2md::Convert` function to convert your HTML content into markdown
+
+Here is an example of how to use the `html2md::Convert` function:
+
+```cpp
+#include <html2md.h>
+
+//...
+
+std::cout << html2md::Convert("<h1>foo</h1>"); // # foo
+```
+
+## Supported Tags
+
+html2md supports the following HTML tags:
+
+| Tag          | Description        | Comment                                             |
+|--------------|--------------------|-----------------------------------------------------|
+| `a`          | Anchor or link     | Supports the `href`, `name` and `title` attributes. |
+| `b`          | Bold               |                                                     |
+| `blockquote` | Indented paragraph |                                                     |
+| `br`         | Line break         |                                                     |
+| `cite`       | Inline citation    | Same as `i`.                                        |
+| `code`       | Code               |                                                     |
+| `dd`         | Definition data    |                                                     |
+| `del`        | Strikethrough      |                                                     |
+| `dfn`        | Definition         | Same as `i`.                                        |
+| `div`        | Document division  |                                                     |
+| `em`         | Emphasized         | Same as `i`.                                        |
+| `h1`         | Level 1 heading    |                                                     |
+| `h2`         | Level 2 heading    |                                                     |
+| `h3`         | Level 3 heading    |                                                     |
+| `h4`         | Level 4 heading    |                                                     |
+| `h5`         | Level 5 heading    |                                                     |
+| `h6`         | Level 6 heading    |                                                     |
+| `head`       | Document header    | Ignored.                                            |
+| `hr`         | Horizontal line    |                                                     |
+| `i`          | Italic             |                                                     |
+| `img`        | Image              | Supports `src`, `alt`, `title` attributes.          |
+| `li`         | List item          |                                                     |
+| `meta`       | Meta-information   | Ignored.                                            |
+| `ol`         | Ordered list       |                                                     |
+| `p`          | Paragraph          |                                                     |
+| `pre`        | Preformatted text  | Works only with `code`.                             |
+| `s`          | Strikethrough      | Same as `del`.                                      |
+| `span`       | Grouped elements   | Does nothing.                                       |
+| `strong`     | Strong             | Same as `b`.                                        |
+| `table`      | Table              | Tables are formatted!                               |
+| `tbody`      | Table body         | Does nothing.                                       |
+| `td`         | Table data cell    | Uses `align` from `th`.                             |
+| `tfoot`      | Table footer       | Does nothing.                                       |
+| `th`         | Table header cell  | Supports the `align` attribute.                     |
+| `thead`      | Table header       | Does nothing.                                       |
+| `title`      | Document title     | Same as `h1`.                                       |
+| `tr`         | Table row          |                                                     |
+| `u`          | Underlined         | Uses HTML.                                          |
+| `ul`         | Unordered list     |                                                     |
+
+## Bindings
+
+- [Python](python/README.md)
+
+## Requirements
+
+1. A compiler with **c++11** support like *g++>=9*
+
+That's all!
+
+## License
+
+html2md is licensed under [The MIT License (MIT)](https://opensource.org/licenses/MIT)

--- a/src/sbml/html2md/VERSION.txt
+++ b/src/sbml/html2md/VERSION.txt
@@ -1,0 +1,3 @@
+From https://github.com/tim-gromeyer/html2md/
+
+Version 1.6.6, https://github.com/tim-gromeyer/html2md/archive/refs/tags/v1.6.6.zip

--- a/src/sbml/html2md/html2md.cpp
+++ b/src/sbml/html2md/html2md.cpp
@@ -78,7 +78,7 @@ string Repeat(const string &str, size_t amount) {
 
 namespace html2md {
 
-Converter::Converter(string *html, Options *options) : html_(*html) {
+Converter::Converter(const string *html, Options *options) : html_(*html) {
   if (options)
     option = *options;
 

--- a/src/sbml/html2md/html2md.cpp
+++ b/src/sbml/html2md/html2md.cpp
@@ -1,0 +1,985 @@
+// Copyright (c) Tim Gromeyer
+// Licensed under the MIT License - https://opensource.org/licenses/MIT
+
+#include "html2md.h"
+#include "table.h"
+
+#include <algorithm>
+#include <cstring>
+#include <memory>
+#include <sstream>
+#include <vector>
+
+using std::make_shared;
+using std::string;
+using std::vector;
+
+namespace {
+bool startsWith(const string &str, const string &prefix) {
+  return str.size() >= prefix.size() &&
+         0 == str.compare(0, prefix.size(), prefix);
+}
+
+bool endsWith(const string &str, const string &suffix) {
+  return str.size() >= suffix.size() &&
+         0 == str.compare(str.size() - suffix.size(), suffix.size(), suffix);
+}
+
+size_t ReplaceAll(string *haystack, const string &needle,
+                  const string &replacement) {
+  // Get first occurrence
+  size_t pos = (*haystack).find(needle);
+
+  size_t amount_replaced = 0;
+
+  // Repeat until end is reached
+  while (pos != string::npos) {
+    // Replace this occurrence of sub string
+    (*haystack).replace(pos, needle.size(), replacement);
+
+    // Get the next occurrence from the current position
+    pos = (*haystack).find(needle, pos + replacement.size());
+
+    ++amount_replaced;
+  }
+
+  return amount_replaced;
+}
+
+size_t ReplaceAll(string *haystack, const string &needle, const char c) {
+  return ReplaceAll(haystack, needle, string({c}));
+}
+
+// Split given string by given character delimiter into vector of strings
+vector<string> Split(string const &str, char delimiter) {
+  vector<string> result;
+  std::stringstream iss(str);
+
+  for (string token; getline(iss, token, delimiter);)
+    result.push_back(token);
+
+  return result;
+}
+
+string Repeat(const string &str, size_t amount) {
+  if (amount == 0)
+    return "";
+  else if (amount == 1)
+    return str;
+
+  string out;
+
+  for (size_t i = 0; i < amount; ++i)
+    out.append(str);
+
+  return out;
+}
+} // namespace
+
+namespace html2md {
+
+Converter::Converter(string *html, Options *options) : html_(*html) {
+  if (options)
+    option = *options;
+
+  tags_.reserve(41);
+
+  // non-printing tags
+  auto tagIgnored = make_shared<Converter::TagIgnored>();
+  tags_[kTagHead] = tagIgnored;
+  tags_[kTagMeta] = tagIgnored;
+  tags_[kTagNav] = tagIgnored;
+  tags_[kTagNoScript] = tagIgnored;
+  tags_[kTagScript] = tagIgnored;
+  tags_[kTagStyle] = tagIgnored;
+  tags_[kTagTemplate] = tagIgnored;
+
+  // printing tags
+  tags_[kTagAnchor] = make_shared<Converter::TagAnchor>();
+  tags_[kTagBreak] = make_shared<Converter::TagBreak>();
+  tags_[kTagDiv] = make_shared<Converter::TagDiv>();
+  tags_[kTagHeader1] = make_shared<Converter::TagHeader1>();
+  tags_[kTagHeader2] = make_shared<Converter::TagHeader2>();
+  tags_[kTagHeader3] = make_shared<Converter::TagHeader3>();
+  tags_[kTagHeader4] = make_shared<Converter::TagHeader4>();
+  tags_[kTagHeader5] = make_shared<Converter::TagHeader5>();
+  tags_[kTagHeader6] = make_shared<Converter::TagHeader6>();
+  tags_[kTagListItem] = make_shared<Converter::TagListItem>();
+  tags_[kTagOption] = make_shared<Converter::TagOption>();
+  tags_[kTagOrderedList] = make_shared<Converter::TagOrderedList>();
+  tags_[kTagPre] = make_shared<Converter::TagPre>();
+  tags_[kTagCode] = make_shared<Converter::TagCode>();
+  tags_[kTagParagraph] = make_shared<Converter::TagParagraph>();
+  tags_[kTagSpan] = make_shared<Converter::TagSpan>();
+  tags_[kTagUnorderedList] = make_shared<Converter::TagUnorderedList>();
+  tags_[kTagTitle] = make_shared<Converter::TagTitle>();
+  tags_[kTagImg] = make_shared<Converter::TagImage>();
+  tags_[kTagSeperator] = make_shared<Converter::TagSeperator>();
+
+  // Text formatting
+  auto tagBold = make_shared<Converter::TagBold>();
+  tags_[kTagBold] = tagBold;
+  tags_[kTagStrong] = tagBold;
+
+  auto tagItalic = make_shared<Converter::TagItalic>();
+  tags_[kTagItalic] = tagItalic;
+  tags_[kTagItalic2] = tagItalic;
+  tags_[kTagDefinition] = tagItalic;
+  tags_[kTagCitation] = tagItalic;
+
+  tags_[kTagUnderline] = make_shared<Converter::TagUnderline>();
+
+  auto tagStrighthrought = make_shared<Converter::TagStrikethrought>();
+  tags_[kTagStrighthrought] = tagStrighthrought;
+  tags_[kTagStrighthrought2] = tagStrighthrought;
+
+  tags_[kTagBlockquote] = make_shared<Converter::TagBlockquote>();
+
+  // Tables
+  tags_[kTagTable] = make_shared<Converter::TagTable>();
+  tags_[kTagTableRow] = make_shared<Converter::TagTableRow>();
+  tags_[kTagTableHeader] = make_shared<Converter::TagTableHeader>();
+  tags_[kTagTableData] = make_shared<Converter::TagTableData>();
+}
+
+void Converter::CleanUpMarkdown() {
+  TidyAllLines(&md_);
+
+  ReplaceAll(&md_, " , ", ", ");
+
+  ReplaceAll(&md_, "\n.\n", ".\n");
+  ReplaceAll(&md_, "\n↵\n", " ↵\n");
+  ReplaceAll(&md_, "\n*\n", "\n");
+  ReplaceAll(&md_, "\n. ", ".\n");
+
+  ReplaceAll(&md_, "&quot;", '"');
+  ReplaceAll(&md_, "&lt;", "<");
+  ReplaceAll(&md_, "&gt;", ">");
+  ReplaceAll(&md_, "&amp;", '&');
+  ReplaceAll(&md_, "&nbsp;", ' ');
+  ReplaceAll(&md_, "&rarr;", "→");
+
+  ReplaceAll(&md_, "\t\t  ", "\t\t");
+}
+
+Converter *Converter::appendToMd(char ch) {
+  if (IsInIgnoredTag())
+    return this;
+
+  if (index_blockquote != 0 && ch == '\n') {
+    if (is_in_pre_) {
+      md_ += ch;
+      chars_in_curr_line_ = 0;
+      appendToMd(Repeat("> ", index_blockquote));
+    }
+
+    return this;
+  }
+
+  md_ += ch;
+
+  if (ch == '\n')
+    chars_in_curr_line_ = 0;
+  else
+    ++chars_in_curr_line_;
+
+  return this;
+}
+
+Converter *Converter::appendToMd(const char *str) {
+  if (IsInIgnoredTag())
+    return this;
+
+  md_ += str;
+
+  auto str_len = strlen(str);
+
+  for (auto i = 0; i < str_len; ++i) {
+    if (str[i] == '\n')
+      chars_in_curr_line_ = 0;
+    else
+      ++chars_in_curr_line_;
+  }
+
+  return this;
+}
+
+Converter *Converter::appendBlank() {
+  UpdatePrevChFromMd();
+
+  if (prev_ch_in_md_ == '\n' ||
+      (prev_ch_in_md_ == '*' && prev_prev_ch_in_md_ == '*'))
+    return this;
+
+  return appendToMd(' ');
+}
+
+bool Converter::ok() const {
+  return !is_in_pre_ && !is_in_list_ && !is_in_p_ && !is_in_table_ &&
+         !is_in_tag_ && index_blockquote == 0 && index_li == 0;
+}
+
+void Converter::LTrim(string *s) {
+  (*s).erase((*s).begin(),
+             find_if((*s).begin(), (*s).end(),
+                     [](unsigned char ch) { return !std::isspace(ch); }));
+}
+
+Converter *Converter::RTrim(string *s, bool trim_only_blank) {
+  (*s).erase(find_if((*s).rbegin(), (*s).rend(),
+                     [trim_only_blank](unsigned char ch) {
+                       if (trim_only_blank)
+                         return !isblank(ch);
+
+                       return !isspace(ch);
+                     })
+                 .base(),
+             (*s).end());
+
+  return this;
+}
+
+// NOTE: Pay attention when changing one of the trim functions. It can break the
+// output!
+Converter *Converter::Trim(string *s) {
+  if (!startsWith(*s, "\t"))
+    LTrim(s);
+
+  if (!(startsWith(*s, "  "), endsWith(*s, "  ")))
+    RTrim(s);
+
+  return this;
+}
+
+void Converter::TidyAllLines(string *str) {
+  auto lines = Split(*str, '\n');
+  string res;
+
+  uint8_t amount_newlines = 0;
+  bool in_code_block = false;
+
+  for (auto line : lines) {
+    if (startsWith(line, "```") || startsWith(line, "~~~"))
+      in_code_block = !in_code_block;
+    if (in_code_block) {
+      res += line + '\n';
+      continue;
+    }
+
+    Trim(&line);
+
+    if (line.empty()) {
+      if (amount_newlines < 2 && !res.empty()) {
+        res += '\n';
+        amount_newlines++;
+      }
+    } else {
+      amount_newlines = 0;
+
+      res += line + '\n';
+    }
+  }
+
+  *str = res;
+}
+
+string Converter::ExtractAttributeFromTagLeftOf(const string &attr) {
+  // Extract the whole tag from current offset, e.g. from '>', backwards
+  auto tag = html_.substr(offset_lt_, index_ch_in_html_ - offset_lt_);
+
+  // locate given attribute
+  auto offset_attr = tag.find(attr);
+
+  if (offset_attr == string::npos)
+    return "";
+
+  // locate attribute-value pair's '='
+  auto offset_equals = tag.find('=', offset_attr);
+
+  if (offset_equals == string::npos)
+    return "";
+
+  // locate value's surrounding quotes
+  auto offset_double_quote = tag.find('"', offset_equals);
+  auto offset_single_quote = tag.find('\'', offset_equals);
+
+  bool has_double_quote = offset_double_quote != string::npos;
+  bool has_single_quote = offset_single_quote != string::npos;
+
+  if (!has_double_quote && !has_single_quote)
+    return "";
+
+  char wrapping_quote = 0;
+
+  size_t offset_opening_quote = 0;
+  size_t offset_closing_quote = 0;
+
+  if (has_double_quote) {
+    if (!has_single_quote) {
+      wrapping_quote = '"';
+      offset_opening_quote = offset_double_quote;
+    } else {
+      if (offset_double_quote < offset_single_quote) {
+        wrapping_quote = '"';
+        offset_opening_quote = offset_double_quote;
+      } else {
+        wrapping_quote = '\'';
+        offset_opening_quote = offset_single_quote;
+      }
+    }
+  } else {
+    // has only single quote
+    wrapping_quote = '\'';
+    offset_opening_quote = offset_single_quote;
+  }
+
+  if (offset_opening_quote == string::npos)
+    return "";
+
+  offset_closing_quote = tag.find(wrapping_quote, offset_opening_quote + 1);
+
+  if (offset_closing_quote == string::npos)
+    return "";
+
+  return tag.substr(offset_opening_quote + 1,
+                    offset_closing_quote - 1 - offset_opening_quote);
+}
+
+void Converter::TurnLineIntoHeader1() {
+  appendToMd('\n' + Repeat("=", chars_in_curr_line_) + "\n\n");
+
+  chars_in_curr_line_ = 0;
+}
+
+void Converter::TurnLineIntoHeader2() {
+  appendToMd('\n' + Repeat("-", chars_in_curr_line_) + "\n\n");
+
+  chars_in_curr_line_ = 0;
+}
+
+string Converter::convert() {
+  // We already converted
+  if (index_ch_in_html_ == html_.size())
+    return md_;
+
+  reset();
+
+  for (char ch : html_) {
+    ++index_ch_in_html_;
+
+    if (!is_in_tag_ && ch == '<') {
+      OnHasEnteredTag();
+
+      continue;
+    }
+
+    if (is_in_tag_)
+      ParseCharInTag(ch);
+    else
+      ParseCharInTagContent(ch);
+  }
+
+  CleanUpMarkdown();
+
+  return md_;
+}
+
+void Converter::OnHasEnteredTag() {
+  offset_lt_ = index_ch_in_html_;
+  is_in_tag_ = true;
+  prev_tag_ = current_tag_;
+  current_tag_ = "";
+
+  if (!md_.empty()) {
+    UpdatePrevChFromMd();
+  }
+}
+
+Converter *Converter::UpdatePrevChFromMd() {
+  if (!md_.empty()) {
+    prev_ch_in_md_ = md_[md_.length() - 1];
+
+    if (md_.length() > 1)
+      prev_prev_ch_in_md_ = md_[md_.length() - 2];
+  }
+
+  return this;
+}
+
+bool Converter::ParseCharInTag(char ch) {
+  if (ch == '/' && !is_in_attribute_value_) {
+    is_closing_tag_ = current_tag_.empty();
+    is_self_closing_tag_ = !is_closing_tag_;
+
+    return true;
+  }
+
+  if (ch == '>')
+    return OnHasLeftTag();
+
+  if (ch == '"') {
+    if (is_in_attribute_value_) {
+      is_in_attribute_value_ = false;
+    } else if (current_tag_[current_tag_.length() - 1] == '=') {
+      is_in_attribute_value_ = true;
+    }
+
+    return true;
+  }
+
+  current_tag_ += ch;
+
+  return false;
+}
+
+bool Converter::OnHasLeftTag() {
+  is_in_tag_ = false;
+
+  UpdatePrevChFromMd();
+
+  if (!is_closing_tag_)
+    if (TagContainsAttributesToHide(&current_tag_))
+      return true;
+
+  auto cut_tags = Split(current_tag_, ' ');
+  if (cut_tags.empty())
+    return true;
+
+  current_tag_ = cut_tags[0];
+
+  auto tag = tags_[current_tag_];
+
+  if (!tag)
+    return true;
+
+  if (!is_closing_tag_) {
+    tag->OnHasLeftOpeningTag(this);
+  }
+  if (is_closing_tag_ || is_self_closing_tag_) {
+    is_closing_tag_ = false;
+
+    tag->OnHasLeftClosingTag(this);
+  }
+
+  return true;
+}
+
+Converter *Converter::ShortenMarkdown(size_t chars) {
+  md_ = md_.substr(0, md_.length() - chars);
+
+  if (chars > chars_in_curr_line_)
+    chars_in_curr_line_ = 0;
+  else
+    chars_in_curr_line_ = chars_in_curr_line_ - chars;
+
+  return this->UpdatePrevChFromMd();
+}
+
+bool Converter::ParseCharInTagContent(char ch) {
+  if (is_in_code_) {
+    md_ += ch;
+
+    if (index_blockquote != 0 && ch == '\n')
+      appendToMd(Repeat("> ", index_blockquote));
+
+    return true;
+  }
+
+  if (IsInIgnoredTag() || current_tag_ == kTagLink) {
+    prev_ch_in_html_ = ch;
+
+    return true;
+  }
+
+  if (ch == '\n') {
+    if (index_blockquote != 0) {
+      md_ += '\n';
+      chars_in_curr_line_ = 0;
+      appendToMd(Repeat("> ", index_blockquote));
+    }
+
+    return true;
+  }
+
+  switch (ch) {
+  case '*':
+    appendToMd("\\*");
+    break;
+  case '`':
+    appendToMd("\\`");
+    break;
+  case '\\':
+    appendToMd("\\\\");
+    break;
+  default:
+    md_ += ch;
+    ++chars_in_curr_line_;
+    break;
+  }
+
+  if (chars_in_curr_line_ > option.softBreak && !is_in_table_ && !is_in_list_ &&
+      current_tag_ != kTagImg && current_tag_ != kTagAnchor &&
+      option.splitLines) {
+    if (ch == ' ') { // If the next char is - it will become a list
+      md_ += '\n';
+      chars_in_curr_line_ = 0;
+    } else if (chars_in_curr_line_ > option.hardBreak) {
+      ReplacePreviousSpaceInLineByNewline();
+    }
+  }
+
+  return false;
+}
+
+bool Converter::ReplacePreviousSpaceInLineByNewline() {
+  if (current_tag_ == kTagParagraph ||
+      is_in_table_ && (prev_tag_ != kTagCode && prev_tag_ != kTagPre))
+    return false;
+
+  auto offset = md_.length() - 1;
+
+  if (md_.length() == 0)
+    return true;
+
+  do {
+    if (md_[offset] == '\n')
+      return false;
+
+    if (md_[offset] == ' ') {
+      md_[offset] = '\n';
+      chars_in_curr_line_ = md_.length() - offset;
+
+      return true;
+    }
+
+    --offset;
+  } while (offset > 0);
+
+  return false;
+}
+
+void Converter::TagAnchor::OnHasLeftOpeningTag(Converter *c) {
+  if (c->prev_tag_ == kTagImg)
+    c->appendToMd('\n');
+
+  current_title_ = c->ExtractAttributeFromTagLeftOf(kAttributeTitle);
+
+  c->appendToMd('[');
+  current_href_ = c->ExtractAttributeFromTagLeftOf(kAttributeHref);
+}
+
+void Converter::TagAnchor::OnHasLeftClosingTag(Converter *c) {
+  if (!c->shortIfPrevCh('[')) {
+    c->appendToMd("](")->appendToMd(current_href_);
+
+    // If title is set append it
+    if (!current_title_.empty()) {
+      c->appendToMd(" \"")->appendToMd(current_title_)->appendToMd('"');
+      current_title_.clear();
+    }
+
+    c->appendToMd(')');
+
+    if (c->prev_tag_ == kTagImg)
+      c->appendToMd('\n');
+  }
+}
+
+void Converter::TagBold::OnHasLeftOpeningTag(Converter *c) {
+  c->appendToMd("**");
+}
+
+void Converter::TagBold::OnHasLeftClosingTag(Converter *c) {
+  c->appendToMd("**");
+}
+
+void Converter::TagItalic::OnHasLeftOpeningTag(Converter *c) {
+  c->appendToMd('*');
+}
+
+void Converter::TagItalic::OnHasLeftClosingTag(Converter *c) {
+  c->appendToMd('*');
+}
+
+void Converter::TagUnderline::OnHasLeftOpeningTag(Converter *c) {
+  c->appendToMd("<u>");
+}
+
+void Converter::TagUnderline::OnHasLeftClosingTag(Converter *c) {
+  c->appendToMd("</u>");
+}
+
+void Converter::TagStrikethrought::OnHasLeftOpeningTag(Converter *c) {
+  c->appendToMd('~');
+}
+
+void Converter::TagStrikethrought::OnHasLeftClosingTag(Converter *c) {
+  c->appendToMd('~');
+}
+
+void Converter::TagBreak::OnHasLeftOpeningTag(Converter *c) {
+  if (c->is_in_list_) { // When it's in a list, it's not in a paragraph
+    c->appendToMd("  \n");
+    c->appendToMd(Repeat("  ", c->index_li));
+  } else if (c->is_in_table_) {
+    c->appendToMd("<br>");
+  } else if (!c->md_.empty())
+    c->appendToMd("  \n");
+}
+
+void Converter::TagBreak::OnHasLeftClosingTag(Converter *c) {}
+
+void Converter::TagDiv::OnHasLeftOpeningTag(Converter *c) {
+  if (c->prev_ch_in_md_ != '\n')
+    c->appendToMd('\n');
+
+  if (c->prev_prev_ch_in_md_ != '\n')
+    c->appendToMd('\n');
+}
+
+void Converter::TagDiv::OnHasLeftClosingTag(Converter *c) {}
+
+void Converter::TagHeader1::OnHasLeftOpeningTag(Converter *c) {
+  c->appendToMd("\n# ");
+}
+
+void Converter::TagHeader1::OnHasLeftClosingTag(Converter *c) {
+  if (c->prev_prev_ch_in_md_ != ' ')
+    c->appendToMd('\n');
+}
+
+void Converter::TagHeader2::OnHasLeftOpeningTag(Converter *c) {
+  c->appendToMd("\n## ");
+}
+
+void Converter::TagHeader2::OnHasLeftClosingTag(Converter *c) {
+  if (c->prev_prev_ch_in_md_ != ' ')
+    c->appendToMd('\n');
+}
+
+void Converter::TagHeader3::OnHasLeftOpeningTag(Converter *c) {
+  c->appendToMd("\n### ");
+}
+
+void Converter::TagHeader3::OnHasLeftClosingTag(Converter *c) {
+  if (c->prev_prev_ch_in_md_ != ' ')
+    c->appendToMd('\n');
+}
+
+void Converter::TagHeader4::OnHasLeftOpeningTag(Converter *c) {
+  c->appendToMd("\n#### ");
+}
+
+void Converter::TagHeader4::OnHasLeftClosingTag(Converter *c) {
+  if (c->prev_prev_ch_in_md_ != ' ')
+    c->appendToMd('\n');
+}
+
+void Converter::TagHeader5::OnHasLeftOpeningTag(Converter *c) {
+  c->appendToMd("\n##### ");
+}
+
+void Converter::TagHeader5::OnHasLeftClosingTag(Converter *c) {
+  if (c->prev_prev_ch_in_md_ != ' ')
+    c->appendToMd('\n');
+}
+
+void Converter::TagHeader6::OnHasLeftOpeningTag(Converter *c) {
+  c->appendToMd("\n###### ");
+}
+
+void Converter::TagHeader6::OnHasLeftClosingTag(Converter *c) {
+  if (c->prev_prev_ch_in_md_ != ' ')
+    c->appendToMd('\n');
+}
+
+void Converter::TagListItem::OnHasLeftOpeningTag(Converter *c) {
+  if (c->is_in_table_)
+    return;
+
+  if (!c->is_in_ordered_list_) {
+    c->appendToMd(string({c->option.unorderedList, ' '}));
+    return;
+  }
+
+  ++c->index_ol;
+
+  string num = std::to_string(c->index_ol);
+  num.append({c->option.orderedList, ' '});
+  c->appendToMd(num);
+}
+
+void Converter::TagListItem::OnHasLeftClosingTag(Converter *c) {
+  if (c->is_in_table_)
+    return;
+
+  if (c->prev_ch_in_md_ != '\n')
+    c->appendToMd('\n');
+}
+
+void Converter::TagOption::OnHasLeftOpeningTag(Converter *c) {}
+
+void Converter::TagOption::OnHasLeftClosingTag(Converter *c) {
+  if (c->md_.length() > 0)
+    c->appendToMd("  \n");
+}
+
+void Converter::TagOrderedList::OnHasLeftOpeningTag(Converter *c) {
+  if (c->is_in_table_)
+    return;
+
+  c->is_in_list_ = true;
+  c->is_in_ordered_list_ = true;
+  c->index_ol = 0;
+
+  ++c->index_li;
+
+  c->ReplacePreviousSpaceInLineByNewline();
+
+  c->appendToMd('\n');
+}
+
+void Converter::TagOrderedList::OnHasLeftClosingTag(Converter *c) {
+  if (c->is_in_table_)
+    return;
+
+  c->is_in_ordered_list_ = false;
+
+  if (c->index_li != 0)
+    --c->index_li;
+
+  c->is_in_list_ = c->index_li != 0;
+
+  c->appendToMd('\n');
+}
+
+void Converter::TagParagraph::OnHasLeftOpeningTag(Converter *c) {
+  c->is_in_p_ = true;
+
+  if (c->is_in_list_ && c->prev_tag_ == kTagParagraph)
+    c->appendToMd("\n\t");
+  else if (!c->is_in_list_)
+    c->appendToMd('\n');
+}
+
+void Converter::TagParagraph::OnHasLeftClosingTag(Converter *c) {
+  c->is_in_p_ = false;
+
+  if (!c->md_.empty())
+    c->appendToMd("\n"); // Workaround \n restriction for blockquotes
+
+  if (c->index_blockquote != 0)
+    c->appendToMd(Repeat("> ", c->index_blockquote));
+}
+
+void Converter::TagPre::OnHasLeftOpeningTag(Converter *c) {
+  c->is_in_pre_ = true;
+
+  if (c->prev_ch_in_md_ != '\n')
+    c->appendToMd('\n');
+
+  if (c->prev_prev_ch_in_md_ != '\n')
+    c->appendToMd('\n');
+
+  if (c->is_in_list_ && c->prev_tag_ != kTagParagraph)
+    c->ShortenMarkdown(2);
+
+  if (c->is_in_list_)
+    c->appendToMd("\t\t");
+  else
+    c->appendToMd("```");
+}
+
+void Converter::TagPre::OnHasLeftClosingTag(Converter *c) {
+  c->is_in_pre_ = false;
+
+  if (c->is_in_list_)
+    return;
+
+  c->appendToMd("```");
+  c->appendToMd('\n'); // Don't combine because of blockquote
+}
+
+void Converter::TagCode::OnHasLeftOpeningTag(Converter *c) {
+  c->is_in_code_ = true;
+
+  if (c->is_in_pre_) {
+    if (c->is_in_list_)
+      return;
+
+    auto code = c->ExtractAttributeFromTagLeftOf(kAttributeClass);
+    if (!code.empty()) {
+      if (startsWith(code, "language-"))
+        code.erase(0, 9); // remove language-
+      c->appendToMd(code);
+    }
+    c->appendToMd('\n');
+  } else
+    c->appendToMd('`');
+}
+
+void Converter::TagCode::OnHasLeftClosingTag(Converter *c) {
+  c->is_in_code_ = false;
+
+  if (c->is_in_pre_)
+    return;
+
+  c->appendToMd('`');
+}
+
+void Converter::TagSpan::OnHasLeftOpeningTag(Converter *c) {}
+
+void Converter::TagSpan::OnHasLeftClosingTag(Converter *c) {}
+
+void Converter::TagTitle::OnHasLeftOpeningTag(Converter *c) {}
+
+void Converter::TagTitle::OnHasLeftClosingTag(Converter *c) {
+  c->TurnLineIntoHeader1();
+}
+
+void Converter::TagUnorderedList::OnHasLeftOpeningTag(Converter *c) {
+  if (c->is_in_list_ || c->is_in_table_)
+    return;
+
+  c->is_in_list_ = true;
+
+  ++c->index_li;
+
+  c->appendToMd('\n');
+}
+
+void Converter::TagUnorderedList::OnHasLeftClosingTag(Converter *c) {
+  if (c->is_in_table_)
+    return;
+
+  if (c->index_li != 0)
+    --c->index_li;
+
+  c->is_in_list_ = c->index_li != 0;
+
+  if (c->prev_prev_ch_in_md_ == '\n' && c->prev_ch_in_md_ == '\n')
+    c->ShortenMarkdown();
+  else if (c->prev_ch_in_md_ != '\n')
+    c->appendToMd('\n');
+}
+
+void Converter::TagImage::OnHasLeftOpeningTag(Converter *c) {
+  if (c->prev_tag_ != kTagAnchor && c->prev_ch_in_md_ != '\n')
+    c->appendToMd('\n');
+
+  c->appendToMd("![")
+      ->appendToMd(c->ExtractAttributeFromTagLeftOf(kAttributeAlt))
+      ->appendToMd("](")
+      ->appendToMd(c->ExtractAttributeFromTagLeftOf(kAttributeSrc));
+
+  auto title = c->ExtractAttributeFromTagLeftOf(kAttributeTitle);
+  if (!title.empty()) {
+    c->appendToMd(" \"")->appendToMd(title)->appendToMd('"');
+  }
+
+  c->appendToMd(")");
+}
+
+void Converter::TagImage::OnHasLeftClosingTag(Converter *c) {
+  if (c->prev_tag_ == kTagAnchor)
+    c->appendToMd('\n');
+}
+
+void Converter::TagSeperator::OnHasLeftOpeningTag(Converter *c) {
+  c->appendToMd("\n---\n"); // NOTE: We can make this an option
+}
+
+void Converter::TagSeperator::OnHasLeftClosingTag(Converter *c) {}
+
+void Converter::TagTable::OnHasLeftOpeningTag(Converter *c) {
+  c->is_in_table_ = true;
+  c->appendToMd('\n');
+  c->table_start = c->md_.length();
+}
+
+void Converter::TagTable::OnHasLeftClosingTag(Converter *c) {
+  c->is_in_table_ = false;
+  c->appendToMd('\n');
+
+  if (!c->option.formatTable)
+    return;
+
+  string table = c->md_.substr(c->table_start);
+  table = formatMarkdownTable(table);
+  c->ShortenMarkdown(c->md_.size() - c->table_start);
+  c->appendToMd(table);
+}
+
+void Converter::TagTableRow::OnHasLeftOpeningTag(Converter *c) {
+  c->appendToMd('\n');
+}
+
+void Converter::TagTableRow::OnHasLeftClosingTag(Converter *c) {
+  c->UpdatePrevChFromMd();
+  if (c->prev_ch_in_md_ == '|')
+    c->appendToMd('\n'); // There's a bug
+  else
+    c->appendToMd('|');
+
+  if (!c->tableLine.empty()) {
+    if (c->prev_ch_in_md_ != '\n')
+      c->appendToMd('\n');
+
+    c->tableLine.append("|\n");
+    c->appendToMd(c->tableLine);
+    c->tableLine.clear();
+  }
+}
+
+void Converter::TagTableHeader::OnHasLeftOpeningTag(Converter *c) {
+  auto align = c->ExtractAttributeFromTagLeftOf(kAttrinuteAlign);
+
+  string line = "| ";
+
+  if (align == "left" || align == "center")
+    line += ':';
+
+  line += '-';
+
+  if (align == "right" || align == "center")
+    line += ": ";
+  else
+    line += ' ';
+
+  c->tableLine.append(line);
+
+  c->appendToMd("| ");
+}
+
+void Converter::TagTableHeader::OnHasLeftClosingTag(Converter *c) {}
+
+void Converter::TagTableData::OnHasLeftOpeningTag(Converter *c) {
+  if (c->prev_prev_ch_in_md_ != '|')
+    c->appendToMd("| ");
+}
+
+void Converter::TagTableData::OnHasLeftClosingTag(Converter *c) {}
+
+void Converter::TagBlockquote::OnHasLeftOpeningTag(Converter *c) {
+  ++c->index_blockquote;
+}
+
+void Converter::TagBlockquote::OnHasLeftClosingTag(Converter *c) {
+  --c->index_blockquote;
+  c->ShortenMarkdown(2); // Remove the '> '
+}
+
+void Converter::reset() {
+  md_.clear();
+  prev_ch_in_md_ = 0;
+  prev_prev_ch_in_md_ = 0;
+  index_ch_in_html_ = 0;
+}
+
+bool Converter::IsInIgnoredTag() const {
+  if (current_tag_ == kTagTitle && !option.includeTitle)
+    return true;
+
+  return IsIgnoredTag(current_tag_);
+}
+} // namespace html2md

--- a/src/sbml/html2md/html2md.h
+++ b/src/sbml/html2md/html2md.h
@@ -170,7 +170,7 @@ public:
    * You can use appendToMd() to append something to the beginning of the
    * generated output.
    */
-  explicit inline Converter(std::string &html,
+  explicit inline Converter(const std::string &html,
                             struct Options *options = nullptr) {
     *this = Converter(&html, options);
   }
@@ -511,7 +511,7 @@ private:
 
   std::unordered_map<std::string, std::shared_ptr<Tag>> tags_;
 
-  explicit Converter(std::string *html, struct Options *options);
+  explicit Converter(const std::string *html, struct Options *options);
 
   void CleanUpMarkdown();
 
@@ -594,7 +594,7 @@ private:
  * \param ok Optional: Pass a reference to a local bool to store the output of
  * Converter::ok() \return Returns the by Converter generated Markdown
  */
-inline std::string Convert(std::string &html, bool *ok = nullptr) {
+inline std::string Convert(const std::string &html, bool *ok = nullptr) {
   Converter c(html);
   auto md = c.convert();
   if (ok != nullptr)
@@ -603,7 +603,7 @@ inline std::string Convert(std::string &html, bool *ok = nullptr) {
 }
 
 #ifndef PYTHON_BINDINGS
-inline std::string Convert(std::string &&html, bool *ok = nullptr) {
+inline std::string Convert(const std::string &&html, bool *ok = nullptr) {
   return Convert(html, ok);
 }
 #endif

--- a/src/sbml/html2md/html2md.h
+++ b/src/sbml/html2md/html2md.h
@@ -1,0 +1,613 @@
+// Copyright (c) Tim Gromeyer
+// Licensed under the MIT License - https://opensource.org/licenses/MIT
+
+#ifndef HTML2MD_H
+#define HTML2MD_H
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+/*!
+ * \brief html2md namespace
+ *
+ * The html2md namespace provides:
+ * 1. The Converter class
+ * 2. Static wrapper around Converter class
+ *
+ * \note Do NOT try to convert HTML that contains a list in an ordered list or a
+ * `blockquote` in a list!\n  This will be a **total** mess!
+ */
+namespace html2md {
+
+/*!
+ * \brief Options for the conversion from HTML to Markdown
+ * \warning Make sure to pass valid options; otherwise, the output will be
+ * invalid!
+ *
+ * Example from `tests/main.cpp`:
+ *
+ * ```cpp
+ * auto *options = new html2md::Options();
+ * options->splitLines = false;
+ *
+ * html2md::Converter c(html, options);
+ * auto md = c.convert();
+ * ```
+ */
+struct Options {
+  /*!
+   * \brief Add new line when a certain number of characters is reached
+   *
+   * \see softBreak
+   * \see hardBreak
+   */
+  bool splitLines = true;
+
+  /*!
+   * \brief softBreak Wrap after ...  characters when the next space is reached
+   * and as long as it's not in a list, table, image or anchor (link).
+   */
+  int softBreak = 80;
+
+  /*!
+   * \brief hardBreak Force a break after ... characters in a line
+   */
+  int hardBreak = 100;
+
+  /*!
+   * \brief The char used for unordered lists
+   *
+   * Valid:
+   * - `-`
+   * - `+`
+   * - `*`
+   *
+   * Example:
+   *
+   * ```markdown
+   * - List
+   * + Also a list
+   * * And this to
+   * ```
+   */
+  char unorderedList = '-';
+
+  /*!
+   * \brief The char used after the number of the item
+   *
+   * Valid:
+   * - `.`
+   * - `)`
+   *
+   * Example:
+   *
+   * ```markdown
+   * 1. Hello
+   * 2) World!
+   * ```
+   */
+  char orderedList = '.';
+
+  /*!
+   * \brief Whether title is added as h1 heading at the very beginning of the
+   * markdown
+   *
+   * Whether title is added as h1 heading at the very beginning of the markdown.
+   * Default is true.
+   */
+  bool includeTitle = true;
+
+  /*!
+   * \brief Whetever to format Markdown Tables
+   *
+   * Whetever to format Markdown Tables.
+   * Default is true.
+   */
+  bool formatTable = true;
+
+  inline bool operator==(html2md::Options o) const {
+    return splitLines == o.splitLines && unorderedList == o.unorderedList &&
+           orderedList == o.orderedList && includeTitle == o.includeTitle &&
+           softBreak == o.softBreak && hardBreak == o.hardBreak;
+  };
+};
+
+/*!
+ * \brief Class for converting HTML to Markdown
+ *
+ * This class converts HTML to Markdown.
+ * There is also a static wrapper for this class (see html2md::Convert).
+ *
+ * ## Usage example
+ *
+ * Option 1: Use the class:
+ *
+ * ```cpp
+ * std::string html = "<h1>example</h1>";
+ * html2md::Converter c(html);
+ * auto md = c.convert();
+ *
+ * if (!c.ok()) std::cout << "There was something wrong in the HTML\n";
+ * std::cout << md; // # example
+ * ```
+ *
+ * Option 2: Use the static wrapper:
+ *
+ * ```cpp
+ * std::string html = "<h1>example</h1>";
+ *
+ * auto md = html2md::Convert(html);
+ * std::cout << md;
+ * ```
+ *
+ * Advanced: use Options:
+ *
+ * ```cpp
+ * std::string html = "<h1>example</h1>";
+ *
+ * auto *options = new html2md::Options();
+ * options->splitLines = false;
+ * options->unorderedList = '*';
+ *
+ * html2md::Converter c(html, options);
+ * auto md = c.convert();
+ * if (!c.ok()) std::cout << "There was something wrong in the HTML\n";
+ * std::cout << md; // # example
+ * ```
+ */
+class Converter {
+public:
+  /*!
+   * \brief Standard initializer, takes HTML as parameter. Also prepares
+   * everything. \param html The HTML as std::string. \param options Options for
+   * the Conversation. See html2md::Options() for more.
+   *
+   * \note Don't pass anything else than HTML, otherwise the output will be a
+   * **mess**!
+   *
+   * This is the default initializer.<br>
+   * You can use appendToMd() to append something to the beginning of the
+   * generated output.
+   */
+  explicit inline Converter(std::string &html,
+                            struct Options *options = nullptr) {
+    *this = Converter(&html, options);
+  }
+
+  /*!
+   * \brief Convert HTML into Markdown.
+   * \return Returns the converted Markdown.
+   *
+   * This function actually converts the HTML into Markdown.
+   * It also cleans up the Markdown so you don't have to do anything.
+   */
+  [[nodiscard]] std::string convert();
+
+  /*!
+   * \brief Append a char to the Markdown.
+   * \param ch The char to append.
+   * \return Returns a copy of the instance with the char appended.
+   */
+  Converter *appendToMd(char ch);
+
+  /*!
+   * \brief Append a char* to the Markdown.
+   * \param str The char* to append.
+   * \return Returns a copy of the instance with the char* appended.
+   */
+  Converter *appendToMd(const char *str);
+
+  /*!
+   * \brief Append a string to the Markdown.
+   * \param s The string to append.
+   * \return Returns a copy of the instance with the string appended.
+   */
+  inline Converter *appendToMd(const std::string &s) {
+    return appendToMd(s.c_str());
+  }
+
+  /*!
+   * \brief Appends a ' ' in certain cases.
+   * \return Copy of the instance with(maybe) the appended space.
+   *
+   * This function appends ' ' if:
+   * - md does not end with `*`
+   * - md does not end with `\n` aka newline
+   */
+  Converter *appendBlank();
+
+  /*!
+   * \brief Checks if everything was closed properly(in the HTML).
+   * \return Returns false if there is a unclosed tag.
+   * \note As long as you have not called convert(), it always returns true.
+   */
+  [[nodiscard]] bool ok() const;
+
+  /*!
+   * \brief Reset the generated Markdown
+   */
+  void reset();
+
+  /*!
+   * \brief Checks if the HTML matches and the options are the same.
+   * \param The Converter object to compare with
+   * \return true if the HTML and options matches otherwise false
+   */
+  inline bool operator==(const Converter *c) const { return *this == *c; }
+
+  inline bool operator==(const Converter &c) const {
+    return html_ == c.html_ && option == c.option;
+  }
+
+  /*!
+   * \brief Returns ok().
+   */
+  inline explicit operator bool() const { return ok(); };
+
+private:
+  // Attributes
+  static constexpr const char *kAttributeHref = "href";
+  static constexpr const char *kAttributeAlt = "alt";
+  static constexpr const char *kAttributeTitle = "title";
+  static constexpr const char *kAttributeClass = "class";
+  static constexpr const char *kAttributeSrc = "src";
+  static constexpr const char *kAttrinuteAlign = "align";
+
+  static constexpr const char *kTagAnchor = "a";
+  static constexpr const char *kTagBreak = "br";
+  static constexpr const char *kTagCode = "code";
+  static constexpr const char *kTagDiv = "div";
+  static constexpr const char *kTagHead = "head";
+  static constexpr const char *kTagLink = "link";
+  static constexpr const char *kTagListItem = "li";
+  static constexpr const char *kTagMeta = "meta";
+  static constexpr const char *kTagNav = "nav";
+  static constexpr const char *kTagNoScript = "noscript";
+  static constexpr const char *kTagOption = "option";
+  static constexpr const char *kTagOrderedList = "ol";
+  static constexpr const char *kTagParagraph = "p";
+  static constexpr const char *kTagPre = "pre";
+  static constexpr const char *kTagScript = "script";
+  static constexpr const char *kTagSpan = "span";
+  static constexpr const char *kTagStyle = "style";
+  static constexpr const char *kTagTemplate = "template";
+  static constexpr const char *kTagTitle = "title";
+  static constexpr const char *kTagUnorderedList = "ul";
+  static constexpr const char *kTagImg = "img";
+  static constexpr const char *kTagSeperator = "hr";
+
+  // Text format
+  static constexpr const char *kTagBold = "b";
+  static constexpr const char *kTagStrong = "strong";
+  static constexpr const char *kTagItalic = "em";
+  static constexpr const char *kTagItalic2 = "i";
+  static constexpr const char *kTagCitation = "cite";
+  static constexpr const char *kTagDefinition = "dfn";
+  static constexpr const char *kTagUnderline = "u";
+  static constexpr const char *kTagStrighthrought = "del";
+  static constexpr const char *kTagStrighthrought2 = "s";
+
+  static constexpr const char *kTagBlockquote = "blockquote";
+
+  // Header
+  static constexpr const char *kTagHeader1 = "h1";
+  static constexpr const char *kTagHeader2 = "h2";
+  static constexpr const char *kTagHeader3 = "h3";
+  static constexpr const char *kTagHeader4 = "h4";
+  static constexpr const char *kTagHeader5 = "h5";
+  static constexpr const char *kTagHeader6 = "h6";
+
+  // Table
+  static constexpr const char *kTagTable = "table";
+  static constexpr const char *kTagTableRow = "tr";
+  static constexpr const char *kTagTableHeader = "th";
+  static constexpr const char *kTagTableData = "td";
+
+  size_t index_ch_in_html_ = 0;
+
+  bool is_closing_tag_ = false;
+  bool is_in_attribute_value_ = false;
+  bool is_in_code_ = false;
+  bool is_in_list_ = false;
+  bool is_in_p_ = false;
+  bool is_in_pre_ = false;
+  bool is_in_table_ = false;
+  bool is_in_table_row_ = false;
+  bool is_in_tag_ = false;
+  bool is_self_closing_tag_ = false;
+
+  // relevant for <li> only, false = is in unordered list
+  bool is_in_ordered_list_ = false;
+  uint8_t index_ol = 0;
+
+  // store the table start
+  size_t table_start = 0;
+
+  // number of lists
+  uint8_t index_li = 0;
+
+  uint8_t index_blockquote = 0;
+
+  char prev_ch_in_md_ = 0, prev_prev_ch_in_md_ = 0;
+  char prev_ch_in_html_ = 'x';
+
+  std::string html_;
+
+  uint16_t offset_lt_ = 0;
+  std::string current_tag_;
+  std::string prev_tag_;
+
+  // Line which separates header from data
+  std::string tableLine;
+
+  size_t chars_in_curr_line_ = 0;
+
+  std::string md_;
+
+  Options option;
+
+  // Tag: base class for tag types
+  struct Tag {
+    virtual void OnHasLeftOpeningTag(Converter *c) = 0;
+    virtual void OnHasLeftClosingTag(Converter *c) = 0;
+  };
+
+  // Tag types
+
+  // tags that are not printed (nav, script, noscript, ...)
+  struct TagIgnored : Tag {
+    void OnHasLeftOpeningTag(Converter *c) override {};
+    void OnHasLeftClosingTag(Converter *c) override {};
+  };
+
+  struct TagAnchor : Tag {
+    void OnHasLeftOpeningTag(Converter *c) override;
+    void OnHasLeftClosingTag(Converter *c) override;
+
+    std::string current_href_;
+    std::string current_title_;
+  };
+
+  struct TagBold : Tag {
+    void OnHasLeftOpeningTag(Converter *c) override;
+    void OnHasLeftClosingTag(Converter *c) override;
+  };
+
+  struct TagItalic : Tag {
+    void OnHasLeftOpeningTag(Converter *c) override;
+    void OnHasLeftClosingTag(Converter *c) override;
+  };
+
+  struct TagUnderline : Tag {
+    void OnHasLeftOpeningTag(Converter *c) override;
+    void OnHasLeftClosingTag(Converter *c) override;
+  };
+
+  struct TagStrikethrought : Tag {
+    void OnHasLeftOpeningTag(Converter *c) override;
+    void OnHasLeftClosingTag(Converter *c) override;
+  };
+
+  struct TagBreak : Tag {
+    void OnHasLeftOpeningTag(Converter *c) override;
+    void OnHasLeftClosingTag(Converter *c) override;
+  };
+
+  struct TagDiv : Tag {
+    void OnHasLeftOpeningTag(Converter *c) override;
+    void OnHasLeftClosingTag(Converter *c) override;
+  };
+
+  struct TagHeader1 : Tag {
+    void OnHasLeftOpeningTag(Converter *c) override;
+    void OnHasLeftClosingTag(Converter *c) override;
+  };
+
+  struct TagHeader2 : Tag {
+    void OnHasLeftOpeningTag(Converter *c) override;
+    void OnHasLeftClosingTag(Converter *c) override;
+  };
+
+  struct TagHeader3 : Tag {
+    void OnHasLeftOpeningTag(Converter *c) override;
+    void OnHasLeftClosingTag(Converter *c) override;
+  };
+
+  struct TagHeader4 : Tag {
+    void OnHasLeftOpeningTag(Converter *c) override;
+    void OnHasLeftClosingTag(Converter *c) override;
+  };
+
+  struct TagHeader5 : Tag {
+    void OnHasLeftOpeningTag(Converter *c) override;
+    void OnHasLeftClosingTag(Converter *c) override;
+  };
+
+  struct TagHeader6 : Tag {
+    void OnHasLeftOpeningTag(Converter *c) override;
+    void OnHasLeftClosingTag(Converter *c) override;
+  };
+
+  struct TagListItem : Tag {
+    void OnHasLeftOpeningTag(Converter *c) override;
+    void OnHasLeftClosingTag(Converter *c) override;
+  };
+
+  struct TagOption : Tag {
+    void OnHasLeftOpeningTag(Converter *c) override;
+    void OnHasLeftClosingTag(Converter *c) override;
+  };
+
+  struct TagOrderedList : Tag {
+    void OnHasLeftOpeningTag(Converter *c) override;
+    void OnHasLeftClosingTag(Converter *c) override;
+  };
+
+  struct TagParagraph : Tag {
+    void OnHasLeftOpeningTag(Converter *c) override;
+    void OnHasLeftClosingTag(Converter *c) override;
+  };
+
+  struct TagPre : Tag {
+    void OnHasLeftOpeningTag(Converter *c) override;
+    void OnHasLeftClosingTag(Converter *c) override;
+  };
+
+  struct TagCode : Tag {
+    void OnHasLeftOpeningTag(Converter *c) override;
+    void OnHasLeftClosingTag(Converter *c) override;
+  };
+
+  struct TagSpan : Tag {
+    void OnHasLeftOpeningTag(Converter *c) override;
+    void OnHasLeftClosingTag(Converter *c) override;
+  };
+
+  struct TagTitle : Tag {
+    void OnHasLeftOpeningTag(Converter *c) override;
+    void OnHasLeftClosingTag(Converter *c) override;
+  };
+
+  struct TagUnorderedList : Tag {
+    void OnHasLeftOpeningTag(Converter *c) override;
+    void OnHasLeftClosingTag(Converter *c) override;
+  };
+
+  struct TagImage : Tag {
+    void OnHasLeftOpeningTag(Converter *c) override;
+    void OnHasLeftClosingTag(Converter *c) override;
+  };
+
+  struct TagSeperator : Tag {
+    void OnHasLeftOpeningTag(Converter *c) override;
+    void OnHasLeftClosingTag(Converter *c) override;
+  };
+
+  struct TagTable : Tag {
+    void OnHasLeftOpeningTag(Converter *c) override;
+    void OnHasLeftClosingTag(Converter *c) override;
+  };
+
+  struct TagTableRow : Tag {
+    void OnHasLeftOpeningTag(Converter *c) override;
+    void OnHasLeftClosingTag(Converter *c) override;
+  };
+
+  struct TagTableHeader : Tag {
+    void OnHasLeftOpeningTag(Converter *c) override;
+    void OnHasLeftClosingTag(Converter *c) override;
+  };
+
+  struct TagTableData : Tag {
+    void OnHasLeftOpeningTag(Converter *c) override;
+    void OnHasLeftClosingTag(Converter *c) override;
+  };
+
+  struct TagBlockquote : Tag {
+    void OnHasLeftOpeningTag(Converter *c) override;
+    void OnHasLeftClosingTag(Converter *c) override;
+  };
+
+  std::unordered_map<std::string, std::shared_ptr<Tag>> tags_;
+
+  explicit Converter(std::string *html, struct Options *options);
+
+  void CleanUpMarkdown();
+
+  // Trim from start (in place)
+  static void LTrim(std::string *s);
+
+  // Trim from end (in place)
+  Converter *RTrim(std::string *s, bool trim_only_blank = false);
+
+  // Trim from both ends (in place)
+  Converter *Trim(std::string *s);
+
+  // 1. trim all lines
+  // 2. reduce consecutive newlines to maximum 3
+  void TidyAllLines(std::string *str);
+
+  std::string ExtractAttributeFromTagLeftOf(const std::string &attr);
+
+  void TurnLineIntoHeader1();
+
+  void TurnLineIntoHeader2();
+
+  // Current char: '<'
+  void OnHasEnteredTag();
+
+  Converter *UpdatePrevChFromMd();
+
+  /**
+   * Handle next char within <...> tag
+   *
+   * @param ch current character
+   * @return   continue surrounding iteration?
+   */
+  bool ParseCharInTag(char ch);
+
+  // Current char: '>'
+  bool OnHasLeftTag();
+
+  inline static bool TagContainsAttributesToHide(std::string *tag) {
+    using std::string;
+
+    return (*tag).find(" aria=\"hidden\"") != string::npos ||
+           (*tag).find("display:none") != string::npos ||
+           (*tag).find("visibility:hidden") != string::npos ||
+           (*tag).find("opacity:0") != string::npos ||
+           (*tag).find("Details-content--hidden-not-important") != string::npos;
+  }
+
+  Converter *ShortenMarkdown(size_t chars = 1);
+  inline bool shortIfPrevCh(char prev) {
+    if (prev_ch_in_md_ == prev) {
+      ShortenMarkdown();
+      return true;
+    }
+    return false;
+  };
+
+  /**
+   * @param ch
+   * @return continue iteration surrounding  this method's invocation?
+   */
+  bool ParseCharInTagContent(char ch);
+
+  // Replace previous space (if any) in current markdown line by newline
+  bool ReplacePreviousSpaceInLineByNewline();
+
+  static inline bool IsIgnoredTag(const std::string &tag) {
+    return (tag[0] == '-' || kTagTemplate == tag || kTagStyle == tag ||
+            kTagScript == tag || kTagNoScript == tag || kTagNav == tag);
+
+    // meta: not ignored to tolerate if closing is omitted
+  }
+
+  [[nodiscard]] bool IsInIgnoredTag() const;
+}; // Converter
+
+/*!
+ * \brief Static wrapper around the Converter class
+ * \param html The HTML passed to Converter
+ * \param ok Optional: Pass a reference to a local bool to store the output of
+ * Converter::ok() \return Returns the by Converter generated Markdown
+ */
+inline std::string Convert(std::string &html, bool *ok = nullptr) {
+  Converter c(html);
+  auto md = c.convert();
+  if (ok != nullptr)
+    *ok = c.ok();
+  return md;
+}
+
+#ifndef PYTHON_BINDINGS
+inline std::string Convert(std::string &&html, bool *ok = nullptr) {
+  return Convert(html, ok);
+}
+#endif
+
+} // namespace html2md
+
+#endif // HTML2MD_H

--- a/src/sbml/html2md/table.cpp
+++ b/src/sbml/html2md/table.cpp
@@ -1,0 +1,106 @@
+// Copyright (c) Tim Gromeyer
+// Licensed under the MIT License - https://opensource.org/licenses/MIT
+
+#include "table.h"
+
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+#include <vector>
+
+using std::string;
+using std::vector;
+
+const size_t MIN_LINE_LENGTH = 3; // Minimum length of line
+
+void removeLeadingTrailingSpaces(string &str) {
+  size_t firstNonSpace = str.find_first_not_of(' ');
+  if (firstNonSpace == string::npos) {
+    str.clear(); // Entire string is spaces
+    return;
+  }
+
+  size_t lastNonSpace = str.find_last_not_of(' ');
+  str = str.substr(firstNonSpace, lastNonSpace - firstNonSpace + 1);
+}
+
+string enlargeTableHeaderLine(const string &str, size_t length) {
+  if (str.empty() || length < MIN_LINE_LENGTH)
+    return "";
+
+  size_t first = str.find_first_of(':');
+  size_t last = str.find_last_of(':');
+
+  if (first == 0 && first == last)
+    last = string::npos;
+
+  string line = string(length, '-');
+
+  if (first == 0)
+    line[0] = ':';
+  if (last == str.length() - 1)
+    line[length - 1] = ':';
+
+  return line;
+}
+
+string formatMarkdownTable(const string &inputTable) {
+  std::istringstream iss(inputTable);
+  string line;
+  vector<vector<string>> tableData;
+
+  // Parse the input table into a 2D vector
+  while (std::getline(iss, line)) {
+    std::istringstream lineStream(line);
+    string cell;
+    vector<string> rowData;
+
+    while (std::getline(lineStream, cell, '|')) {
+      if (!cell.empty()) {
+        removeLeadingTrailingSpaces(cell); // Use the trim function
+        rowData.push_back(cell);
+      }
+    }
+
+    if (!rowData.empty()) {
+      tableData.push_back(std::move(rowData)); // Move rowData to avoid copying
+    }
+  }
+
+  if (tableData.empty()) { 
+    return ""; 
+  }
+
+  // Determine maximum width of each column
+  vector<size_t> columnWidths(tableData[0].size(), 0);
+  for (const auto &row : tableData) {
+    if (columnWidths.size() < row.size()) {
+      columnWidths.resize(row.size(), 0);
+    }
+
+    for (size_t i = 0; i < row.size(); ++i) {
+      columnWidths[i] = std::max(columnWidths[i], row[i].size());
+    }
+  }
+
+  // Build the formatted table
+  std::ostringstream formattedTable;
+  for (size_t rowNumber = 0; rowNumber < tableData.size(); ++rowNumber) {
+    const auto &row = tableData[rowNumber];
+
+    formattedTable << "|";
+
+    for (size_t i = 0; i < row.size(); ++i) {
+      if (rowNumber == 1) {
+        formattedTable << enlargeTableHeaderLine(row[i], columnWidths[i] + 2)
+                       << "|";
+        continue;
+      }
+      formattedTable << " " << std::setw(columnWidths[i]) << std::left << row[i]
+                     << " |";
+    }
+    formattedTable << "\n";
+  }
+
+  return formattedTable.str();
+}

--- a/src/sbml/html2md/table.h
+++ b/src/sbml/html2md/table.h
@@ -1,0 +1,11 @@
+// Copyright (c) Tim Gromeyer
+// Licensed under the MIT License - https://opensource.org/licenses/MIT
+
+#ifndef TABLE_H
+#define TABLE_H
+
+#include <string>
+
+[[nodiscard]] std::string formatMarkdownTable(const std::string &inputTable);
+
+#endif // TABLE_H

--- a/src/sbml/maddy/CMakeLists.txt
+++ b/src/sbml/maddy/CMakeLists.txt
@@ -1,0 +1,61 @@
+# This project is licensed under the MIT license. For more information see the
+# LICENSE file.
+
+cmake_minimum_required(VERSION 3.25)
+
+project(maddy)
+
+# ------------------------------------------------------------------------------
+
+set(CMAKE_BINARY_DIR ${CMAKE_CURRENT_SOURCE_DIR}/build)
+set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR})
+set(LIBRARY_OUTPUT_PATH ${CMAKE_BINARY_DIR})
+
+# ------------------------------------------------------------------------------
+
+option(MADDY_BUILD_WITH_TESTS "enable building tests - does not work with zip download" OFF)
+
+if(${MADDY_BUILD_WITH_TESTS})
+  enable_testing()
+endif()
+
+option(MADDY_CREATE_PACKAGE "create a package for a version release" OFF)
+
+# ------------------------------------------------------------------------------
+
+set(MADDY_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/include)
+
+# ------------------------------------------------------------------------------
+
+if(NOT DEFINED CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 14)
+endif()
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+if(${CMAKE_CXX_STANDARD} LESS 14)
+  message(FATAL_ERROR "maddy requires >=C++14")
+endif()
+
+# ------------------------------------------------------------------------------
+
+add_library(maddy INTERFACE)
+target_include_directories(maddy INTERFACE
+  ${MADDY_INCLUDE_DIR}
+)
+
+# ------------------------------------------------------------------------------
+
+if(${MADDY_BUILD_WITH_TESTS})
+  add_subdirectory(tests)
+endif()
+
+# ------------------------------------------------------------------------------
+
+if(${MADDY_CREATE_PACKAGE})
+  set(MADDY_PACKAGE_FILES include/ CMakeLists.txt LICENSE)
+  add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/${PROJECT_NAME}-src.zip
+    COMMAND ${CMAKE_COMMAND} -E tar c ${CMAKE_BINARY_DIR}/${PROJECT_NAME}-src.zip --format=zip -- ${MADDY_PACKAGE_FILES}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    DEPENDS ${MADDY_PACKAGE_FILES})
+  add_custom_target(${PROJECT_NAME}_package DEPENDS ${CMAKE_BINARY_DIR}/${PROJECT_NAME}-src.zip)
+endif()

--- a/src/sbml/maddy/LICENSE
+++ b/src/sbml/maddy/LICENSE
@@ -1,0 +1,18 @@
+Copyright 2017, 2018, 2019, 2020, 2023 M. Petra Baranski
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/sbml/maddy/VERSION.txt
+++ b/src/sbml/maddy/VERSION.txt
@@ -1,0 +1,3 @@
+From https://github.com/progsource/maddy
+
+Version 1.4.0, https://github.com/progsource/maddy/releases/download/1.4.0/maddy-src.zip

--- a/src/sbml/maddy/blockparser.h
+++ b/src/sbml/maddy/blockparser.h
@@ -1,0 +1,192 @@
+/*
+ * This project is licensed under the MIT license. For more information see the
+ * LICENSE file.
+ */
+#pragma once
+
+// -----------------------------------------------------------------------------
+
+#include <functional>
+#include <sstream>
+#include <string>
+// windows compatibility includes
+#include <algorithm>
+#include <cctype>
+
+// -----------------------------------------------------------------------------
+
+namespace maddy {
+
+// -----------------------------------------------------------------------------
+
+/**
+ * BlockParser
+ *
+ * The code expects every child to have the following static function to be
+ * implemented:
+ * `static bool IsStartingLine(const std::string& line)`
+ *
+ * @class
+ */
+class BlockParser
+{
+public:
+  /**
+   * ctor
+   *
+   * @method
+   * @param {std::function<void(std::string&)>} parseLineCallback
+   * @param {std::function<std::shared_ptr<BlockParser>(const std::string&
+   * line)>} getBlockParserForLineCallback
+   */
+  BlockParser(
+    std::function<void(std::string&)> parseLineCallback,
+    std::function<std::shared_ptr<BlockParser>(const std::string& line)>
+      getBlockParserForLineCallback
+  )
+    : result("", std::ios_base::ate | std::ios_base::in | std::ios_base::out)
+    , childParser(nullptr)
+    , parseLineCallback(parseLineCallback)
+    , getBlockParserForLineCallback(getBlockParserForLineCallback)
+  {}
+
+  /**
+   * dtor
+   *
+   * @method
+   */
+  virtual ~BlockParser() {}
+
+  /**
+   * AddLine
+   *
+   * Adding a line which has to be parsed.
+   *
+   * @method
+   * @param {std::string&} line
+   * @return {void}
+   */
+  virtual void AddLine(std::string& line)
+  {
+    this->parseBlock(line);
+
+    if (this->isInlineBlockAllowed() && !this->childParser)
+    {
+      this->childParser = this->getBlockParserForLine(line);
+    }
+
+    if (this->childParser)
+    {
+      this->childParser->AddLine(line);
+
+      if (this->childParser->IsFinished())
+      {
+        this->result << this->childParser->GetResult().str();
+        this->childParser = nullptr;
+      }
+
+      return;
+    }
+
+    if (this->isLineParserAllowed())
+    {
+      this->parseLine(line);
+    }
+
+    this->result << line;
+  }
+
+  /**
+   * IsFinished
+   *
+   * Check if the BlockParser is done
+   *
+   * @method
+   * @return {bool}
+   */
+  virtual bool IsFinished() const = 0;
+
+  /**
+   * GetResult
+   *
+   * Get the parsed HTML output.
+   *
+   * @method
+   * @return {std::stringstream}
+   */
+  std::stringstream& GetResult() { return this->result; }
+
+  /**
+   * Clear
+   *
+   * Clear the result to reuse the parser object.
+   *
+   * It is only used by one test for now.
+   *
+   * @method
+   * @return {void}
+   */
+  void Clear() { this->result.str(""); }
+
+protected:
+  std::stringstream result;
+  std::shared_ptr<BlockParser> childParser;
+
+  virtual bool isInlineBlockAllowed() const = 0;
+  virtual bool isLineParserAllowed() const = 0;
+  virtual void parseBlock(std::string& line) = 0;
+
+  void parseLine(std::string& line)
+  {
+    if (parseLineCallback)
+    {
+      parseLineCallback(line);
+    }
+  }
+
+  uint32_t getIndentationWidth(const std::string& line) const
+  {
+    bool hasMetNonSpace = false;
+
+    uint32_t indentation = static_cast<uint32_t>(std::count_if(
+      line.begin(),
+      line.end(),
+      [&hasMetNonSpace](unsigned char c)
+      {
+        if (hasMetNonSpace)
+        {
+          return false;
+        }
+
+        if (std::isspace(c))
+        {
+          return true;
+        }
+
+        hasMetNonSpace = true;
+        return false;
+      }
+    ));
+
+    return indentation;
+  }
+
+  std::shared_ptr<BlockParser> getBlockParserForLine(const std::string& line)
+  {
+    if (getBlockParserForLineCallback)
+    {
+      return getBlockParserForLineCallback(line);
+    }
+
+    return nullptr;
+  }
+
+private:
+  std::function<void(std::string&)> parseLineCallback;
+  std::function<std::shared_ptr<BlockParser>(const std::string& line)>
+    getBlockParserForLineCallback;
+}; // class BlockParser
+
+// -----------------------------------------------------------------------------
+
+} // namespace maddy

--- a/src/sbml/maddy/breaklineparser.h
+++ b/src/sbml/maddy/breaklineparser.h
@@ -1,0 +1,50 @@
+/*
+ * This project is licensed under the MIT license. For more information see the
+ * LICENSE file.
+ */
+#pragma once
+
+// -----------------------------------------------------------------------------
+
+#include <regex>
+#include <string>
+
+#include "maddy/lineparser.h"
+
+// -----------------------------------------------------------------------------
+
+namespace maddy {
+
+// -----------------------------------------------------------------------------
+
+/**
+ * BreakLineParser
+ *
+ * @class
+ */
+class BreakLineParser : public LineParser
+{
+public:
+  /**
+   * Parse
+   *
+   * From Markdown: `text\r\n text`
+   *
+   * To HTML: `text<br> text`
+   *
+   * @method
+   * @param {std::string&} line The line to interpret
+   * @return {void}
+   */
+  void Parse(std::string& line) override
+  {
+    static std::regex re(R"((\r\n|\r))");
+    static std::string replacement = "<br>";
+
+    line = std::regex_replace(line, re, replacement);
+  }
+}; // class BreakLineParser
+
+// -----------------------------------------------------------------------------
+
+} // namespace maddy

--- a/src/sbml/maddy/checklistparser.h
+++ b/src/sbml/maddy/checklistparser.h
@@ -1,0 +1,127 @@
+/*
+ * This project is licensed under the MIT license. For more information see the
+ * LICENSE file.
+ */
+#pragma once
+
+// -----------------------------------------------------------------------------
+
+#include <functional>
+#include <regex>
+#include <string>
+
+#include "maddy/blockparser.h"
+
+// -----------------------------------------------------------------------------
+
+namespace maddy {
+
+// -----------------------------------------------------------------------------
+
+/**
+ * ChecklistParser
+ *
+ * @class
+ */
+class ChecklistParser : public BlockParser
+{
+public:
+  /**
+   * ctor
+   *
+   * @method
+   * @param {std::function<void(std::string&)>} parseLineCallback
+   * @param {std::function<std::shared_ptr<BlockParser>(const std::string&
+   * line)>} getBlockParserForLineCallback
+   */
+  ChecklistParser(
+    std::function<void(std::string&)> parseLineCallback,
+    std::function<std::shared_ptr<BlockParser>(const std::string& line)>
+      getBlockParserForLineCallback
+  )
+    : BlockParser(parseLineCallback, getBlockParserForLineCallback)
+    , isStarted(false)
+    , isFinished(false)
+  {}
+
+  /**
+   * IsStartingLine
+   *
+   * An unordered list starts with `* `.
+   *
+   * @method
+   * @param {const std::string&} line
+   * @return {bool}
+   */
+  static bool IsStartingLine(const std::string& line)
+  {
+    static std::regex re(R"(^- \[[x| ]\] .*)");
+    return std::regex_match(line, re);
+  }
+
+  /**
+   * IsFinished
+   *
+   * @method
+   * @return {bool}
+   */
+  bool IsFinished() const override { return this->isFinished; }
+
+protected:
+  bool isInlineBlockAllowed() const override { return true; }
+
+  bool isLineParserAllowed() const override { return true; }
+
+  void parseBlock(std::string& line) override
+  {
+    bool isStartOfNewListItem = IsStartingLine(line);
+    uint32_t indentation = getIndentationWidth(line);
+
+    static std::regex lineRegex("^(- )");
+    line = std::regex_replace(line, lineRegex, "");
+
+    static std::regex emptyBoxRegex(R"(^\[ \])");
+    static std::string emptyBoxReplacement = "<input type=\"checkbox\"/>";
+    line = std::regex_replace(line, emptyBoxRegex, emptyBoxReplacement);
+
+    static std::regex boxRegex(R"(^\[x\])");
+    static std::string boxReplacement =
+      "<input type=\"checkbox\" checked=\"checked\"/>";
+    line = std::regex_replace(line, boxRegex, boxReplacement);
+
+    if (!this->isStarted)
+    {
+      line = "<ul class=\"checklist\"><li><label>" + line;
+      this->isStarted = true;
+      return;
+    }
+
+    if (indentation >= 2)
+    {
+      line = line.substr(2);
+      return;
+    }
+
+    if (line.empty() ||
+        line.find("</label></li><li><label>") != std::string::npos ||
+        line.find("</label></li></ul>") != std::string::npos)
+    {
+      line = "</label></li></ul>" + line;
+      this->isFinished = true;
+      return;
+    }
+
+    if (isStartOfNewListItem)
+    {
+      line = "</label></li><li><label>" + line;
+    }
+  }
+
+private:
+  bool isStarted;
+  bool isFinished;
+}; // class ChecklistParser
+
+// -----------------------------------------------------------------------------
+
+} // namespace maddy

--- a/src/sbml/maddy/codeblockparser.h
+++ b/src/sbml/maddy/codeblockparser.h
@@ -1,0 +1,132 @@
+/*
+ * This project is licensed under the MIT license. For more information see the
+ * LICENSE file.
+ */
+#pragma once
+
+// -----------------------------------------------------------------------------
+
+#include <functional>
+#include <regex>
+#include <string>
+
+#include "maddy/blockparser.h"
+
+// -----------------------------------------------------------------------------
+
+namespace maddy {
+
+// -----------------------------------------------------------------------------
+
+/**
+ * CodeBlockParser
+ *
+ * From Markdown: 3 times surrounded code (without space in the beginning)
+ *
+ * ```
+ *  ```
+ * some code
+ *  ```
+ * ```
+ *
+ * To HTML:
+ *
+ * ```
+ * <pre><code>
+ * some code
+ * </code></pre>
+ * ```
+ *
+ * @class
+ */
+class CodeBlockParser : public BlockParser
+{
+public:
+  /**
+   * ctor
+   *
+   * @method
+   * @param {std::function<void(std::string&)>} parseLineCallback
+   * @param {std::function<std::shared_ptr<BlockParser>(const std::string&
+   * line)>} getBlockParserForLineCallback
+   */
+  CodeBlockParser(
+    std::function<void(std::string&)> parseLineCallback,
+    std::function<std::shared_ptr<BlockParser>(const std::string& line)>
+      getBlockParserForLineCallback
+  )
+    : BlockParser(parseLineCallback, getBlockParserForLineCallback)
+    , isStarted(false)
+    , isFinished(false)
+  {}
+
+  /**
+   * IsStartingLine
+   *
+   * If the line starts with three code signs, then it is a code block.
+   *
+   * ```
+   *  ```
+   * ```
+   *
+   * @method
+   * @param {const std::string&} line
+   * @return {bool}
+   */
+  static bool IsStartingLine(const std::string& line)
+  {
+    static std::regex re("^(?:`){3}(.*)$");
+    return std::regex_match(line, re);
+  }
+
+  /**
+   * IsFinished
+   *
+   * @method
+   * @return {bool}
+   */
+  bool IsFinished() const override { return this->isFinished; }
+
+protected:
+  bool isInlineBlockAllowed() const override { return false; }
+
+  bool isLineParserAllowed() const override { return false; }
+
+  void parseBlock(std::string& line) override
+  {
+    if (line == "```")
+    {
+      if (!this->isStarted)
+      {
+        line = "<pre><code>\n";
+        this->isStarted = true;
+        this->isFinished = false;
+        return;
+      }
+      else
+      {
+        line = "</code></pre>";
+        this->isFinished = true;
+        this->isStarted = false;
+        return;
+      }
+    }
+    else if (!this->isStarted && line.substr(0, 3) == "```")
+    {
+      line = "<pre class=\"" + line.substr(3) + "\"><code>\n";
+      this->isStarted = true;
+      this->isFinished = false;
+      return;
+    }
+
+    line += "\n";
+  }
+
+private:
+  bool isStarted;
+  bool isFinished;
+}; // class CodeBlockParser
+
+// -----------------------------------------------------------------------------
+
+} // namespace maddy

--- a/src/sbml/maddy/emphasizedparser.h
+++ b/src/sbml/maddy/emphasizedparser.h
@@ -1,0 +1,54 @@
+/*
+ * This project is licensed under the MIT license. For more information see the
+ * LICENSE file.
+ */
+#pragma once
+
+// -----------------------------------------------------------------------------
+
+#include <regex>
+#include <string>
+
+#include "maddy/lineparser.h"
+
+// -----------------------------------------------------------------------------
+
+namespace maddy {
+
+// -----------------------------------------------------------------------------
+
+/**
+ * EmphasizedParser
+ *
+ * Has to be used after the `StrongParser`.
+ *
+ * @class
+ */
+class EmphasizedParser : public LineParser
+{
+public:
+  /**
+   * Parse
+   *
+   * From Markdown: `text _text_`
+   *
+   * To HTML: `text <em>text</em>`
+   *
+   * @method
+   * @param {std::string&} line The line to interpret
+   * @return {void}
+   */
+  void Parse(std::string& line) override
+  {
+    static std::regex re(
+      R"((?!.*`.*|.*<code>.*)_(?!.*`.*|.*<\/code>.*)([^_]*)_(?!.*`.*|.*<\/code>.*))"
+    );
+    static std::string replacement = "<em>$1</em>";
+
+    line = std::regex_replace(line, re, replacement);
+  }
+}; // class EmphasizedParser
+
+// -----------------------------------------------------------------------------
+
+} // namespace maddy

--- a/src/sbml/maddy/headlineparser.h
+++ b/src/sbml/maddy/headlineparser.h
@@ -1,0 +1,134 @@
+/*
+ * This project is licensed under the MIT license. For more information see the
+ * LICENSE file.
+ */
+#pragma once
+
+// -----------------------------------------------------------------------------
+
+#include <functional>
+#include <regex>
+#include <string>
+
+#include "maddy/blockparser.h"
+
+// -----------------------------------------------------------------------------
+
+namespace maddy {
+
+// -----------------------------------------------------------------------------
+
+/**
+ * HeadlineParser
+ *
+ * From Markdown:
+ *
+ * ```
+ * # Headline 1
+ * ## Headline 2
+ * ### Headline 3
+ * #### Headline 4
+ * ##### Headline 5
+ * ###### Headline 6
+ * ```
+ *
+ * To HTML:
+ *
+ * ```
+ * <h1>Headline 1</h1>
+ * <h2>Headline 2</h2>
+ * <h3>Headline 3</h3>
+ * <h4>Headline 4</h4>
+ * <h5>Headline 5</h5>
+ * <h6>Headline 6</h6>
+ * ```
+ *
+ * @class
+ */
+class HeadlineParser : public BlockParser
+{
+public:
+  /**
+   * ctor
+   *
+   * @method
+   * @param {std::function<void(std::string&)>} parseLineCallback
+   * @param {std::function<std::shared_ptr<BlockParser>(const std::string&
+   * line)>} getBlockParserForLineCallback
+   */
+  HeadlineParser(
+    std::function<void(std::string&)> parseLineCallback,
+    std::function<std::shared_ptr<BlockParser>(const std::string& line)>
+      getBlockParserForLineCallback,
+    bool isInlineParserAllowed = true
+  )
+    : BlockParser(parseLineCallback, getBlockParserForLineCallback)
+    , isInlineParserAllowed(isInlineParserAllowed)
+  {}
+
+  /**
+   * IsStartingLine
+   *
+   * If the line starts with 1 - 6 `#`, then it is a headline.
+   *
+   * @method
+   * @param {const std::string&} line
+   * @return {bool}
+   */
+  static bool IsStartingLine(const std::string& line)
+  {
+    static std::regex re("^(?:#){1,6} (.*)");
+    return std::regex_match(line, re);
+  }
+
+  /**
+   * IsFinished
+   *
+   * The headline is always only one line long, so this method always returns
+   * true.
+   *
+   * @method
+   * @return {bool}
+   */
+  bool IsFinished() const override { return true; }
+
+protected:
+  bool isInlineBlockAllowed() const override { return false; }
+
+  bool isLineParserAllowed() const override
+  {
+    return this->isInlineParserAllowed;
+  }
+
+  void parseBlock(std::string& line) override
+  {
+    static std::vector<std::regex> hlRegex = {
+      std::regex("^# (.*)"),
+      std::regex("^(?:#){2} (.*)"),
+      std::regex("^(?:#){3} (.*)"),
+      std::regex("^(?:#){4} (.*)"),
+      std::regex("^(?:#){5} (.*)"),
+      std::regex("^(?:#){6} (.*)")
+    };
+    static std::vector<std::string> hlReplacement = {
+      "<h1>$1</h1>",
+      "<h2>$1</h2>",
+      "<h3>$1</h3>",
+      "<h4>$1</h4>",
+      "<h5>$1</h5>",
+      "<h6>$1</h6>"
+    };
+
+    for (uint8_t i = 0; i < 6; ++i)
+    {
+      line = std::regex_replace(line, hlRegex[i], hlReplacement[i]);
+    }
+  }
+
+private:
+  bool isInlineParserAllowed;
+}; // class HeadlineParser
+
+// -----------------------------------------------------------------------------
+
+} // namespace maddy

--- a/src/sbml/maddy/horizontallineparser.h
+++ b/src/sbml/maddy/horizontallineparser.h
@@ -1,0 +1,94 @@
+/*
+ * This project is licensed under the MIT license. For more information see the
+ * LICENSE file.
+ */
+#pragma once
+
+// -----------------------------------------------------------------------------
+
+#include <functional>
+#include <regex>
+#include <string>
+
+#include "maddy/blockparser.h"
+
+// -----------------------------------------------------------------------------
+
+namespace maddy {
+
+// -----------------------------------------------------------------------------
+
+/**
+ * HorizontalLineParser
+ *
+ * From Markdown: `---`
+ *
+ * To HTML: `<hr/>`
+ *
+ * @class
+ */
+class HorizontalLineParser : public BlockParser
+{
+public:
+  /**
+   * ctor
+   *
+   * @method
+   * @param {std::function<void(std::string&)>} parseLineCallback
+   * @param {std::function<std::shared_ptr<BlockParser>(const std::string&
+   * line)>} getBlockParserForLineCallback
+   */
+  HorizontalLineParser(
+    std::function<void(std::string&)> parseLineCallback,
+    std::function<std::shared_ptr<BlockParser>(const std::string& line)>
+      getBlockParserForLineCallback
+  )
+    : BlockParser(parseLineCallback, getBlockParserForLineCallback)
+    , lineRegex("^---$")
+  {}
+
+  /**
+   * IsStartingLine
+   *
+   * If the line has exact three dashes `---`, then it is a horizontal line.
+   *
+   * @method
+   * @param {const std::string&} line
+   * @return {bool}
+   */
+  static bool IsStartingLine(const std::string& line)
+  {
+    static std::regex re("^---$");
+    return std::regex_match(line, re);
+  }
+
+  /**
+   * IsFinished
+   *
+   * The horizontal line is always only one line long, so this method always
+   * returns true.
+   *
+   * @method
+   * @return {bool}
+   */
+  bool IsFinished() const override { return true; }
+
+protected:
+  bool isInlineBlockAllowed() const override { return false; }
+
+  bool isLineParserAllowed() const override { return false; }
+
+  void parseBlock(std::string& line) override
+  {
+    static std::string replacement = "<hr/>";
+
+    line = std::regex_replace(line, lineRegex, replacement);
+  }
+
+private:
+  std::regex lineRegex;
+}; // class HorizontalLineParser
+
+// -----------------------------------------------------------------------------
+
+} // namespace maddy

--- a/src/sbml/maddy/htmlparser.h
+++ b/src/sbml/maddy/htmlparser.h
@@ -1,0 +1,112 @@
+/*
+ * This project is licensed under the MIT license. For more information see the
+ * LICENSE file.
+ */
+#pragma once
+
+// -----------------------------------------------------------------------------
+
+#include <functional>
+#include <string>
+
+#include "maddy/blockparser.h"
+
+// -----------------------------------------------------------------------------
+
+namespace maddy {
+
+// -----------------------------------------------------------------------------
+
+/**
+ * HtmlParser
+ *
+ * @class
+ */
+class HtmlParser : public BlockParser
+{
+public:
+  /**
+   * ctor
+   *
+   * @method
+   * @param {std::function<void(std::string&)>} parseLineCallback
+   * @param {std::function<std::shared_ptr<BlockParser>(const std::string&
+   * line)>} getBlockParserForLineCallback
+   */
+  HtmlParser(
+    std::function<void(std::string&)> parseLineCallback,
+    std::function<std::shared_ptr<BlockParser>(const std::string& line)>
+      getBlockParserForLineCallback
+  )
+    : BlockParser(parseLineCallback, getBlockParserForLineCallback)
+    , isStarted(false)
+    , isFinished(false)
+    , isGreaterThanFound(false)
+  {}
+
+  /**
+   * IsStartingLine
+   *
+   * If the line is starting with `<`, HTML is expected to follow.
+   * Nothing after that will be parsed, it only is copied.
+   *
+   * @method
+   * @param {const std::string&} line
+   * @return {bool}
+   */
+  static bool IsStartingLine(const std::string& line) { return line[0] == '<'; }
+
+  /**
+   * IsFinished
+   *
+   * `>` followed by an empty line will end the HTML block.
+   *
+   * @method
+   * @return {bool}
+   */
+  bool IsFinished() const override { return this->isFinished; }
+
+protected:
+  bool isInlineBlockAllowed() const override { return false; }
+
+  bool isLineParserAllowed() const override { return false; }
+
+  void parseBlock(std::string& line) override
+  {
+    if (!this->isStarted)
+    {
+      this->isStarted = true;
+    }
+
+    if (!line.empty() && line[line.size() - 1] == '>')
+    {
+      this->isGreaterThanFound = true;
+      return;
+    }
+
+    if (line.empty() && this->isGreaterThanFound)
+    {
+      this->isFinished = true;
+      return;
+    }
+
+    if (!line.empty() && this->isGreaterThanFound)
+    {
+      this->isGreaterThanFound = false;
+    }
+
+    if (!line.empty())
+    {
+      line += " ";
+    }
+  }
+
+private:
+  bool isStarted;
+  bool isFinished;
+  bool isGreaterThanFound;
+}; // class HtmlParser
+
+// -----------------------------------------------------------------------------
+
+} // namespace maddy

--- a/src/sbml/maddy/imageparser.h
+++ b/src/sbml/maddy/imageparser.h
@@ -1,0 +1,52 @@
+/*
+ * This project is licensed under the MIT license. For more information see the
+ * LICENSE file.
+ */
+#pragma once
+
+// -----------------------------------------------------------------------------
+
+#include <regex>
+#include <string>
+
+#include "maddy/lineparser.h"
+
+// -----------------------------------------------------------------------------
+
+namespace maddy {
+
+// -----------------------------------------------------------------------------
+
+/**
+ * ImageParser
+ *
+ * Has to be used before the `LinkParser`.
+ *
+ * @class
+ */
+class ImageParser : public LineParser
+{
+public:
+  /**
+   * Parse
+   *
+   * From Markdown: `![text](http://example.com/a.png)`
+   *
+   * To HTML: `<img src="http://example.com/a.png" alt="text"/>`
+   *
+   * @method
+   * @param {std::string&} line The line to interpret
+   * @return {void}
+   */
+  void Parse(std::string& line) override
+  {
+    static std::regex re(R"(\!\[([^\]]*)\]\(([^\]]*)\))");
+    static std::string replacement = "<img src=\"$2\" alt=\"$1\"/>";
+
+    line = std::regex_replace(line, re, replacement);
+  }
+}; // class ImageParser
+
+// -----------------------------------------------------------------------------
+
+} // namespace maddy

--- a/src/sbml/maddy/inlinecodeparser.h
+++ b/src/sbml/maddy/inlinecodeparser.h
@@ -1,0 +1,50 @@
+/*
+ * This project is licensed under the MIT license. For more information see the
+ * LICENSE file.
+ */
+#pragma once
+
+// -----------------------------------------------------------------------------
+
+#include <regex>
+#include <string>
+
+#include "maddy/lineparser.h"
+
+// -----------------------------------------------------------------------------
+
+namespace maddy {
+
+// -----------------------------------------------------------------------------
+
+/**
+ * InlineCodeParser
+ *
+ * @class
+ */
+class InlineCodeParser : public LineParser
+{
+public:
+  /**
+   * Parse
+   *
+   * From Markdown: `text `some code``
+   *
+   * To HTML: `text <code>some code</code>`
+   *
+   * @method
+   * @param {std::string&} line The line to interpret
+   * @return {void}
+   */
+  void Parse(std::string& line) override
+  {
+    static std::regex re("`([^`]*)`");
+    static std::string replacement = "<code>$1</code>";
+
+    line = std::regex_replace(line, re, replacement);
+  }
+}; // class InlineCodeParser
+
+// -----------------------------------------------------------------------------
+
+} // namespace maddy

--- a/src/sbml/maddy/italicparser.h
+++ b/src/sbml/maddy/italicparser.h
@@ -1,0 +1,51 @@
+/*
+ * This project is licensed under the MIT license. For more information see the
+ * LICENSE file.
+ */
+#pragma once
+
+// -----------------------------------------------------------------------------
+
+#include <regex>
+#include <string>
+
+#include "maddy/lineparser.h"
+
+// -----------------------------------------------------------------------------
+
+namespace maddy {
+
+// -----------------------------------------------------------------------------
+
+/**
+ * ItalicParser
+ *
+ * @class
+ */
+class ItalicParser : public LineParser
+{
+public:
+  /**
+   * Parse
+   *
+   * From Markdown: `text *text*`
+   *
+   * To HTML: `text <i>text</i>`
+   *
+   * @method
+   * @param {std::string&} line The line to interpret
+   * @return {void}
+   */
+  void Parse(std::string& line) override
+  {
+    static std::regex re(
+      R"((?!.*`.*|.*<code>.*)\*(?!.*`.*|.*<\/code>.*)([^\*]*)\*(?!.*`.*|.*<\/code>.*))"
+    );
+    static std::string replacement = "<i>$1</i>";
+    line = std::regex_replace(line, re, replacement);
+  }
+}; // class ItalicParser
+
+// -----------------------------------------------------------------------------
+
+} // namespace maddy

--- a/src/sbml/maddy/latexblockparser.h
+++ b/src/sbml/maddy/latexblockparser.h
@@ -1,0 +1,124 @@
+/*
+ * This project is licensed under the MIT license. For more information see the
+ * LICENSE file.
+ */
+#pragma once
+
+// -----------------------------------------------------------------------------
+
+#include <functional>
+#include <regex>
+#include <string>
+
+#include "maddy/blockparser.h"
+
+// -----------------------------------------------------------------------------
+
+namespace maddy {
+
+// -----------------------------------------------------------------------------
+
+/**
+ * LatexBlockParser
+ *
+ * Support for https://www.mathjax.org/
+ * Be aware, that if you want to make MathJax work, you need also their
+ * JavaScript library added to your HTML code.
+ * maddy does not itself add that code to be more flexible in how you write your
+ * head and full body.
+ *
+ * From Markdown: `$$` surrounded text
+ *
+ * ```
+ *  $$some formula
+ *  $$
+ * ```
+ *
+ * To HTML:
+ *
+ * ```
+ * $$some formula
+ * $$
+ * ```
+ *
+ * @class
+ */
+class LatexBlockParser : public BlockParser
+{
+public:
+  /**
+   * ctor
+   *
+   * @method
+   * @param {std::function<void(std::string&)>} parseLineCallback
+   * @param {std::function<std::shared_ptr<BlockParser>(const std::string&
+   * line)>} getBlockParserForLineCallback
+   */
+  LatexBlockParser(
+    std::function<void(std::string&)> parseLineCallback,
+    std::function<std::shared_ptr<BlockParser>(const std::string& line)>
+      getBlockParserForLineCallback
+  )
+    : BlockParser(parseLineCallback, getBlockParserForLineCallback)
+    , isStarted(false)
+    , isFinished(false)
+  {}
+
+  /**
+   * IsStartingLine
+   *
+   * If the line starts with two dollars, then it is a latex block.
+   *
+   * ```
+   *  $$
+   * ```
+   *
+   * @method
+   * @param {const std::string&} line
+   * @return {bool}
+   */
+  static bool IsStartingLine(const std::string& line)
+  {
+    static std::regex re(R"(^(?:\$){2}(.*)$)");
+    return std::regex_match(line, re);
+  }
+
+  /**
+   * IsFinished
+   *
+   * @method
+   * @return {bool}
+   */
+  bool IsFinished() const override { return this->isFinished; }
+
+protected:
+  bool isInlineBlockAllowed() const override { return false; }
+
+  bool isLineParserAllowed() const override { return false; }
+
+  void parseBlock(std::string& line) override
+  {
+    if (!this->isStarted && line.substr(0, 2) == "$$")
+    {
+      this->isStarted = true;
+      this->isFinished = false;
+    }
+
+    if (this->isStarted && !this->isFinished && line.size() > 1 &&
+        line.substr(line.size() - 2, 2) == "$$")
+    {
+      this->isFinished = true;
+      this->isStarted = false;
+    }
+
+    line += "\n";
+  }
+
+private:
+  bool isStarted;
+  bool isFinished;
+}; // class LatexBlockParser
+
+// -----------------------------------------------------------------------------
+
+} // namespace maddy

--- a/src/sbml/maddy/lineparser.h
+++ b/src/sbml/maddy/lineparser.h
@@ -1,0 +1,46 @@
+/*
+ * This project is licensed under the MIT license. For more information see the
+ * LICENSE file.
+ */
+#pragma once
+
+// -----------------------------------------------------------------------------
+
+#include <string>
+
+// -----------------------------------------------------------------------------
+
+namespace maddy {
+
+// -----------------------------------------------------------------------------
+
+/**
+ * LineParser
+ *
+ * @class
+ */
+class LineParser
+{
+public:
+  /**
+   * dtor
+   *
+   * @method
+   */
+  virtual ~LineParser() {}
+
+  /**
+   * Parse
+   *
+   * From Markdown to HTML
+   *
+   * @method
+   * @param {std::string&} line The line to interpret
+   * @return {void}
+   */
+  virtual void Parse(std::string& line) = 0;
+}; // class LineParser
+
+// -----------------------------------------------------------------------------
+
+} // namespace maddy

--- a/src/sbml/maddy/linkparser.h
+++ b/src/sbml/maddy/linkparser.h
@@ -1,0 +1,52 @@
+/*
+ * This project is licensed under the MIT license. For more information see the
+ * LICENSE file.
+ */
+#pragma once
+
+// -----------------------------------------------------------------------------
+
+#include <regex>
+#include <string>
+
+#include "maddy/lineparser.h"
+
+// -----------------------------------------------------------------------------
+
+namespace maddy {
+
+// -----------------------------------------------------------------------------
+
+/**
+ * LinkParser
+ *
+ * Has to be used after the `ImageParser`.
+ *
+ * @class
+ */
+class LinkParser : public LineParser
+{
+public:
+  /**
+   * Parse
+   *
+   * From Markdown: `[text](http://example.com)`
+   *
+   * To HTML: `<a href="http://example.com">text</a>`
+   *
+   * @method
+   * @param {std::string&} line The line to interpret
+   * @return {void}
+   */
+  void Parse(std::string& line) override
+  {
+    static std::regex re(R"(\[([^\]]*)\]\(([^)]*)\))");
+    static std::string replacement = "<a href=\"$2\">$1</a>";
+
+    line = std::regex_replace(line, re, replacement);
+  }
+}; // class LinkParser
+
+// -----------------------------------------------------------------------------
+
+} // namespace maddy

--- a/src/sbml/maddy/linkparser.h
+++ b/src/sbml/maddy/linkparser.h
@@ -40,10 +40,15 @@ public:
    */
   void Parse(std::string& line) override
   {
-    static std::regex re(R"(\[([^\]]*)\]\(([^)]*)\))");
-    static std::string replacement = "<a href=\"$2\">$1</a>";
+      //Match [name](http:://link "title text")
+      static std::regex re(R"(\[([^\]]*)\]\(([^\)\" ]*) \"([^\"]*)\"\))");
+      static std::string replacement = "<a href=\"$2\" title=\"$3\">$1</a>";
+      line = std::regex_replace(line, re, replacement);
 
-    line = std::regex_replace(line, re, replacement);
+      //Match [name](http:://link)
+      static std::regex re2(R"(\[([^\]]*)\]\(([^)]*)\))");
+      static std::string replacement2 = "<a href=\"$2\">$1</a>";
+      line = std::regex_replace(line, re2, replacement2);
   }
 }; // class LinkParser
 

--- a/src/sbml/maddy/orderedlistparser.h
+++ b/src/sbml/maddy/orderedlistparser.h
@@ -1,0 +1,126 @@
+/*
+ * This project is licensed under the MIT license. For more information see the
+ * LICENSE file.
+ */
+#pragma once
+
+// -----------------------------------------------------------------------------
+
+#include <functional>
+#include <regex>
+#include <string>
+
+#include "maddy/blockparser.h"
+
+// -----------------------------------------------------------------------------
+
+namespace maddy {
+
+// -----------------------------------------------------------------------------
+
+/**
+ * OrderedListParser
+ *
+ * @class
+ */
+class OrderedListParser : public BlockParser
+{
+public:
+  /**
+   * ctor
+   *
+   * @method
+   * @param {std::function<void(std::string&)>} parseLineCallback
+   * @param {std::function<std::shared_ptr<BlockParser>(const std::string&
+   * line)>} getBlockParserForLineCallback
+   */
+  OrderedListParser(
+    std::function<void(std::string&)> parseLineCallback,
+    std::function<std::shared_ptr<BlockParser>(const std::string& line)>
+      getBlockParserForLineCallback
+  )
+    : BlockParser(parseLineCallback, getBlockParserForLineCallback)
+    , isStarted(false)
+    , isFinished(false)
+  {}
+
+  /**
+   * IsStartingLine
+   *
+   * An ordered list starts with `1. `.
+   *
+   * @method
+   * @param {const std::string&} line
+   * @return {bool}
+   */
+  static bool IsStartingLine(const std::string& line)
+  {
+    static std::regex re("^1\\. .*");
+    return std::regex_match(line, re);
+  }
+
+  /**
+   * IsFinished
+   *
+   * @method
+   * @return {bool}
+   */
+  bool IsFinished() const override { return this->isFinished; }
+
+protected:
+  bool isInlineBlockAllowed() const override { return true; }
+
+  bool isLineParserAllowed() const override { return true; }
+
+  void parseBlock(std::string& line) override
+  {
+    bool isStartOfNewListItem = this->isStartOfNewListItem(line);
+    uint32_t indentation = getIndentationWidth(line);
+
+    static std::regex orderedlineRegex(R"(^[1-9]+[0-9]*\. )");
+    line = std::regex_replace(line, orderedlineRegex, "");
+    static std::regex unorderedlineRegex(R"(^\* )");
+    line = std::regex_replace(line, unorderedlineRegex, "");
+
+    if (!this->isStarted)
+    {
+      line = "<ol><li>" + line;
+      this->isStarted = true;
+      return;
+    }
+
+    if (indentation >= 2)
+    {
+      line = line.substr(2);
+      return;
+    }
+
+    if (line.empty() || line.find("</li><li>") != std::string::npos ||
+        line.find("</li></ol>") != std::string::npos ||
+        line.find("</li></ul>") != std::string::npos)
+    {
+      line = "</li></ol>" + line;
+      this->isFinished = true;
+      return;
+    }
+
+    if (isStartOfNewListItem)
+    {
+      line = "</li><li>" + line;
+    }
+  }
+
+private:
+  bool isStarted;
+  bool isFinished;
+
+  bool isStartOfNewListItem(const std::string& line) const
+  {
+    static std::regex re(R"(^(?:[1-9]+[0-9]*\. |\* ).*)");
+    return std::regex_match(line, re);
+  }
+}; // class OrderedListParser
+
+// -----------------------------------------------------------------------------
+
+} // namespace maddy

--- a/src/sbml/maddy/paragraphparser.h
+++ b/src/sbml/maddy/paragraphparser.h
@@ -1,0 +1,115 @@
+/*
+ * This project is licensed under the MIT license. For more information see the
+ * LICENSE file.
+ */
+#pragma once
+
+// -----------------------------------------------------------------------------
+
+#include <functional>
+#include <string>
+
+#include "maddy/blockparser.h"
+
+// -----------------------------------------------------------------------------
+
+namespace maddy {
+
+// -----------------------------------------------------------------------------
+
+/**
+ * ParagraphParser
+ *
+ * @class
+ */
+class ParagraphParser : public BlockParser
+{
+public:
+  /**
+   * ctor
+   *
+   * @method
+   * @param {std::function<void(std::string&)>} parseLineCallback
+   * @param {std::function<std::shared_ptr<BlockParser>(const std::string&
+   * line)>} getBlockParserForLineCallback
+   */
+  ParagraphParser(
+    std::function<void(std::string&)> parseLineCallback,
+    std::function<std::shared_ptr<BlockParser>(const std::string& line)>
+      getBlockParserForLineCallback,
+    bool isEnabled
+  )
+    : BlockParser(parseLineCallback, getBlockParserForLineCallback)
+    , isStarted(false)
+    , isFinished(false)
+    , isEnabled(isEnabled)
+  {}
+
+  /**
+   * IsStartingLine
+   *
+   * If the line is not empty, it will be a paragraph.
+   *
+   * This block parser has to always run as the last one!
+   *
+   * @method
+   * @param {const std::string&} line
+   * @return {bool}
+   */
+  static bool IsStartingLine(const std::string& line) { return !line.empty(); }
+
+  /**
+   * IsFinished
+   *
+   * An empty line will end the paragraph.
+   *
+   * @method
+   * @return {bool}
+   */
+  bool IsFinished() const override { return this->isFinished; }
+
+protected:
+  bool isInlineBlockAllowed() const override { return false; }
+
+  bool isLineParserAllowed() const override { return true; }
+
+  void parseBlock(std::string& line) override
+  {
+    if (this->isEnabled && !this->isStarted)
+    {
+      line = "<p>" + line + " ";
+      this->isStarted = true;
+      return;
+    }
+    else if (!this->isEnabled && !this->isStarted)
+    {
+      line += " ";
+      this->isStarted = true;
+      return;
+    }
+
+    if (this->isEnabled && line.empty())
+    {
+      line += "</p>";
+      this->isFinished = true;
+      return;
+    }
+    else if (!this->isEnabled && line.empty())
+    {
+      line += "<br/>";
+      this->isFinished = true;
+      return;
+    }
+
+    line += " ";
+  }
+
+private:
+  bool isStarted;
+  bool isFinished;
+  bool isEnabled;
+}; // class ParagraphParser
+
+// -----------------------------------------------------------------------------
+
+} // namespace maddy

--- a/src/sbml/maddy/parser.h
+++ b/src/sbml/maddy/parser.h
@@ -1,0 +1,401 @@
+/*
+ * This project is licensed under the MIT license. For more information see the
+ * LICENSE file.
+ */
+#pragma once
+
+// -----------------------------------------------------------------------------
+
+#include <functional>
+#include <memory>
+#include <string>
+
+#include "maddy/parserconfig.h"
+
+// BlockParser
+#include "maddy/checklistparser.h"
+#include "maddy/codeblockparser.h"
+#include "maddy/headlineparser.h"
+#include "maddy/horizontallineparser.h"
+#include "maddy/htmlparser.h"
+#include "maddy/latexblockparser.h"
+#include "maddy/orderedlistparser.h"
+#include "maddy/paragraphparser.h"
+#include "maddy/quoteparser.h"
+#include "maddy/tableparser.h"
+#include "maddy/unorderedlistparser.h"
+
+// LineParser
+#include "maddy/breaklineparser.h"
+#include "maddy/emphasizedparser.h"
+#include "maddy/imageparser.h"
+#include "maddy/inlinecodeparser.h"
+#include "maddy/italicparser.h"
+#include "maddy/linkparser.h"
+#include "maddy/strikethroughparser.h"
+#include "maddy/strongparser.h"
+
+// -----------------------------------------------------------------------------
+
+namespace maddy {
+
+// -----------------------------------------------------------------------------
+
+/**
+ * Parser
+ *
+ * Transforms Markdown to HTML
+ *
+ * @class
+ */
+class Parser
+{
+public:
+  /**
+   * Version info
+   *
+   * Check https://github.com/progsource/maddy/blob/master/CHANGELOG.md
+   * for the changelog.
+   */
+  static const std::string& version()
+  {
+    static const std::string v = "1.4.0";
+    return v;
+  }
+
+  /**
+   * ctor
+   *
+   * Initializes all `LineParser`
+   *
+   * @method
+   */
+  Parser(std::shared_ptr<ParserConfig> config = nullptr) : config(config)
+  {
+    if (!this->config ||
+        (this->config->enabledParsers & maddy::types::BREAKLINE_PARSER) != 0)
+    {
+      this->breakLineParser = std::make_shared<BreakLineParser>();
+    }
+
+    if (!this->config ||
+        (this->config->enabledParsers & maddy::types::EMPHASIZED_PARSER) != 0)
+    {
+      this->emphasizedParser = std::make_shared<EmphasizedParser>();
+    }
+
+    if (!this->config ||
+        (this->config->enabledParsers & maddy::types::IMAGE_PARSER) != 0)
+    {
+      this->imageParser = std::make_shared<ImageParser>();
+    }
+
+    if (!this->config ||
+        (this->config->enabledParsers & maddy::types::INLINE_CODE_PARSER) != 0)
+    {
+      this->inlineCodeParser = std::make_shared<InlineCodeParser>();
+    }
+
+    if (!this->config ||
+        (this->config->enabledParsers & maddy::types::ITALIC_PARSER) != 0)
+    {
+      this->italicParser = std::make_shared<ItalicParser>();
+    }
+
+    if (!this->config ||
+        (this->config->enabledParsers & maddy::types::LINK_PARSER) != 0)
+    {
+      this->linkParser = std::make_shared<LinkParser>();
+    }
+
+    if (!this->config || (this->config->enabledParsers &
+                          maddy::types::STRIKETHROUGH_PARSER) != 0)
+    {
+      this->strikeThroughParser = std::make_shared<StrikeThroughParser>();
+    }
+
+    if (!this->config ||
+        (this->config->enabledParsers & maddy::types::STRONG_PARSER) != 0)
+    {
+      this->strongParser = std::make_shared<StrongParser>();
+    }
+  }
+
+  /**
+   * Parse
+   *
+   * @method
+   * @param {const std::istream&} markdown
+   * @return {std::string} HTML
+   */
+  std::string Parse(std::istream& markdown) const
+  {
+    std::string result = "";
+    std::shared_ptr<BlockParser> currentBlockParser = nullptr;
+
+    for (std::string line; std::getline(markdown, line);)
+    {
+      if (!currentBlockParser)
+      {
+        currentBlockParser = getBlockParserForLine(line);
+      }
+
+      if (currentBlockParser)
+      {
+        currentBlockParser->AddLine(line);
+
+        if (currentBlockParser->IsFinished())
+        {
+          result += currentBlockParser->GetResult().str();
+          currentBlockParser = nullptr;
+        }
+      }
+    }
+
+    // make sure, that all parsers are finished
+    if (currentBlockParser)
+    {
+      std::string emptyLine = "";
+      currentBlockParser->AddLine(emptyLine);
+      if (currentBlockParser->IsFinished())
+      {
+        result += currentBlockParser->GetResult().str();
+        currentBlockParser = nullptr;
+      }
+    }
+
+    return result;
+  }
+
+private:
+  std::shared_ptr<ParserConfig> config;
+  std::shared_ptr<BreakLineParser> breakLineParser;
+  std::shared_ptr<EmphasizedParser> emphasizedParser;
+  std::shared_ptr<ImageParser> imageParser;
+  std::shared_ptr<InlineCodeParser> inlineCodeParser;
+  std::shared_ptr<ItalicParser> italicParser;
+  std::shared_ptr<LinkParser> linkParser;
+  std::shared_ptr<StrikeThroughParser> strikeThroughParser;
+  std::shared_ptr<StrongParser> strongParser;
+
+  // block parser have to run before
+  void runLineParser(std::string& line) const
+  {
+    // Attention! ImageParser has to be before LinkParser
+    if (this->imageParser)
+    {
+      this->imageParser->Parse(line);
+    }
+
+    if (this->linkParser)
+    {
+      this->linkParser->Parse(line);
+    }
+
+    // Attention! StrongParser has to be before EmphasizedParser
+    if (this->strongParser)
+    {
+      this->strongParser->Parse(line);
+    }
+
+    if (this->emphasizedParser)
+    {
+      this->emphasizedParser->Parse(line);
+    }
+
+    if (this->strikeThroughParser)
+    {
+      this->strikeThroughParser->Parse(line);
+    }
+
+    if (this->inlineCodeParser)
+    {
+      this->inlineCodeParser->Parse(line);
+    }
+
+    if (this->italicParser)
+    {
+      this->italicParser->Parse(line);
+    }
+
+    if (this->breakLineParser)
+    {
+      this->breakLineParser->Parse(line);
+    }
+  }
+
+  std::shared_ptr<BlockParser> getBlockParserForLine(const std::string& line
+  ) const
+  {
+    std::shared_ptr<BlockParser> parser;
+
+    if ((!this->config || (this->config->enabledParsers &
+                           maddy::types::CODE_BLOCK_PARSER) != 0) &&
+        maddy::CodeBlockParser::IsStartingLine(line))
+    {
+      parser = std::make_shared<maddy::CodeBlockParser>(nullptr, nullptr);
+    }
+    else if (this->config &&
+             (this->config->enabledParsers & maddy::types::LATEX_BLOCK_PARSER
+             ) != 0 &&
+             maddy::LatexBlockParser::IsStartingLine(line))
+    {
+      parser = std::make_shared<LatexBlockParser>(nullptr, nullptr);
+    }
+    else if ((!this->config || (this->config->enabledParsers &
+                                maddy::types::HEADLINE_PARSER) != 0) &&
+             maddy::HeadlineParser::IsStartingLine(line))
+    {
+      if (!this->config || this->config->isHeadlineInlineParsingEnabled)
+      {
+        parser = std::make_shared<maddy::HeadlineParser>(
+          [this](std::string& line) { this->runLineParser(line); },
+          nullptr,
+          true
+        );
+      }
+      else
+      {
+        parser =
+          std::make_shared<maddy::HeadlineParser>(nullptr, nullptr, false);
+      }
+    }
+    else if ((!this->config || (this->config->enabledParsers &
+                                maddy::types::HORIZONTAL_LINE_PARSER) != 0) &&
+             maddy::HorizontalLineParser::IsStartingLine(line))
+    {
+      parser = std::make_shared<maddy::HorizontalLineParser>(nullptr, nullptr);
+    }
+    else if ((!this->config || (this->config->enabledParsers &
+                                maddy::types::QUOTE_PARSER) != 0) &&
+             maddy::QuoteParser::IsStartingLine(line))
+    {
+      parser = std::make_shared<maddy::QuoteParser>(
+        [this](std::string& line) { this->runLineParser(line); },
+        [this](const std::string& line)
+        { return this->getBlockParserForLine(line); }
+      );
+    }
+    else if ((!this->config || (this->config->enabledParsers &
+                                maddy::types::TABLE_PARSER) != 0) &&
+             maddy::TableParser::IsStartingLine(line))
+    {
+      parser = std::make_shared<maddy::TableParser>(
+        [this](std::string& line) { this->runLineParser(line); }, nullptr
+      );
+    }
+    else if ((!this->config || (this->config->enabledParsers &
+                                maddy::types::CHECKLIST_PARSER) != 0) &&
+             maddy::ChecklistParser::IsStartingLine(line))
+    {
+      parser = this->createChecklistParser();
+    }
+    else if ((!this->config || (this->config->enabledParsers &
+                                maddy::types::ORDERED_LIST_PARSER) != 0) &&
+             maddy::OrderedListParser::IsStartingLine(line))
+    {
+      parser = this->createOrderedListParser();
+    }
+    else if ((!this->config || (this->config->enabledParsers &
+                                maddy::types::UNORDERED_LIST_PARSER) != 0) &&
+             maddy::UnorderedListParser::IsStartingLine(line))
+    {
+      parser = this->createUnorderedListParser();
+    }
+    else if (this->config &&
+             (this->config->enabledParsers & maddy::types::HTML_PARSER) != 0 &&
+             maddy::HtmlParser::IsStartingLine(line))
+    {
+      parser = std::make_shared<maddy::HtmlParser>(nullptr, nullptr);
+    }
+    else if (maddy::ParagraphParser::IsStartingLine(line))
+    {
+      parser = std::make_shared<maddy::ParagraphParser>(
+        [this](std::string& line) { this->runLineParser(line); },
+        nullptr,
+        (!this->config ||
+         (this->config->enabledParsers & maddy::types::PARAGRAPH_PARSER) != 0)
+      );
+    }
+
+    return parser;
+  }
+
+  std::shared_ptr<BlockParser> createChecklistParser() const
+  {
+    return std::make_shared<maddy::ChecklistParser>(
+      [this](std::string& line) { this->runLineParser(line); },
+      [this](const std::string& line)
+      {
+        std::shared_ptr<BlockParser> parser;
+
+        if ((!this->config || (this->config->enabledParsers &
+                               maddy::types::CHECKLIST_PARSER) != 0) &&
+            maddy::ChecklistParser::IsStartingLine(line))
+        {
+          parser = this->createChecklistParser();
+        }
+
+        return parser;
+      }
+    );
+  }
+
+  std::shared_ptr<BlockParser> createOrderedListParser() const
+  {
+    return std::make_shared<maddy::OrderedListParser>(
+      [this](std::string& line) { this->runLineParser(line); },
+      [this](const std::string& line)
+      {
+        std::shared_ptr<BlockParser> parser;
+
+        if ((!this->config || (this->config->enabledParsers &
+                               maddy::types::ORDERED_LIST_PARSER) != 0) &&
+            maddy::OrderedListParser::IsStartingLine(line))
+        {
+          parser = this->createOrderedListParser();
+        }
+        else if ((!this->config || (this->config->enabledParsers &
+                                    maddy::types::UNORDERED_LIST_PARSER) != 0
+                 ) &&
+                 maddy::UnorderedListParser::IsStartingLine(line))
+        {
+          parser = this->createUnorderedListParser();
+        }
+
+        return parser;
+      }
+    );
+  }
+
+  std::shared_ptr<BlockParser> createUnorderedListParser() const
+  {
+    return std::make_shared<maddy::UnorderedListParser>(
+      [this](std::string& line) { this->runLineParser(line); },
+      [this](const std::string& line)
+      {
+        std::shared_ptr<BlockParser> parser;
+
+        if ((!this->config || (this->config->enabledParsers &
+                               maddy::types::ORDERED_LIST_PARSER) != 0) &&
+            maddy::OrderedListParser::IsStartingLine(line))
+        {
+          parser = this->createOrderedListParser();
+        }
+        else if ((!this->config || (this->config->enabledParsers &
+                                    maddy::types::UNORDERED_LIST_PARSER) != 0
+                 ) &&
+                 maddy::UnorderedListParser::IsStartingLine(line))
+        {
+          parser = this->createUnorderedListParser();
+        }
+
+        return parser;
+      }
+    );
+  }
+}; // class Parser
+
+// -----------------------------------------------------------------------------
+
+} // namespace maddy

--- a/src/sbml/maddy/parserconfig.h
+++ b/src/sbml/maddy/parserconfig.h
@@ -1,0 +1,81 @@
+/*
+ * This project is licensed under the MIT license. For more information see the
+ * LICENSE file.
+ */
+#pragma once
+
+#include <stdint.h>
+
+// -----------------------------------------------------------------------------
+
+namespace maddy {
+
+// -----------------------------------------------------------------------------
+
+namespace types {
+
+// clang-format off
+/**
+ * PARSER_TYPE
+ *
+ * Bitwise flags to turn on/off each parser
+*/
+enum PARSER_TYPE : uint32_t
+{
+  NONE                     = 0,
+
+  BREAKLINE_PARSER         = 0b1,
+  CHECKLIST_PARSER         = 0b10,
+  CODE_BLOCK_PARSER        = 0b100,
+  EMPHASIZED_PARSER        = 0b1000,
+  HEADLINE_PARSER          = 0b10000,
+  HORIZONTAL_LINE_PARSER   = 0b100000,
+  HTML_PARSER              = 0b1000000,
+  IMAGE_PARSER             = 0b10000000,
+  INLINE_CODE_PARSER       = 0b100000000,
+  ITALIC_PARSER            = 0b1000000000,
+  LINK_PARSER              = 0b10000000000,
+  ORDERED_LIST_PARSER      = 0b100000000000,
+  PARAGRAPH_PARSER         = 0b1000000000000,
+  QUOTE_PARSER             = 0b10000000000000,
+  STRIKETHROUGH_PARSER     = 0b100000000000000,
+  STRONG_PARSER            = 0b1000000000000000,
+  TABLE_PARSER             = 0b10000000000000000,
+  UNORDERED_LIST_PARSER    = 0b100000000000000000,
+  LATEX_BLOCK_PARSER       = 0b1000000000000000000,
+
+  DEFAULT                  = 0b0111111111110111111,
+  ALL                      = 0b1111111111111111111,
+};
+// clang-format on
+
+} // namespace types
+
+/**
+ * ParserConfig
+ *
+ * @class
+ */
+struct ParserConfig
+{
+  /**
+   * en-/disable headline inline-parsing
+   *
+   * default: enabled
+   */
+  bool isHeadlineInlineParsingEnabled;
+
+  /**
+   * enabled parsers bitfield
+   */
+  uint32_t enabledParsers;
+
+  ParserConfig()
+    : isHeadlineInlineParsingEnabled(true)
+    , enabledParsers(maddy::types::DEFAULT)
+  {}
+}; // class ParserConfig
+
+// -----------------------------------------------------------------------------
+
+} // namespace maddy

--- a/src/sbml/maddy/quoteparser.h
+++ b/src/sbml/maddy/quoteparser.h
@@ -1,0 +1,152 @@
+/*
+ * This project is licensed under the MIT license. For more information see the
+ * LICENSE file.
+ */
+#pragma once
+
+// -----------------------------------------------------------------------------
+
+#include <functional>
+#include <regex>
+#include <string>
+
+#include "maddy/blockparser.h"
+
+// -----------------------------------------------------------------------------
+
+namespace maddy {
+
+// -----------------------------------------------------------------------------
+
+/**
+ * QuoteParser
+ *
+ * @class
+ */
+class QuoteParser : public BlockParser
+{
+public:
+  /**
+   * ctor
+   *
+   * @method
+   * @param {std::function<void(std::string&)>} parseLineCallback
+   * @param {std::function<std::shared_ptr<BlockParser>(const std::string&
+   * line)>} getBlockParserForLineCallback
+   */
+  QuoteParser(
+    std::function<void(std::string&)> parseLineCallback,
+    std::function<std::shared_ptr<BlockParser>(const std::string& line)>
+      getBlockParserForLineCallback
+  )
+    : BlockParser(parseLineCallback, getBlockParserForLineCallback)
+    , isStarted(false)
+    , isFinished(false)
+  {}
+
+  /**
+   * IsStartingLine
+   *
+   * A quote starts with `> `.
+   *
+   * @method
+   * @param {const std::string&} line
+   * @return {bool}
+   */
+  static bool IsStartingLine(const std::string& line)
+  {
+    static std::regex re(R"(^\>.*)");
+    return std::regex_match(line, re);
+  }
+
+  /**
+   * AddLine
+   *
+   * Adding a line which has to be parsed.
+   *
+   * @method
+   * @param {std::string&} line
+   * @return {void}
+   */
+  void AddLine(std::string& line) override
+  {
+    if (!this->isStarted)
+    {
+      this->result << "<blockquote>";
+      this->isStarted = true;
+    }
+
+    bool finish = false;
+    if (line.empty())
+    {
+      finish = true;
+    }
+
+    this->parseBlock(line);
+
+    if (this->isInlineBlockAllowed() && !this->childParser)
+    {
+      this->childParser = this->getBlockParserForLine(line);
+    }
+
+    if (this->childParser)
+    {
+      this->childParser->AddLine(line);
+
+      if (this->childParser->IsFinished())
+      {
+        this->result << this->childParser->GetResult().str();
+        this->childParser = nullptr;
+      }
+
+      return;
+    }
+
+    if (this->isLineParserAllowed())
+    {
+      this->parseLine(line);
+    }
+
+    if (finish)
+    {
+      this->result << "</blockquote>";
+      this->isFinished = true;
+    }
+
+    this->result << line;
+  }
+
+  /**
+   * IsFinished
+   *
+   * @method
+   * @return {bool}
+   */
+  bool IsFinished() const override { return this->isFinished; }
+
+protected:
+  bool isInlineBlockAllowed() const override { return true; }
+
+  bool isLineParserAllowed() const override { return true; }
+
+  void parseBlock(std::string& line) override
+  {
+    static std::regex lineRegexWithSpace(R"(^\> )");
+    line = std::regex_replace(line, lineRegexWithSpace, "");
+    static std::regex lineRegexWithoutSpace(R"(^\>)");
+    line = std::regex_replace(line, lineRegexWithoutSpace, "");
+
+    if (!line.empty())
+    {
+      line += " ";
+    }
+  }
+
+private:
+  bool isStarted;
+  bool isFinished;
+}; // class QuoteParser
+
+// -----------------------------------------------------------------------------
+
+} // namespace maddy

--- a/src/sbml/maddy/strikethroughparser.h
+++ b/src/sbml/maddy/strikethroughparser.h
@@ -1,0 +1,52 @@
+/*
+ * This project is licensed under the MIT license. For more information see the
+ * LICENSE file.
+ */
+#pragma once
+
+// -----------------------------------------------------------------------------
+
+#include <regex>
+#include <string>
+
+#include "maddy/lineparser.h"
+
+// -----------------------------------------------------------------------------
+
+namespace maddy {
+
+// -----------------------------------------------------------------------------
+
+/**
+ * StrikeThroughParser
+ *
+ * @class
+ */
+class StrikeThroughParser : public LineParser
+{
+public:
+  /**
+   * Parse
+   *
+   * From Markdown: `text ~~text~~`
+   *
+   * To HTML: `text <s>text</s>`
+   *
+   * @method
+   * @param {std::string&} line The line to interpret
+   * @return {void}
+   */
+  void Parse(std::string& line) override
+  {
+    static std::regex re(
+      R"((?!.*`.*|.*<code>.*)\~\~(?!.*`.*|.*<\/code>.*)([^\~]*)\~\~(?!.*`.*|.*<\/code>.*))"
+    );
+    static std::string replacement = "<s>$1</s>";
+
+    line = std::regex_replace(line, re, replacement);
+  }
+}; // class StrikeThroughParser
+
+// -----------------------------------------------------------------------------
+
+} // namespace maddy

--- a/src/sbml/maddy/strongparser.h
+++ b/src/sbml/maddy/strongparser.h
@@ -1,0 +1,61 @@
+/*
+ * This project is licensed under the MIT license. For more information see the
+ * LICENSE file.
+ */
+#pragma once
+
+// -----------------------------------------------------------------------------
+
+#include <regex>
+#include <string>
+
+#include "maddy/lineparser.h"
+
+// -----------------------------------------------------------------------------
+
+namespace maddy {
+
+// -----------------------------------------------------------------------------
+
+/**
+ * StrongParser
+ *
+ * Has to be used before the `EmphasizedParser`.
+ *
+ * @class
+ */
+class StrongParser : public LineParser
+{
+public:
+  /**
+   * Parse
+   *
+   * From Markdown: `text **text** __text__`
+   *
+   * To HTML: `text <strong>text</strong> <strong>text</strong>`
+   *
+   * @method
+   * @param {std::string&} line The line to interpret
+   * @return {void}
+   */
+  void Parse(std::string& line) override
+  {
+    static std::vector<std::regex> res{
+      std::regex{
+        R"((?!.*`.*|.*<code>.*)\*\*(?!.*`.*|.*<\/code>.*)([^\*\*]*)\*\*(?!.*`.*|.*<\/code>.*))"
+      },
+      std::regex{
+        R"((?!.*`.*|.*<code>.*)__(?!.*`.*|.*<\/code>.*)([^__]*)__(?!.*`.*|.*<\/code>.*))"
+      }
+    };
+    static std::string replacement = "<strong>$1</strong>";
+    for (const auto& re : res)
+    {
+      line = std::regex_replace(line, re, replacement);
+    }
+  }
+}; // class StrongParser
+
+// -----------------------------------------------------------------------------
+
+} // namespace maddy

--- a/src/sbml/maddy/tableparser.h
+++ b/src/sbml/maddy/tableparser.h
@@ -1,0 +1,233 @@
+/*
+ * This project is licensed under the MIT license. For more information see the
+ * LICENSE file.
+ */
+#pragma once
+
+// -----------------------------------------------------------------------------
+
+#include <functional>
+#include <regex>
+#include <string>
+
+#include "maddy/blockparser.h"
+
+// -----------------------------------------------------------------------------
+
+namespace maddy {
+
+// -----------------------------------------------------------------------------
+
+/**
+ * TableParser
+ *
+ * For more information, see the docs folder.
+ *
+ * @class
+ */
+class TableParser : public BlockParser
+{
+public:
+  /**
+   * ctor
+   *
+   * @method
+   * @param {std::function<void(std::string&)>} parseLineCallback
+   * @param {std::function<std::shared_ptr<BlockParser>(const std::string&
+   * line)>} getBlockParserForLineCallback
+   */
+  TableParser(
+    std::function<void(std::string&)> parseLineCallback,
+    std::function<std::shared_ptr<BlockParser>(const std::string& line)>
+      getBlockParserForLineCallback
+  )
+    : BlockParser(parseLineCallback, getBlockParserForLineCallback)
+    , isStarted(false)
+    , isFinished(false)
+    , currentBlock(0)
+    , currentRow(0)
+  {}
+
+  /**
+   * IsStartingLine
+   *
+   * If the line has exact `|table>`, then it is starting the table.
+   *
+   * @method
+   * @param {const std::string&} line
+   * @return {bool}
+   */
+  static bool IsStartingLine(const std::string& line)
+  {
+    static std::string matchString("|table>");
+    return line == matchString;
+  }
+
+  /**
+   * AddLine
+   *
+   * Adding a line which has to be parsed.
+   *
+   * @method
+   * @param {std::string&} line
+   * @return {void}
+   */
+  void AddLine(std::string& line) override
+  {
+    if (!this->isStarted && line == "|table>")
+    {
+      this->isStarted = true;
+      return;
+    }
+
+    if (this->isStarted)
+    {
+      if (line == "- | - | -")
+      {
+        ++this->currentBlock;
+        this->currentRow = 0;
+        return;
+      }
+
+      if (line == "|<table")
+      {
+        static std::string emptyLine = "";
+        this->parseBlock(emptyLine);
+        this->isFinished = true;
+        return;
+      }
+
+      if (this->table.size() < this->currentBlock + 1)
+      {
+        this->table.push_back(std::vector<std::vector<std::string>>());
+      }
+      this->table[this->currentBlock].push_back(std::vector<std::string>());
+
+      std::string segment;
+      std::stringstream streamToSplit(line);
+
+      while (std::getline(streamToSplit, segment, '|'))
+      {
+        this->parseLine(segment);
+        this->table[this->currentBlock][this->currentRow].push_back(segment);
+      }
+
+      ++this->currentRow;
+    }
+  }
+
+  /**
+   * IsFinished
+   *
+   * A table ends with `|<table`.
+   *
+   * @method
+   * @return {bool}
+   */
+  bool IsFinished() const override { return this->isFinished; }
+
+protected:
+  bool isInlineBlockAllowed() const override { return false; }
+
+  bool isLineParserAllowed() const override { return true; }
+
+  void parseBlock(std::string&) override
+  {
+    result << "<table>";
+
+    bool hasHeader = false;
+    bool hasFooter = false;
+    bool isFirstBlock = true;
+    uint32_t currentBlockNumber = 0;
+
+    if (this->table.size() > 1)
+    {
+      hasHeader = true;
+    }
+
+    if (this->table.size() >= 3)
+    {
+      hasFooter = true;
+    }
+
+    for (const std::vector<std::vector<std::string>>& block : this->table)
+    {
+      bool isInHeader = false;
+      bool isInFooter = false;
+      ++currentBlockNumber;
+
+      if (hasHeader && isFirstBlock)
+      {
+        result << "<thead>";
+        isInHeader = true;
+      }
+      else if (hasFooter && currentBlockNumber == this->table.size())
+      {
+        result << "<tfoot>";
+        isInFooter = true;
+      }
+      else
+      {
+        result << "<tbody>";
+      }
+
+      for (const std::vector<std::string>& row : block)
+      {
+        result << "<tr>";
+
+        for (const std::string& column : row)
+        {
+          if (isInHeader)
+          {
+            result << "<th>";
+          }
+          else
+          {
+            result << "<td>";
+          }
+
+          result << column;
+
+          if (isInHeader)
+          {
+            result << "</th>";
+          }
+          else
+          {
+            result << "</td>";
+          }
+        }
+
+        result << "</tr>";
+      }
+
+      if (isInHeader)
+      {
+        result << "</thead>";
+      }
+      else if (isInFooter)
+      {
+        result << "</tfoot>";
+      }
+      else
+      {
+        result << "</tbody>";
+      }
+
+      isFirstBlock = false;
+    }
+
+    result << "</table>";
+  }
+
+private:
+  bool isStarted;
+  bool isFinished;
+  uint32_t currentBlock;
+  uint32_t currentRow;
+  std::vector<std::vector<std::vector<std::string>>> table;
+}; // class TableParser
+
+// -----------------------------------------------------------------------------
+
+} // namespace maddy

--- a/src/sbml/maddy/unorderedlistparser.h
+++ b/src/sbml/maddy/unorderedlistparser.h
@@ -1,0 +1,118 @@
+/*
+ * This project is licensed under the MIT license. For more information see the
+ * LICENSE file.
+ */
+#pragma once
+
+// -----------------------------------------------------------------------------
+
+#include <functional>
+#include <regex>
+#include <string>
+
+#include "maddy/blockparser.h"
+
+// -----------------------------------------------------------------------------
+
+namespace maddy {
+
+// -----------------------------------------------------------------------------
+
+/**
+ * UnorderedListParser
+ *
+ * @class
+ */
+class UnorderedListParser : public BlockParser
+{
+public:
+  /**
+   * ctor
+   *
+   * @method
+   * @param {std::function<void(std::string&)>} parseLineCallback
+   * @param {std::function<std::shared_ptr<BlockParser>(const std::string&
+   * line)>} getBlockParserForLineCallback
+   */
+  UnorderedListParser(
+    std::function<void(std::string&)> parseLineCallback,
+    std::function<std::shared_ptr<BlockParser>(const std::string& line)>
+      getBlockParserForLineCallback
+  )
+    : BlockParser(parseLineCallback, getBlockParserForLineCallback)
+    , isStarted(false)
+    , isFinished(false)
+  {}
+
+  /**
+   * IsStartingLine
+   *
+   * An unordered list starts with `* `.
+   *
+   * @method
+   * @param {const std::string&} line
+   * @return {bool}
+   */
+  static bool IsStartingLine(const std::string& line)
+  {
+    static std::regex re("^[+*-] .*");
+    return std::regex_match(line, re);
+  }
+
+  /**
+   * IsFinished
+   *
+   * @method
+   * @return {bool}
+   */
+  bool IsFinished() const override { return this->isFinished; }
+
+protected:
+  bool isInlineBlockAllowed() const override { return true; }
+
+  bool isLineParserAllowed() const override { return true; }
+
+  void parseBlock(std::string& line) override
+  {
+    bool isStartOfNewListItem = IsStartingLine(line);
+    uint32_t indentation = getIndentationWidth(line);
+
+    static std::regex lineRegex("^([+*-] )");
+    line = std::regex_replace(line, lineRegex, "");
+
+    if (!this->isStarted)
+    {
+      line = "<ul><li>" + line;
+      this->isStarted = true;
+      return;
+    }
+
+    if (indentation >= 2)
+    {
+      line = line.substr(2);
+      return;
+    }
+
+    if (line.empty() || line.find("</li><li>") != std::string::npos ||
+        line.find("</li></ol>") != std::string::npos ||
+        line.find("</li></ul>") != std::string::npos)
+    {
+      line = "</li></ul>" + line;
+      this->isFinished = true;
+      return;
+    }
+
+    if (isStartOfNewListItem)
+    {
+      line = "</li><li>" + line;
+    }
+  }
+
+private:
+  bool isStarted;
+  bool isFinished;
+}; // class UnorderedListParser
+
+// -----------------------------------------------------------------------------
+
+} // namespace maddy

--- a/src/sbml/test/TestConstraint.c
+++ b/src/sbml/test/TestConstraint.c
@@ -199,6 +199,83 @@ START_TEST (test_Constraint_setMessage)
 END_TEST
 
 
+START_TEST(test_Constraint_setMessageFromMarkdown)
+{
+    const char* message = "This is a test message";
+    const char* taggedMessage = "<message>\n  <body xmlns=\"http://www.w3.org/1999/xhtml\">\n    <p>This is a test message </p>\n  </body>\n</message>";
+
+    Constraint_setMessageFromMarkdown(C, message);
+
+    fail_unless(Constraint_isSetMessage(C) == 1);
+
+    char* str = Constraint_getMessageString(C);
+    if (strcmp(str, taggedMessage))
+    {
+        fail("Constraint_setMessageFromMarkdown(...) did not make a copy of node.");
+    }
+    safe_free(str);
+    char* t1 = Constraint_getMessageMarkdown(C);
+    fail_unless(!strcmp(t1, message));
+    safe_free(t1);
+
+    //const XMLNode_t* t2 = XMLNode_getChild(t1, 0);
+    //fail_unless(!strcmp(XMLNode_getCharacters(t2), "This is a test message"));
+
+
+    /* Reflexive case (pathological)  */
+    str = Constraint_getMessageString(C);
+    Constraint_setMessageString(C, str);
+    safe_free(str);
+    t1 = Constraint_getMessageMarkdown(C);
+    fail_unless(!strcmp(t1, message));
+    safe_free(t1);
+
+    Constraint_setMessageFromMarkdown(C, (char*)"");
+    fail_unless(Constraint_isSetMessage(C) == 0);
+
+    if (Constraint_getMessageString(C) != NULL)
+    {
+        fail("Constraint_getMessageString(C, "") did not clear string.");
+    }
+
+    Constraint_setMessageFromMarkdown(C, message);
+
+    fail_unless(Constraint_isSetMessage(C) == 1);
+
+    str = Constraint_getMessageString(C);
+    if (strcmp(str, taggedMessage))
+    {
+        fail("Constraint_setMessageString(...) did not make a copy of node.");
+    }
+    safe_free(str);
+
+    t1 = Constraint_getMessageMarkdown(C);
+    fail_unless(!strcmp(t1, message));
+    safe_free(t1);
+    Constraint_unsetMessage(C);
+}
+END_TEST
+
+
+START_TEST(test_Constraint_setMessageFromMarkdown2)
+{
+    const char* Message = "# Header\n\nHere is a list:\n\n- First\n- Second";
+    const char* taggedMessage = "<message>\n  <body xmlns=\"http://www.w3.org/1999/xhtml\">\n    <h1>Header</h1>\n    <p>Here is a list: </p>\n    <ul>\n      <li>First</li>\n      <li>Second</li>\n    </ul>\n  </body>\n</message>";
+
+    Constraint_setMessageFromMarkdown(C, Message);
+
+    fail_unless(Constraint_isSetMessage(C) == 1);
+    char* str = Constraint_getMessageString(C);
+    fail_unless(!strcmp(str, taggedMessage));
+    safe_free(str);
+    char* t1 = Constraint_getMessageMarkdown(C);
+    fail_unless(!strcmp(t1, Message));
+    safe_free(t1);
+    Constraint_unsetMessage(C);
+}
+END_TEST
+
+
 START_TEST (test_Constraint_createWithNS )
 {
   XMLNamespaces_t *xmlns = XMLNamespaces_create();
@@ -239,11 +316,14 @@ create_suite_Constraint (void)
                              ConstraintTest_setup,
                              ConstraintTest_teardown );
 
-  tcase_add_test( tcase, test_Constraint_create      );
+  tcase_add_test( tcase, test_Constraint_create   );
   //tcase_add_test( tcase, test_Constraint_createWithMath      );
-  tcase_add_test( tcase, test_Constraint_free_NULL   );
-  tcase_add_test( tcase, test_Constraint_setMath     );
-  tcase_add_test( tcase, test_Constraint_setMessage  );
+  tcase_add_test( tcase, test_Constraint_free_NULL);
+  tcase_add_test( tcase, test_Constraint_setMath  );
+  tcase_add_test(tcase, test_Constraint_setMessage);
+  tcase_add_test(tcase, test_Constraint_setMessageFromMarkdown);
+  tcase_add_test(tcase, test_Constraint_setMessageFromMarkdown2);
+  
   tcase_add_test( tcase, test_Constraint_createWithNS         );
 
   suite_add_tcase(suite, tcase);

--- a/src/sbml/test/TestSBase.cpp
+++ b/src/sbml/test/TestSBase.cpp
@@ -631,6 +631,25 @@ START_TEST(test_SBase_setNotesFromMarkdown2)
 END_TEST
 
 
+START_TEST(test_SBase_setNotesFromMarkdown3)
+{
+    Model_t* c = new(std::nothrow) Model(3, 1);
+    const char* notes = "Please refer to[CC0  Public Domain Dedication](http://creativecommons.org/publicdomain/zero/1.0/ \"Access to: CC0 1.0 Universal (CC0 1.0), Public Domain Dedication\") for more information.";
+    const char* taggednotes = "<notes>\n  <body xmlns=\"http://www.w3.org/1999/xhtml\">\n    <p>Please refer to<a href=\"http://creativecommons.org/publicdomain/zero/1.0/\" title=\"Access to: CC0 1.0 Universal (CC0 1.0), Public Domain Dedication\">CC0  Public Domain Dedication</a> for more information. </p>\n  </body>\n</notes>";
+
+    SBase_setNotesFromMarkdown(c, notes);
+
+    fail_unless(SBase_isSetNotes(c) == 1);
+    char* str = SBase_getNotesString(c);
+    fail_unless(!strcmp(str, taggednotes));
+    safe_free(str);
+    char* t1 = SBase_getNotesMarkdown(c);
+    fail_unless(!strcmp(t1, notes));
+    safe_free(t1);
+}
+END_TEST
+
+
 START_TEST(test_SBase_setAnnotationString)
 {
   const char * annotation = "This is a test note";
@@ -2653,6 +2672,7 @@ create_suite_SBase (void)
   tcase_add_test(tcase, test_SBase_setNotesString_l3_addMarkup);
   tcase_add_test(tcase, test_SBase_setNotesFromMarkdown);
   tcase_add_test(tcase, test_SBase_setNotesFromMarkdown2);
+  tcase_add_test(tcase, test_SBase_setNotesFromMarkdown3);
   tcase_add_test(tcase, test_SBase_setAnnotationString);
   tcase_add_test(tcase, test_SBase_unsetAnnotationWithCVTerms );
   tcase_add_test(tcase, test_SBase_unsetAnnotationWithModelHistory );

--- a/src/sbml/test/TestSBase.cpp
+++ b/src/sbml/test/TestSBase.cpp
@@ -634,8 +634,8 @@ END_TEST
 START_TEST(test_SBase_setNotesFromMarkdown3)
 {
     Model_t* c = new(std::nothrow) Model(3, 1);
-    const char* notes = "Please refer to[CC0  Public Domain Dedication](http://creativecommons.org/publicdomain/zero/1.0/ \"Access to: CC0 1.0 Universal (CC0 1.0), Public Domain Dedication\") for more information.";
-    const char* taggednotes = "<notes>\n  <body xmlns=\"http://www.w3.org/1999/xhtml\">\n    <p>Please refer to<a href=\"http://creativecommons.org/publicdomain/zero/1.0/\" title=\"Access to: CC0 1.0 Universal (CC0 1.0), Public Domain Dedication\">CC0  Public Domain Dedication</a> for more information. </p>\n  </body>\n</notes>";
+    const char* notes = "Please refer to [CC0  Public Domain Dedication](http://creativecommons.org/publicdomain/zero/1.0/ \"Access to: CC0 1.0 Universal (CC0 1.0), Public Domain Dedication\") for more information.";
+    const char* taggednotes = "<notes>\n  <body xmlns=\"http://www.w3.org/1999/xhtml\">\n    <p>Please refer to <a href=\"http://creativecommons.org/publicdomain/zero/1.0/\" title=\"Access to: CC0 1.0 Universal (CC0 1.0), Public Domain Dedication\">CC0  Public Domain Dedication</a> for more information. </p>\n  </body>\n</notes>";
 
     SBase_setNotesFromMarkdown(c, notes);
 

--- a/src/sbml/test/TestSBase.cpp
+++ b/src/sbml/test/TestSBase.cpp
@@ -552,7 +552,86 @@ START_TEST (test_SBase_setNotesString_l3_addMarkup)
 END_TEST
 
 
-START_TEST (test_SBase_setAnnotationString)
+START_TEST(test_SBase_setNotesFromMarkdown)
+{
+    Model_t* c = new(std::nothrow) Model(1, 2);
+    const char* notes = "This is a test note";
+    const char* taggednotes = "<notes>\n  <p>This is a test note </p>\n</notes>";
+
+    SBase_setNotesFromMarkdown(c, notes);
+
+    fail_unless(SBase_isSetNotes(c) == 1);
+
+    char* str = SBase_getNotesString(c);
+    if (strcmp(str, taggednotes))
+    {
+        fail("SBase_setNotesFromMarkdown(...) did not make a copy of node.");
+    }
+    safe_free(str);
+    char* t1 = SBase_getNotesMarkdown(c);
+    fail_unless(!strcmp(t1, notes));
+    safe_free(t1);
+
+    //const XMLNode_t* t2 = XMLNode_getChild(t1, 0);
+    //fail_unless(!strcmp(XMLNode_getCharacters(t2), "This is a test note"));
+
+
+    /* Reflexive case (pathological)  */
+    str = SBase_getNotesString(c);
+    SBase_setNotesString(c, str);
+    safe_free(str);
+    t1 = SBase_getNotesMarkdown(c);
+    fail_unless(!strcmp(t1, notes));
+    safe_free(t1);
+
+    SBase_setNotesFromMarkdown(c, (char*)"");
+    fail_unless(SBase_isSetNotes(c) == 0);
+
+    if (SBase_getNotesString(c) != NULL)
+    {
+        fail("SBase_getNotesString(c, "") did not clear string.");
+    }
+
+    SBase_setNotesFromMarkdown(c, notes);
+
+    fail_unless(SBase_isSetNotes(c) == 1);
+
+    str = SBase_getNotesString(c);
+    if (strcmp(str, taggednotes))
+    {
+        fail("SBase_setNotesString(...) did not make a copy of node.");
+    }
+    safe_free(str);
+
+    t1 = SBase_getNotesMarkdown(c);
+    fail_unless(!strcmp(t1, notes));
+    safe_free(t1);
+
+    Model_free(c);
+}
+END_TEST
+
+
+START_TEST(test_SBase_setNotesFromMarkdown2)
+{
+    Model_t* c = new(std::nothrow) Model(3, 1);
+    const char* notes = "# Header\n\nHere is a list:\n\n- First\n- Second";
+    const char* taggednotes = "<notes>\n  <body xmlns=\"http://www.w3.org/1999/xhtml\">\n    <h1>Header</h1>\n    <p>Here is a list: </p>\n    <ul>\n      <li>First</li>\n      <li>Second</li>\n    </ul>\n  </body>\n</notes>";
+
+    SBase_setNotesFromMarkdown(c, notes);
+
+    fail_unless(SBase_isSetNotes(c) == 1);
+    char* str = SBase_getNotesString(c);
+    fail_unless(!strcmp(str, taggednotes));
+    safe_free(str);
+    char* t1 = SBase_getNotesMarkdown(c);
+    fail_unless(!strcmp(t1, notes));
+    safe_free(t1);
+}
+END_TEST
+
+
+START_TEST(test_SBase_setAnnotationString)
 {
   const char * annotation = "This is a test note";
   const char * taggedannotation = "<annotation>This is a test note</annotation>";
@@ -2572,6 +2651,8 @@ create_suite_SBase (void)
   tcase_add_test(tcase, test_SBase_setNotesString);
   tcase_add_test(tcase, test_SBase_setNotesString_l3);
   tcase_add_test(tcase, test_SBase_setNotesString_l3_addMarkup);
+  tcase_add_test(tcase, test_SBase_setNotesFromMarkdown);
+  tcase_add_test(tcase, test_SBase_setNotesFromMarkdown2);
   tcase_add_test(tcase, test_SBase_setAnnotationString);
   tcase_add_test(tcase, test_SBase_unsetAnnotationWithCVTerms );
   tcase_add_test(tcase, test_SBase_unsetAnnotationWithModelHistory );

--- a/src/sbml/util/test/TestUtil.c
+++ b/src/sbml/util/test/TestUtil.c
@@ -347,6 +347,28 @@ START_TEST (test_util_operationReturn)
 END_TEST
 
 
+START_TEST(test_util_html_to_markdown)
+{
+    const char* html = "<h1>Header</h1>\n    <p>Here is a list: </p>\n    <ul>\n      <li>First</li>\n      <li>Second</li>\n    </ul>";
+    const char* markdown = "# Header\n\nHere is a list:\n\n- First\n- Second\n\n";
+
+    char* new_md = util_html_to_markdown_c(html);
+    fail_unless(!strcmp(new_md, markdown));
+}
+END_TEST
+
+
+START_TEST(test_util_markdown_to_html)
+{
+    const char* markdown = "# Header\n\nHere is a list:\n\n- First\n- Second\n\n";
+    const char* html = "<h1>Header</h1><p>Here is a list: </p><ul><li>First</li><li>Second</li></ul>";
+
+    char* new_html = util_markdown_to_html_c(markdown);
+    fail_unless(!strcmp(new_html, html));
+}
+END_TEST
+
+
 Suite *
 create_suite_util (void) 
 { 
@@ -368,6 +390,8 @@ create_suite_util (void)
   tcase_add_test( tcase, test_util_isInf              );
   tcase_add_test( tcase, test_util_accessWithNULL     );
   tcase_add_test( tcase, test_util_operationReturn    );
+  tcase_add_test( tcase, test_util_html_to_markdown   );
+  tcase_add_test( tcase, test_util_markdown_to_html   );
 
   suite_add_tcase(suite, tcase);
 

--- a/src/sbml/util/test/TestUtil.c
+++ b/src/sbml/util/test/TestUtil.c
@@ -354,6 +354,7 @@ START_TEST(test_util_html_to_markdown)
 
     char* new_md = util_html_to_markdown_c(html);
     fail_unless(!strcmp(new_md, markdown));
+    safe_free(new_md);
 }
 END_TEST
 
@@ -365,6 +366,7 @@ START_TEST(test_util_markdown_to_html)
 
     char* new_html = util_markdown_to_html_c(markdown);
     fail_unless(!strcmp(new_html, html));
+    safe_free(new_html);
 }
 END_TEST
 

--- a/src/sbml/util/util.cpp
+++ b/src/sbml/util/util.cpp
@@ -62,6 +62,8 @@
 #include <sbml/util/List.h>
 #include <sbml/util/util.h>
 
+#include <sbml/maddy/parser.h>
+#include <sbml/html2md/html2md.h>
 
 #include <math.h>
 
@@ -526,6 +528,25 @@ std::string& replaceAllSubStrings(
   }
   return str;
 }
+
+std::string util_markdown_to_html(const std::string& markdown)
+{
+    // If we want to use the maddy config:
+    //std::shared_ptr<maddy::ParserConfig> config = std::make_shared<maddy::ParserConfig>();
+    //config->enabledParsers &= ~maddy::types::EMPHASIZED_PARSER; // disable emphasized parser
+    //config->enabledParsers |= maddy::types::HTML_PARSER; // do not wrap HTML in paragraph
+    //std::shared_ptr<maddy::Parser> parser = std::make_shared<maddy::Parser>(config);
+
+    std::stringstream markdownInput(markdown);
+    static maddy::Parser parser;
+    return parser.Parse(markdownInput);
+}
+
+std::string util_html_to_markdown(std::string& html)
+{
+    return html2md::Convert(html);
+}
+
 
 #endif // __cplusplus
 

--- a/src/sbml/util/util.cpp
+++ b/src/sbml/util/util.cpp
@@ -104,6 +104,27 @@ int util_isEqual(double a, double b)
   return (fabs(a-b) < sqrt(util_epsilon())) ? 1 : 0;
 }
 
+LIBSBML_EXTERN
+char* util_html_to_markdown_c(const char* html)
+{
+    if (html == NULL) {
+        return NULL;
+    }
+    std::string ret = util_html_to_markdown(html);
+    return safe_strdup(ret.c_str());
+}
+
+
+LIBSBML_EXTERN
+char* util_markdown_to_html_c(const char* markdown)
+{
+    if (markdown == NULL) {
+        return NULL;
+    }
+    std::string ret = util_markdown_to_html(markdown);
+    return safe_strdup(ret.c_str());
+}
+
 
 int
 c_locale_snprintf (char *str, size_t size, const char *format, ...)

--- a/src/sbml/util/util.cpp
+++ b/src/sbml/util/util.cpp
@@ -542,7 +542,7 @@ std::string util_markdown_to_html(const std::string& markdown)
     return parser.Parse(markdownInput);
 }
 
-std::string util_html_to_markdown(std::string& html)
+std::string util_html_to_markdown(const std::string& html)
 {
     return html2md::Convert(html);
 }

--- a/src/sbml/util/util.h
+++ b/src/sbml/util/util.h
@@ -72,6 +72,8 @@ LIBSBML_CPP_NAMESPACE_BEGIN
 /**
  * Utility function that converts the input string from markdown to HTML.
  *
+ * The HTML is translated by 'html2md', https://github.com/tim-gromeyer/html2md/
+ * 
  * @param markdown, the string to be modified.
  *
  * @return the HTML version of the string.
@@ -81,6 +83,8 @@ std::string util_markdown_to_html(const std::string& markdown);
 /**
  * Utility function that converts the input string from HTML to markdown.
  *
+ * Markdown parser is 'maddy' (https://github.com/progsource/maddy).
+ * 
  * @param html, the string to be converted.
  *
  * @return the markdown version of the string.
@@ -368,6 +372,34 @@ double util_epsilon();
  */
 LIBSBML_EXTERN
 int util_isEqual(double a, double b);
+
+/**
+ * Utility function that converts the input string from HTML to markdown.
+ * 
+ * The string is owned by the caller and should be freed
+ * (with free()) when no longer needed.  The HTML is translated
+ * by 'html2md', https://github.com/tim-gromeyer/html2md/
+ *
+ * @param html, the string to be converted.
+ *
+ * @return the markdown version of the string.
+ */
+LIBSBML_EXTERN
+char* util_html_to_markdown_c(const char* html);
+
+/**
+ * Utility function that converts the input string from HTML to markdown.
+ *
+ * The string is owned by the caller and should be freed
+ * (with free()) when no longer needed.  The HTML is translated
+ * by 'maddy', https://github.com/progsource/maddy
+ *
+ * @param markdown, the string to be converted.
+ *
+ * @return the html version of the string.
+ */
+LIBSBML_EXTERN
+char* util_markdown_to_html_c(const char* markdown);
 
 END_C_DECLS
 LIBSBML_CPP_NAMESPACE_END

--- a/src/sbml/util/util.h
+++ b/src/sbml/util/util.h
@@ -68,6 +68,25 @@ LIBSBML_CPP_NAMESPACE_BEGIN
  std::string& replaceAllSubStrings(std::string& str, 
               const std::string& from, const std::string& to);
 
+
+/**
+ * Utility function that converts the input string from markdown to HTML.
+ *
+ * @param markdown, the string to be modified.
+ *
+ * @return the HTML version of the string.
+ */
+std::string util_markdown_to_html(const std::string& markdown);
+
+/**
+ * Utility function that converts the input string from HTML to markdown.
+ *
+ * @param html, the string to be converted.
+ *
+ * @return the markdown version of the string.
+ */
+std::string util_html_to_markdown(std::string& html);
+
 LIBSBML_CPP_NAMESPACE_END
 
 

--- a/src/sbml/util/util.h
+++ b/src/sbml/util/util.h
@@ -85,7 +85,7 @@ std::string util_markdown_to_html(const std::string& markdown);
  *
  * @return the markdown version of the string.
  */
-std::string util_html_to_markdown(std::string& html);
+std::string util_html_to_markdown(const std::string& html);
 
 LIBSBML_CPP_NAMESPACE_END
 


### PR DESCRIPTION
Add the ability to set and get SBase notes and Constraint messages in the 'markdown' format, as translated md->html using maddy, and html->md using html2md.

I made no attempt to save the raw markdown for now; the functions simply translate to and from each other.  If the user wants to store the raw markdown as an annotation, they'll need to do that themselves (at least for now).

Function names are

setNotesFromMarkdown
setMessageFromMarkdown

getNotesMarkdown
getMessageMarkdown

There wasn't a 'setNotesString' function, hence the 'From'.  But the names are negotiable if someone thinks they should be changed.

From #416.