### PR TITLE
#453: check for NULL, ensure boundary condition is reset

### DIFF
--- a/src/sbml/conversion/ExpressionAnalyser.cpp
+++ b/src/sbml/conversion/ExpressionAnalyser.cpp
@@ -99,6 +99,7 @@ ExpressionAnalyser::ExpressionAnalyser(Model * m, pairODEs odes)
     mHiddenNodes(NULL)
 {
   SBMLTransforms::mapComponentValues(mModel);
+  if (mModel)
   mModel->populateAllElementIdList();
   mODEs = deepCopyODEs(odes);
 }
@@ -112,6 +113,7 @@ ExpressionAnalyser::ExpressionAnalyser(const ExpressionAnalyser& orig) :
     mHiddenNodes(orig.mHiddenNodes)
 {
     SBMLTransforms::mapComponentValues(mModel);
+    if (mModel)
     mModel->populateAllElementIdList();
 }
 
@@ -131,6 +133,7 @@ ExpressionAnalyser::operator=(const ExpressionAnalyser& rhs)
     mHiddenNodes = rhs.mHiddenNodes;
   }
   SBMLTransforms::mapComponentValues(mModel);
+  if (mModel)
   mModel->populateAllElementIdList();
 
 

--- a/src/sbml/conversion/SBMLRateRuleConverter.cpp
+++ b/src/sbml/conversion/SBMLRateRuleConverter.cpp
@@ -256,7 +256,7 @@ SBMLRateRuleConverter::setDocument(const SBMLDocument* doc)
 {
     if (SBMLConverter::setDocument(doc) == LIBSBML_OPERATION_SUCCESS)
     {
-        if (mDocument != NULL)
+        if (mDocument != NULL && mDocument->getModel() != NULL)
         {
             mOriginalModel = mDocument->getModel()->clone();
             return LIBSBML_OPERATION_SUCCESS;
@@ -924,6 +924,10 @@ void
 SBMLRateRuleConverter::populateInitialODEinfo()
 {
     Model* model = mDocument->getModel();
+    if (model == NULL)
+    {
+        return;
+    }
 
     // Fages algo 3.6 create set O
     // create pairs of variables and their corresponding ODE
@@ -1277,10 +1281,18 @@ SBMLRateRuleConverter::removeRules()
 {
   for (unsigned int j = 0; j < mODEs.size(); ++j)
   {
-    Rule *rr = mDocument->getModel()->removeRuleByVariable(mODEs.at(j).first);
+		std::string variable = mODEs.at(j).first;
+    Rule *rr = mDocument->getModel()->removeRuleByVariable(variable);
     if (rr != NULL)
     {
       delete rr;
+    }
+
+    // ensure that if variable is species, the boundaryCondition is false
+    Species* s = mDocument->getModel()->getSpecies(variable);
+    if (s != NULL)
+    {
+      s->setBoundaryCondition(false);
     }
   }
 }

--- a/src/sbml/conversion/test/TestSBMLRateRuleConverter.cpp
+++ b/src/sbml/conversion/test/TestSBMLRateRuleConverter.cpp
@@ -372,6 +372,11 @@ START_TEST(test_crash_converter)
   fail_unless(rule_rn_converter->convert() == LIBSBML_OPERATION_FAILED);
 
   delete doc;
+
+	// ensure that we dont crash on null document
+	rule_rn_converter->setDocument((SBMLDocument*)NULL);
+	fail_unless(rule_rn_converter->convert() == LIBSBML_INVALID_OBJECT);
+
 }
 END_TEST
 
@@ -716,6 +721,38 @@ START_TEST(test_rule_reaction_01)
 }
 END_TEST
 
+START_TEST(test_rule_reaction_01_boundaryCondition)
+{
+	std::string reaction_file(TestDataDirectory);
+	reaction_file += "valid_01_bio.xml";
+	SBMLDocument* d = readSBMLFromFile(reaction_file.c_str());
+
+	// convert to ode
+	auto prop = ConversionProperties();
+	prop.addOption("replaceReactions", true,
+		"Replace reactions with rateRules");
+	prop.addOption("rateRuleVariablesShouldBeParameters", false,
+		"make any species into parameters");
+
+	fail_unless(d->convert(prop) == LIBSBML_OPERATION_SUCCESS);
+
+	// ensure species is boundaryCondition (does not matter for ODEs)
+	// to test that convert back removes it
+	d->getModel()->getSpecies(0)->setBoundaryCondition(true);
+
+	// convert back
+	fail_unless(d->convert(rule_rn_props) == LIBSBML_OPERATION_SUCCESS);
+
+	std::string out = writeSBMLToStdString(d);
+
+	// species now can not have boundaryCondition true
+	fail_unless(!d->getModel()->getSpecies(0)->getBoundaryCondition() == true);
+
+	delete d;
+	
+}
+END_TEST
+
 START_TEST(test_rule_reaction_02)
 {
 	std::string raterule_file(TestDataDirectory);
@@ -1011,7 +1048,8 @@ Suite *suite = suite_create("SBMLRateRuleConverter");
 	  tcase_add_test(tcase, test_crash_converter); 
 	  //tcase_add_test(tcase, test_conversion_raterule_converter_hidden_variable);
 	  tcase_add_test(tcase, test_rule_reaction_01);
-	  tcase_add_test(tcase, test_rule_reaction_02);
+    tcase_add_test(tcase, test_rule_reaction_01_boundaryCondition);
+    tcase_add_test(tcase, test_rule_reaction_02);
 	  tcase_add_test(tcase, test_rule_reaction_03); 
 	  tcase_add_test(tcase, test_rule_reaction_04);
 	  tcase_add_test(tcase, test_rule_reaction_05);


### PR DESCRIPTION
## Description
add checks for NULL, ensure boundaryCondition is reset after conversion when removing rules

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here, using the 'fixes #<issue>' syntax. -->
fixes #453 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Change in documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have updated all documentation necessary.
- [ ] I have checked spelling in (new) comments.

## Testing
- [X] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested -->

