### PR TITLE
Added missing <cstdint> include in html2md

### DIFF
--- a/src/sbml/html2md/html2md.cpp
+++ b/src/sbml/html2md/html2md.cpp
@@ -9,6 +9,7 @@
 #include <memory>
 #include <sstream>
 #include <vector>
+#include <cctype>
 
 using std::make_shared;
 using std::string;

--- a/src/sbml/html2md/html2md.h
+++ b/src/sbml/html2md/html2md.h
@@ -7,6 +7,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <cstdint>
 
 /*!
  * \brief html2md namespace

--- a/src/sbml/html2md/table.cpp
+++ b/src/sbml/html2md/table.cpp
@@ -7,6 +7,7 @@
 #include <iostream>
 #include <sstream>
 #include <vector>
+#include <algorithm>
 
 using std::string;
 using std::vector;

--- a/src/sbml/maddy/checklistparser.h
+++ b/src/sbml/maddy/checklistparser.h
@@ -78,7 +78,7 @@ protected:
     uint32_t indentation = getIndentationWidth(line);
 
     static std::regex lineRegex("^(- )");
-    line = std::regex_replace(line, lineRegex, "");
+    line = std::regex_replace(line, lineRegex, std::string(""));
 
     static std::regex emptyBoxRegex(R"(^\[ \])");
     static std::string emptyBoxReplacement = "<input type=\"checkbox\"/>";

--- a/src/sbml/maddy/orderedlistparser.h
+++ b/src/sbml/maddy/orderedlistparser.h
@@ -78,9 +78,9 @@ protected:
     uint32_t indentation = getIndentationWidth(line);
 
     static std::regex orderedlineRegex(R"(^[1-9]+[0-9]*\. )");
-    line = std::regex_replace(line, orderedlineRegex, "");
+    line = std::regex_replace(line, orderedlineRegex, std::string(""));
     static std::regex unorderedlineRegex(R"(^\* )");
-    line = std::regex_replace(line, unorderedlineRegex, "");
+    line = std::regex_replace(line, unorderedlineRegex, std::string(""));
 
     if (!this->isStarted)
     {

--- a/src/sbml/maddy/quoteparser.h
+++ b/src/sbml/maddy/quoteparser.h
@@ -132,9 +132,9 @@ protected:
   void parseBlock(std::string& line) override
   {
     static std::regex lineRegexWithSpace(R"(^\> )");
-    line = std::regex_replace(line, lineRegexWithSpace, "");
+    line = std::regex_replace(line, lineRegexWithSpace, std::string(""));
     static std::regex lineRegexWithoutSpace(R"(^\>)");
-    line = std::regex_replace(line, lineRegexWithoutSpace, "");
+    line = std::regex_replace(line, lineRegexWithoutSpace, std::string(""));
 
     if (!line.empty())
     {

--- a/src/sbml/maddy/unorderedlistparser.h
+++ b/src/sbml/maddy/unorderedlistparser.h
@@ -78,7 +78,7 @@ protected:
     uint32_t indentation = getIndentationWidth(line);
 
     static std::regex lineRegex("^([+*-] )");
-    line = std::regex_replace(line, lineRegex, "");
+    line = std::regex_replace(line, lineRegex, std::string(""));
 
     if (!this->isStarted)
     {

--- a/src/sbml/util/util.cpp
+++ b/src/sbml/util/util.cpp
@@ -562,16 +562,16 @@ std::string util_markdown_to_html(const std::string& markdown)
     // ones that needed to be encoded, but failed. Everything will officially
     // translate if we encode them all indiscriminately, so hey!  Here we go.
     std::regex pattern("&");
-    std::string copy = std::regex_replace(markdown, pattern, "&amp;");
+    std::string copy = std::regex_replace(markdown, pattern, std::string("&amp;"));
 
     pattern = "&amp;amp;";
-    copy = std::regex_replace(copy, pattern, "&amp;");
+    copy = std::regex_replace(copy, pattern, std::string("&amp;"));
 
     pattern = "<";
-    copy = std::regex_replace(copy, pattern, "&lt;");
+    copy = std::regex_replace(copy, pattern, std::string("&lt;"));
 
     pattern = ">";
-    copy = std::regex_replace(copy, pattern, "&gt;");
+    copy = std::regex_replace(copy, pattern, std::string("&gt;"));
 
     std::stringstream markdownInput(copy);
     static maddy::Parser parser;
@@ -581,13 +581,13 @@ std::string util_markdown_to_html(const std::string& markdown)
 std::string util_html_to_markdown(const std::string& html)
 {
     std::regex pattern("[Hh][Rr][Ee][Ff] *= *");
-    std::string copy = std::regex_replace(html, pattern, "href=");
+    std::string copy = std::regex_replace(html, pattern, std::string("href="));
     
     pattern = "< *([a-zA-Z]*) */ *>";
-    copy = std::regex_replace(copy, pattern, "<$1></$1>");
+    copy = std::regex_replace(copy, pattern, std::string("<$1></$1>"));
 
     pattern = "< */ *([a-zA-Z]*) *>";
-    copy = std::regex_replace(copy, pattern, "</$1>");
+    copy = std::regex_replace(copy, pattern, std::string("</$1>"));
 
     return html2md::Convert(copy);
 }


### PR DESCRIPTION
## Description
Added a missing cstdint include in src/sbml/html2md/html2md.h

## Motivation and Context
Without this import, when compiling with GCC 15, an error is raised as reported in #439

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Change in documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have updated all documentation necessary.
- [ ] I have checked spelling in (new) comments.

## Testing
- [ ] Testing is done automatically and codecov shows test coverage
- [X] This cannot be tested automatically <!-- describe how it has been tested -->

This needs to be tested with GCC15. I tested it on MSYS2 and ubuntu 25.


