### PR TITLE
Revert including util in the bindings.

### DIFF
--- a/src/bindings/swig/libsbml.h
+++ b/src/bindings/swig/libsbml.h
@@ -141,7 +141,6 @@
 #include <sbml/extension/SBMLExtensionRegistry.h>
 
 #include <sbml/util/CallbackRegistry.h>
-#include <sbml/util/util.h>
 
 #include "ListWrapper.h"
 

--- a/src/bindings/swig/libsbml.i
+++ b/src/bindings/swig/libsbml.i
@@ -783,7 +783,6 @@ as a comment in the output stream.
 %include <sbml/util/IdList.h>
 %include <sbml/util/IdentifierTransformer.h>
 %include <sbml/util/ElementFilter.h>
-%include <sbml/util/util.h>
 
 %include <sbml/SBMLReader.h>
 %include sbml/SBMLWriter.h


### PR DESCRIPTION
It causes errors in most builds, for a variety of reasons.