### PR TITLE
Update Maddy to not convert internal single underscores.

### DIFF
--- a/src/sbml/maddy/emphasizedparser.h
+++ b/src/sbml/maddy/emphasizedparser.h
@@ -40,8 +40,10 @@ public:
    */
   void Parse(std::string& line) override
   {
+    // Modifed from previous version, with help from
+    // https://stackoverflow.com/questions/61346949/regex-for-markdown-emphasis
     static std::regex re(
-      R"((?!.*`.*|.*<code>.*)_(?!.*`.*|.*<\/code>.*)([^_]*)_(?!.*`.*|.*<\/code>.*))"
+      R"((?!.*`.*|.*<code>.*)\b_(?![\s])(?!.*`.*|.*<\/code>.*)(.*?[^\s])_\b(?!.*`.*|.*<\/code>.*))"
     );
     static std::string replacement = "<em>$1</em>";
 

--- a/src/sbml/maddy/parser.h
+++ b/src/sbml/maddy/parser.h
@@ -59,7 +59,7 @@ public:
    */
   static const std::string& version()
   {
-    static const std::string v = "1.4.0";
+    static const std::string v = "1.5.0";
     return v;
   }
 

--- a/src/sbml/maddy/strongparser.h
+++ b/src/sbml/maddy/strongparser.h
@@ -40,6 +40,23 @@ public:
    */
   void Parse(std::string& line) override
   {
+    // This version of the regex is changed exactly the same way
+    // that the regex for the emphasized parser was changed, and
+    // it then passes all the 'disabled' tests in the 'strong parser'
+    // test, but then it fails general parsing.  For some reason,
+    // "__text__" translates "<i></i>text<i></i>" even though there
+    // are no word boundaries at the correct places.  It's weird!
+
+    // static std::vector<std::regex> res{
+    //   std::regex{
+    //     R"((?!.*`.*|.*<code>.*)\b\*\*(?![\s])(?!.*`.*|.*<\/code>.*)"
+    //      "(.*?[^\s])\*\*\b(?!.*`.*|.*<\/code>.*))"
+    //   },
+    //   std::regex{
+    //     R"((?!.*`.*|.*<code>.*)\b__(?![\s])(?!.*`.*|.*<\/code>.*)"
+    //      "(.*?[^\s])__\b(?!.*`.*|.*<\/code>.*))"
+    //   }
+    // };
     static std::vector<std::regex> res{
       std::regex{
         R"((?!.*`.*|.*<code>.*)\*\*(?!.*`.*|.*<\/code>.*)([^\*\*]*)\*\*(?!.*`.*|.*<\/code>.*))"

--- a/src/sbml/util/util.cpp
+++ b/src/sbml/util/util.cpp
@@ -558,7 +558,22 @@ std::string util_markdown_to_html(const std::string& markdown)
     //config->enabledParsers |= maddy::types::HTML_PARSER; // do not wrap HTML in paragraph
     //std::shared_ptr<maddy::Parser> parser = std::make_shared<maddy::Parser>(config);
 
-    std::stringstream markdownInput(markdown);
+    //Note:  tried to figure out difference between genuine HTML-ish of &, < and > vs. 
+    // ones that needed to be encoded, but failed. Everything will officially
+    // translate if we encode them all indiscriminately, so hey!  Here we go.
+    std::regex pattern("&");
+    std::string copy = std::regex_replace(markdown, pattern, "&amp;");
+
+    pattern = "&amp;amp;";
+    copy = std::regex_replace(copy, pattern, "&amp;");
+
+    pattern = "<";
+    copy = std::regex_replace(copy, pattern, "&lt;");
+
+    pattern = ">";
+    copy = std::regex_replace(copy, pattern, "&gt;");
+
+    std::stringstream markdownInput(copy);
     static maddy::Parser parser;
     return parser.Parse(markdownInput);
 }

--- a/src/sbml/util/util.cpp
+++ b/src/sbml/util/util.cpp
@@ -565,7 +565,16 @@ std::string util_markdown_to_html(const std::string& markdown)
 
 std::string util_html_to_markdown(const std::string& html)
 {
-    return html2md::Convert(html);
+    std::regex pattern("[Hh][Rr][Ee][Ff] *= *");
+    std::string copy = std::regex_replace(html, pattern, "href=");
+    
+    pattern = "< *([a-zA-Z]*) */ *>";
+    copy = std::regex_replace(copy, pattern, "<$1></$1>");
+
+    pattern = "< */ *([a-zA-Z]*) *>";
+    copy = std::regex_replace(copy, pattern, "</$1>");
+
+    return html2md::Convert(copy);
 }
 
 


### PR DESCRIPTION
Still has problems with internal double-underscores, but at least those are less common.

I've been going through all the 'notes' in Biomodels models, checking to see if they roundtrip through the new markdown parsers.  Many don't!  I've been submitting issue requests and fixes to maddy and to html2md.  This is a pretty large fix, as there are many URLs with internal underscores in them that maddy was converting to `<em>`.

However, there are other problems; if you have to release now, we do indeed do what we claim (use those two libraries to convert markdown); it's just that those libraries have issues.