### PR TITLE
Allow a model history parent to be set.

### DIFF
--- a/src/sbml/SBase.cpp
+++ b/src/sbml/SBase.cpp
@@ -2362,6 +2362,7 @@ SBase::setModelHistory(ModelHistory * history)
     {
       delete mHistory;
       mHistory = static_cast<ModelHistory*>(history->clone());
+      mHistory->setParentSBMLObject(this);
       mHistoryChanged = true;
       status = LIBSBML_OPERATION_SUCCESS;
     }

--- a/src/sbml/annotation/ModelHistory.cpp
+++ b/src/sbml/annotation/ModelHistory.cpp
@@ -486,21 +486,6 @@ ModelHistory::resetModifiedFlags()
 }
 /** @endcond */
 
-/*
-  * Sets the parent SBML object of this SBML object.
-  *
-  * @param sb the SBML object to use.
-  */
-void
-ModelHistory::connectToParent(SBase* parent)
-{
-  mParentSBMLObject = parent;
-}
-
-
-
-/** @cond doxygenLibsbmlInternal */
-
 const SBase * 
 ModelHistory::getParentSBMLObject() const
 {
@@ -528,8 +513,6 @@ ModelHistory::unsetParentSBMLObject()
   mParentSBMLObject = NULL;
   return LIBSBML_OPERATION_SUCCESS;
 }
-
-/** @endcond */
 
 
 #endif /* __cplusplus */

--- a/src/sbml/annotation/ModelHistory.cpp
+++ b/src/sbml/annotation/ModelHistory.cpp
@@ -486,6 +486,19 @@ ModelHistory::resetModifiedFlags()
 }
 /** @endcond */
 
+/*
+  * Sets the parent SBML object of this SBML object.
+  *
+  * @param sb the SBML object to use.
+  */
+void
+ModelHistory::connectToParent(SBase* parent)
+{
+  mParentSBMLObject = parent;
+}
+
+
+
 /** @cond doxygenLibsbmlInternal */
 
 const SBase * 

--- a/src/sbml/annotation/ModelHistory.h
+++ b/src/sbml/annotation/ModelHistory.h
@@ -382,6 +382,20 @@ public:
    
   /** @endcond */
 
+  /** @cond doxygenLibsbmlInternal */
+  /**
+   * Sets the parent SBML object of this SBML object.
+   * (Creates a child-parent relationship by the child)
+   * This function is called when a child element is
+   * set/added/created by its parent element (e.g. by setXXX,
+   * addXXX, createXXX, and connectToChild functions of the
+   * parent element).
+   *
+   * @param parent the SBML object to use.
+   */
+  virtual void connectToParent(SBase* parent);
+  /** @endcond */
+
 
 protected:
   /** @cond doxygenLibsbmlInternal */

--- a/src/sbml/annotation/ModelHistory.h
+++ b/src/sbml/annotation/ModelHistory.h
@@ -382,30 +382,28 @@ public:
    
   /** @endcond */
 
-  /** @cond doxygenLibsbmlInternal */
   /**
-   * Sets the parent SBML object of this SBML object.
-   * (Creates a child-parent relationship by the child)
-   * This function is called when a child element is
-   * set/added/created by its parent element (e.g. by setXXX,
-   * addXXX, createXXX, and connectToChild functions of the
-   * parent element).
-   *
-   * @param parent the SBML object to use.
+   * Return the parent object of this ModelHistory.
    */
-  virtual void connectToParent(SBase* parent);
-  /** @endcond */
+  const SBase * getParentSBMLObject() const;
 
+  /**
+   * Returns whether the parent object of this ModelHistory has been set (true), or is NULL (false).
+   */
+  bool isSetParentSBMLObject() const;
+
+  /**
+   * Sets the parent object of this ModelHistory.
+   */
+  void setParentSBMLObject(const SBase * sb);
+
+  /**
+   * Sets the parent object of this ModelHistory to NULL.
+   */
+  int unsetParentSBMLObject();
 
 protected:
   /** @cond doxygenLibsbmlInternal */
-
-  // record the SBML Object on which this ModelHistory is set
-
-  const SBase * getParentSBMLObject() const;
-  bool isSetParentSBMLObject() const;
-  void setParentSBMLObject(const SBase * sb);
-  int unsetParentSBMLObject();
 
   friend class RDFAnnotationParser;
   friend class SBase;


### PR DESCRIPTION
Also, set the parent correctly when adding one to an existing element.

Found a bug in Antimony where I would copy a ModelHistory object from one document to another, and it came with its old parent, which would often be deleted.  However, there was no way for me to unset the parent of a ModelHistory, so this fixes that.