### PR TITLE
Test whether big/little endian using newer constructs.

### DIFF
--- a/CMakeModules/FindZLIB.cmake
+++ b/CMakeModules/FindZLIB.cmake
@@ -1,4 +1,4 @@
-# Copyright (C) 2022 by Pedro Mendes, Rector and Visitors of the 
+# Copyright (C) 2022 - 2025 by Pedro Mendes, Rector and Visitors of the 
 # University of Virginia, University of Heidelberg, and University 
 # of Connecticut School of Medicine. 
 # All rights reserved. 
@@ -31,7 +31,7 @@ if (NOT (ZLIB_INCLUDE_DIR AND ZLIB_LIBRARY) OR NOT ZLIB_FOUND)
     find_path(ZLIB_INCLUDE_DIR zlib.h zlib/zlib.h
 	    PATHS $ENV{ZLIB_DIR}/include
 	          $ENV{ZLIB_DIR}
-            ${${_PROJECT_DEPENDENCY_DIR}}/include
+              ${${_PROJECT_DEPENDENCY_DIR}}/include
 	          ~/Library/Frameworks
 	          /Library/Frameworks
 	          /sw/include        # Fink
@@ -39,19 +39,22 @@ if (NOT (ZLIB_INCLUDE_DIR AND ZLIB_LIBRARY) OR NOT ZLIB_FOUND)
 	          /opt/csw/include   # Blastwave
 	          /opt/include
 	          /usr/freeware/include
-            NO_DEFAULT_PATH)
+              CMAKE_FIND_ROOT_PATH_BOTH
+              NO_DEFAULT_PATH)
 
     if (NOT ZLIB_INCLUDE_DIR)
-        find_path(ZLIB_INCLUDE_DIR zlib.h zlib/zlib.h)
+        find_path(ZLIB_INCLUDE_DIR zlib.h zlib/zlib.h
+        CMAKE_FIND_ROOT_PATH_BOTH )
     endif ()
 
     find_library(ZLIB_LIBRARY 
-	    NAMES zdll.lib z zlib.lib libzlib zlib libzlib.a 
+	    NAMES zdll.lib z zlib.lib libzlib zlib libzlib.a libzdll.a
 	    PATHS $ENV{ZLIB_DIR}/lib
 	          $ENV{ZLIB_DIR}/lib-dbg
 	          $ENV{ZLIB_DIR}
-            ${${_PROJECT_DEPENDENCY_DIR}}/${CMAKE_INSTALL_LIBDIR}
-            ${${_PROJECT_DEPENDENCY_DIR}}
+              ${${_PROJECT_DEPENDENCY_DIR}}/${CMAKE_INSTALL_LIBDIR}
+              ${${_PROJECT_DEPENDENCY_DIR}}/lib
+              ${${_PROJECT_DEPENDENCY_DIR}}
 	          ~/Library/Frameworks
 	          /Library/Frameworks
 	          /sw/lib        # Fink
@@ -59,10 +62,12 @@ if (NOT (ZLIB_INCLUDE_DIR AND ZLIB_LIBRARY) OR NOT ZLIB_FOUND)
 	          /opt/csw/lib   # Blastwave
 	          /opt/lib
 	          /usr/freeware/lib64
+              CMAKE_FIND_ROOT_PATH_BOTH
              NO_DEFAULT_PATH)
 
     if (NOT ZLIB_LIBRARY)
-        find_library(ZLIB_LIBRARY NAMES zdll.lib z zlib.lib libzlib zlib libzlib.a)
+        find_library(ZLIB_LIBRARY NAMES zdll.lib z zlib.lib libzlib zlib libzlib.a libzdll.a
+        CMAKE_FIND_ROOT_PATH_BOTH )
     endif ()
 
     if (NOT WIN32)
@@ -76,11 +81,12 @@ if (NOT (ZLIB_INCLUDE_DIR AND ZLIB_LIBRARY) OR NOT ZLIB_FOUND)
             set(ZLIB_VERSION ${PC_ZLIB_VERSION} CACHE STRING "Zlib Version found" )
         endif (PC_ZLIB_FOUND)
     endif (NOT WIN32)
-
+    
+    
     # make sure that we have a valid zip library
     file(TO_CMAKE_PATH "${ZLIB_LIBRARY}" LIBZ_CMAKE_PATH)
     include (CheckLibraryExists)
-    check_library_exists("${LIBZ_CMAKE_PATH}" "gzopen" "" LIBZ_CMAKE_PATH)
+    check_library_exists("${LIBZ_CMAKE_PATH}" "gzopen" "" LIBZ_FOUND_SYMBOL)
     if(NOT LIBZ_FOUND_SYMBOL)
         # this is odd, but on windows this check always fails! must be a
         # bug in the current cmake version so for now only issue this
@@ -90,10 +96,9 @@ if (NOT (ZLIB_INCLUDE_DIR AND ZLIB_LIBRARY) OR NOT ZLIB_FOUND)
 "The chosen zlib library does not appear to be valid because it is
 missing certain required symbols. Please check that ${LIBZ_LIBRARY} is
 the correct zlib library. For details about the error, please see
-${LIBSBML_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeError.log")
+CMakeError.log or CMakeConfigureLog.yaml in the build directory.")
         endif()
     endif()
-
 
     mark_as_advanced(ZLIB_INCLUDE_DIR ZLIB_LIBRARY)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -147,12 +147,9 @@ check_include_files (stdlib.h STDC_HEADERS)
 check_include_files (string.h STDC_HEADERS)
 
 set(WORDS_BIGENDIAN)
-if (UNIX)
-  include (TestBigEndian)
-  test_big_endian(WORDS_BIGENDIAN)
+if(CMAKE_C_BYTE_ORDER STREQUAL "BIG_ENDIAN")
+  set(WORDS_BIGENDIAN TRUE)
 else()
-  # test_big_endian seems to fail with nmake (VS 2010) on windows
-  # however, windows is always little endian, so catch this here
   set(WORDS_BIGENDIAN FALSE)
 endif()
 


### PR DESCRIPTION
For some reason, Windows WSL/Ubuntu didn't work with the older method (which I believe is now deprecated); use the newer 'CMAKE_C_BYTE_ORDER' instead.