### PR TITLE
Fix leak on fail:  xmlstr_c now freed.

### DIFF
--- a/src/sbml/xml/XMLNode.cpp
+++ b/src/sbml/xml/XMLNode.cpp
@@ -637,6 +637,7 @@ XMLNode* XMLNode::convertStringToXMLNode(const std::string& xmlstr, const XMLNam
   if(xis.isError() || (xmlnode_tmp->getNumChildren() == 0) )
   {
     delete xmlnode_tmp;
+    safe_free(const_cast<char*>(xmlstr_c));
     return NULL;
   }
 


### PR DESCRIPTION
On failure, xmlstr_c wasn't being freed and instead leaked.  This properly frees it.