### PR TITLE
Allow to bypass suitability tests in raterule connverter

### DIFF
--- a/src/sbml/conversion/SBMLRateRuleConverter.cpp
+++ b/src/sbml/conversion/SBMLRateRuleConverter.cpp
@@ -238,6 +238,9 @@ SBMLRateRuleConverter::getDefaultProperties() const
     prop.addOption("useStoichiometryFromMath", true,
                      "If a number appears in the math use it as the stoichiometry");
 
+		prop.addOption("performSanityCheck", true,
+			"Whether the model should be checked for suitability first");
+
     init = true;
     return prop;
   }
@@ -300,7 +303,7 @@ SBMLRateRuleConverter::convert()
 {
   // if we cannot do the conversion - dont try
   OperationReturnValues_t returnValue;
-  if (!isDocumentAppropriate(returnValue))
+  if (performSanityCheck() && !isDocumentAppropriate(returnValue))
   {
     return returnValue;
   }
@@ -1136,6 +1139,21 @@ bool SBMLRateRuleConverter::useStoichiometryFromMath()
     }
     return value;
 }
+
+bool SBMLRateRuleConverter::performSanityCheck()
+{
+	bool value = true;
+	if (getProperties() == NULL || getProperties()->hasOption("performSanityCheck") == false)
+	{
+		return value;
+	}
+	else
+	{
+		value = getProperties()->getBoolValue("performSanityCheck");
+	}
+	return value;
+}
+
 
 void
 SBMLRateRuleConverter::analyseCoefficient(std::vector<double> coeffs, unsigned int term_index)

--- a/src/sbml/conversion/SBMLRateRuleConverter.h
+++ b/src/sbml/conversion/SBMLRateRuleConverter.h
@@ -229,6 +229,8 @@ private:
 
   bool useStoichiometryFromMath();
 
+  bool performSanityCheck();
+
   // functions to deal with multiple compartments
   bool speciesFromMultipleCompartmentsInSameRateRule();
 

--- a/src/sbml/conversion/test/TestSBMLRateRuleConverter.cpp
+++ b/src/sbml/conversion/test/TestSBMLRateRuleConverter.cpp
@@ -254,6 +254,18 @@ START_TEST(test_conversion_raterule_converter_invalid)
 
   fail_unless(rule_rn_converter->convert() == LIBSBML_OPERATION_FAILED);
 
+	// now override the check for suitability to force an invalid document through
+	// assuming the user knows what they are doing
+	rule_rn_props.addOption("performSanityCheck", false);
+	rule_rn_converter->setProperties(&rule_rn_props);
+
+	fail_unless(rule_rn_converter->convert() == LIBSBML_OPERATION_SUCCESS);
+	
+	// reset to default
+	rule_rn_props.setBoolValue("performSanityCheck", true);
+	rule_rn_converter->setProperties(&rule_rn_props);
+
+
   delete doc;
 }
 END_TEST


### PR DESCRIPTION
## Description
adds a connversion option that bypasses the check for suitability

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here, using the 'fixes #<issue>' syntax. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Change in documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have updated all documentation necessary.
- [ ] I have checked spelling in (new) comments.

## Testing
- [X] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested -->

