### PR TITLE
Making MISC_PREFIX user-settable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -640,14 +640,14 @@ endif(WITH_CHECK)
 # documentation to be installed in PREFIX/${MISC_PREFIX}.
 #
 
-set( MISC_PREFIX )
+
 if(UNIX OR CYGWIN)
     set(PATH_SEP "/")
     set(FILE_SEP ":")
-    set( MISC_PREFIX "${CMAKE_INSTALL_DATADIR}/libsbml/" )
+    set(MISC_PREFIX "${CMAKE_INSTALL_DATADIR}/libsbml/" CACHE PATH "bindings, examples and documentation path")
     set(LIBSBML_LIBRARY sbml)
 else()
-    set( MISC_PREFIX ".\\" )
+    set(MISC_PREFIX ".\\" CACHE PATH "bindings, examples and documentation path")
     set(PATH_SEP "\\")
     set(FILE_SEP ";")
     if(MINGW)


### PR DESCRIPTION
## Description
The MISC_PREFIX variable in CMakeLists.txt defines the path where the bindings, documentation and examples will be installed. It is hardcoded to be "$CMAKE_INSTALL_DATADIR/libsbml/" on unix/cygwin platforms, ".\\\\" otherwise. 
Making this variable user-settable would give more flexibility to the user. 

## Motivation and Context
I'm maintaining a libsbml conda package (c++, not the python one) now on conda-forge (https://github.com/conda-forge/libsbml-feedstock) and the path of some documentation (NEWS.txt, COPYING.txt) on Windows is conflicting with other packages, preventing them to be installed together. 
The obvious fix is for me to move them in the desired folder during the conda build script, but this change is more elegant, and might be useful for other people. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Change in documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have updated all documentation necessary.
- [ ] I have checked spelling in (new) comments.

## Testing
- [] Testing is done automatically and codecov shows test coverage
- [X] This cannot be tested automatically 
I have tested this with and without setting the variable, on linux, mac and windows. It shows the expected behaviors, no errors/warnings. 
