### PR TITLE
Allow uncerml annotations

### DIFF
--- a/src/sbml/packages/distrib/util/AnnotationToDistribConverter.cpp
+++ b/src/sbml/packages/distrib/util/AnnotationToDistribConverter.cpp
@@ -199,59 +199,51 @@ AnnotationToDistribConverter::convertModel(Model* model)
       continue;
     }
     string value = attrs.getValue(defindex);
-    if (value == "http://en.wikipedia.org/wiki/Normal_distribution")
+    if (value == "http://en.wikipedia.org/wiki/Normal_distribution" || value == "http://en.wikipedia.org/wiki/Truncated_normal_distribution" || value == "http://www.uncertml.org/distributions/normal")
     {
       replacements[funcdef->getId()] = AST_DISTRIB_FUNCTION_NORMAL;
     }
-    else if (value == "http://en.wikipedia.org/wiki/Truncated_normal_distribution")
-    {
-      replacements[funcdef->getId()] = AST_DISTRIB_FUNCTION_NORMAL;
-    }
-    else if (value == "http://en.wikipedia.org/wiki/Uniform_distribution")
+    else if (value == "http://en.wikipedia.org/wiki/Uniform_distribution" || value == "http://en.wikipedia.org/wiki/Uniform_distribution_(continuous)" || value == "http://www.uncertml.org/distributions/uniform")
     {
       replacements[funcdef->getId()] = AST_DISTRIB_FUNCTION_UNIFORM;
     }
-    else if (value == "http://en.wikipedia.org/wiki/Uniform_distribution_(continuous)")
-    {
-      replacements[funcdef->getId()] = AST_DISTRIB_FUNCTION_UNIFORM;
-    }
-    else if (value == "http://en.wikipedia.org/wiki/Exponential_distribution")
+    else if (value == "http://en.wikipedia.org/wiki/Exponential_distribution" || value == "http://www.uncertml.org/distributions/exponential")
     {
       replacements[funcdef->getId()] = AST_DISTRIB_FUNCTION_EXPONENTIAL;
     }
-    else if (value == "http://en.wikipedia.org/wiki/Gamma_distribution")
+    else if (value == "http://en.wikipedia.org/wiki/Gamma_distribution" || value == "http://www.uncertml.org/distributions/gamma")
     {
       replacements[funcdef->getId()] = AST_DISTRIB_FUNCTION_GAMMA;
     }
-    else if (value == "http://en.wikipedia.org/wiki/Poisson_distribution")
+    else if (value == "http://en.wikipedia.org/wiki/Poisson_distribution" || value == "http://www.uncertml.org/distributions/poisson")
     {
       replacements[funcdef->getId()] = AST_DISTRIB_FUNCTION_POISSON;
     }
-    else if (value == "http://en.wikipedia.org/wiki/Log-normal_distribution")
+    else if (value == "http://en.wikipedia.org/wiki/Log-normal_distribution" || value == "http://www.uncertml.org/distributions/log-normal")
     {
       replacements[funcdef->getId()] = AST_DISTRIB_FUNCTION_LOGNORMAL;
     }
-    else if (value == "http://en.wikipedia.org/wiki/Chi-squared_distribution")
+    else if (value == "http://en.wikipedia.org/wiki/Chi-squared_distribution" || value == "http://www.uncertml.org/distributions/chisquare")
     {
       replacements[funcdef->getId()] = AST_DISTRIB_FUNCTION_CHISQUARE;
     }
-    else if (value == "http://en.wikipedia.org/wiki/Laplace_distribution")
+    else if (value == "http://en.wikipedia.org/wiki/Laplace_distribution" || value == "http://www.uncertml.org/distributions/laplace")
     {
       replacements[funcdef->getId()] = AST_DISTRIB_FUNCTION_LAPLACE;
     }
-    else if (value == "http://en.wikipedia.org/wiki/Cauchy_distribution")
+    else if (value == "http://en.wikipedia.org/wiki/Cauchy_distribution" || value == "http://www.uncertml.org/distributions/cauchy")
     {
       replacements[funcdef->getId()] = AST_DISTRIB_FUNCTION_CAUCHY;
     }
-    else if (value == "http://en.wikipedia.org/wiki/Rayleigh_distribution")
+    else if (value == "http://en.wikipedia.org/wiki/Rayleigh_distribution" || value == "http://www.uncertml.org/distributions/weibull")
     {
       replacements[funcdef->getId()] = AST_DISTRIB_FUNCTION_RAYLEIGH;
     }
-    else if (value == "http://en.wikipedia.org/wiki/Binomial_distribution")
+    else if (value == "http://en.wikipedia.org/wiki/Binomial_distribution" || value == "http://www.uncertml.org/distributions/binomial")
     {
       replacements[funcdef->getId()] = AST_DISTRIB_FUNCTION_BINOMIAL;
     }
-    else if (value == "http://en.wikipedia.org/wiki/Bernoulli_distribution")
+    else if (value == "http://en.wikipedia.org/wiki/Bernoulli_distribution" || value == "http://www.uncertml.org/distributions/bernoulli")
     {
       replacements[funcdef->getId()] = AST_DISTRIB_FUNCTION_BERNOULLI;
     }

--- a/src/sbml/packages/distrib/util/DistribToAnnotationConverter.h
+++ b/src/sbml/packages/distrib/util/DistribToAnnotationConverter.h
@@ -133,6 +133,8 @@ public:
 
   bool getWriteMeans();
 
+  bool getUseUncertML();
+
 
   /** @cond doxygenLibsbmlInternal */
   /**
@@ -178,8 +180,9 @@ private:
   std::string getUnusedIDFor(ASTNodeType_t type, Model * model);
 
   bool replaceDistribWithFunctionCalls(ASTNode * astn, Model* model);
-  std::string getWikipediaURLFor(ASTNodeType_t type);
-  bool addFunctionDefinitionWith(Model * model, const std::string& id, ASTNodeType_t type, unsigned int nargs);
+  static std::string getWikipediaURLFor(ASTNodeType_t type);
+  static std::string getUncertMLURLFor(ASTNodeType_t type);
+  bool addFunctionDefinitionWith(Model * model, const std::string& id, ASTNodeType_t type, unsigned int nargs, bool useUncertML=false);
 
   //Member variables
   std::map<ASTNodeType_t, std::string> mCreatedFunctions;

--- a/src/sbml/packages/distrib/util/test/TestDistribAnnotationConverter.cpp
+++ b/src/sbml/packages/distrib/util/test/TestDistribAnnotationConverter.cpp
@@ -290,6 +290,42 @@ START_TEST(test_distrib_annotation_converter_uniformb)
 }
 END_TEST
 
+START_TEST(test_distrib_annotation_converter_uncertml)
+{
+  string filename(TestDataDirectory);
+
+  ConversionProperties props;
+
+  props.addOption("convert distrib annotations");
+
+  SBMLConverter* converter = SBMLConverterRegistry::getInstance().getConverterFor(props);
+
+  // load document
+  string cfile = filename + "normal_l3v1_annot_uncertml.xml";
+  SBMLDocument* doc = readSBMLFromFile(cfile.c_str());
+
+  // fail if there is no model (readSBMLFromFile always returns a valid document)
+  fail_unless(doc->getModel() != NULL);
+
+  converter->setDocument(doc);
+  int result = converter->convert();
+
+  // fail if conversion was not valid
+  fail_unless(result == LIBSBML_OPERATION_SUCCESS);
+
+  string newModel = writeSBMLToStdString(doc);
+
+  string ffile = filename + "normal_l3v1_distrib.xml";
+  SBMLDocument* fdoc = readSBMLFromFile(ffile.c_str());
+  string flatModel = writeSBMLToStdString(fdoc);
+
+  fail_unless(flatModel == newModel);
+
+  delete doc;
+  delete fdoc;
+  delete converter;
+}
+END_TEST
 
 START_TEST(test_distrib_annotation_converter_exponential)
 {
@@ -468,6 +504,7 @@ create_suite_TestDistribAnnotationConverter (void)
   tcase_add_test(tcase, test_distrib_annotation_converter_truncated_normal);
   tcase_add_test(tcase, test_distrib_annotation_converter_uniform);
   tcase_add_test(tcase, test_distrib_annotation_converter_uniformb);
+  tcase_add_test(tcase, test_distrib_annotation_converter_uncertml);
   tcase_add_test(tcase, test_distrib_annotation_converter_exponential);
   tcase_add_test(tcase, test_distrib_annotation_converter_truncated_exponential);
   tcase_add_test(tcase, test_distrib_annotation_converter_gamma);

--- a/src/sbml/packages/distrib/util/test/test-data/normal_l3v1_annot_uncertml.xml
+++ b/src/sbml/packages/distrib/util/test/test-data/normal_l3v1_annot_uncertml.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sbml xmlns="http://www.sbml.org/sbml/level3/version1/core" level="3" version="1">
+  <model id="__main" name="__main">
+    <listOfFunctionDefinitions>
+      <functionDefinition id="normal">
+        <annotation>
+          <distribution xmlns="http://sbml.org/annotations/distribution" definition="http://www.uncertml.org/distributions/normal"/>
+        </annotation>
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <lambda>
+            <bvar>
+              <ci> mean </ci>
+            </bvar>
+            <bvar>
+              <ci> stdev </ci>
+            </bvar>
+            <notanumber/>
+          </lambda>
+        </math>
+      </functionDefinition>
+    </listOfFunctionDefinitions>
+    <listOfParameters>
+      <parameter id="a" constant="true"/>
+    </listOfParameters>
+    <listOfInitialAssignments>
+      <initialAssignment symbol="a">
+        <math xmlns="http://www.w3.org/1998/Math/MathML">
+          <apply>
+            <ci> normal </ci>
+            <cn type="integer"> 1 </cn>
+            <cn type="integer"> 2 </cn>
+          </apply>
+        </math>
+      </initialAssignment>
+    </listOfInitialAssignments>
+  </model>
+</sbml>


### PR DESCRIPTION
## Description
Modified the distrib converter, so it would be able to read / write annotations in the uncertml format as well. 

## Motivation and Context
provides support for the uncertml format of distribution annotation

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Change in documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have updated all documentation necessary.
- [ ] I have checked spelling in (new) comments.

## Testing
- [X] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested -->

