### PR TITLE
Allow a model history parent to be set.

### DIFF
--- a/src/sbml/SBase.cpp
+++ b/src/sbml/SBase.cpp
@@ -2362,6 +2362,7 @@ SBase::setModelHistory(ModelHistory * history)
     {
       delete mHistory;
       mHistory = static_cast<ModelHistory*>(history->clone());
+      mHistory->setParentSBMLObject(this);
       mHistoryChanged = true;
       status = LIBSBML_OPERATION_SUCCESS;
     }

--- a/src/sbml/annotation/ModelHistory.cpp
+++ b/src/sbml/annotation/ModelHistory.cpp
@@ -486,6 +486,19 @@ ModelHistory::resetModifiedFlags()
 }
 /** @endcond */
 
+/*
+  * Sets the parent SBML object of this SBML object.
+  *
+  * @param sb the SBML object to use.
+  */
+void
+ModelHistory::connectToParent(SBase* parent)
+{
+  mParentSBMLObject = parent;
+}
+
+
+
 /** @cond doxygenLibsbmlInternal */
 
 const SBase * 

--- a/src/sbml/annotation/ModelHistory.h
+++ b/src/sbml/annotation/ModelHistory.h
@@ -382,6 +382,20 @@ public:
    
   /** @endcond */
 
+  /** @cond doxygenLibsbmlInternal */
+  /**
+   * Sets the parent SBML object of this SBML object.
+   * (Creates a child-parent relationship by the child)
+   * This function is called when a child element is
+   * set/added/created by its parent element (e.g. by setXXX,
+   * addXXX, createXXX, and connectToChild functions of the
+   * parent element).
+   *
+   * @param parent the SBML object to use.
+   */
+  virtual void connectToParent(SBase* parent);
+  /** @endcond */
+
 
 protected:
   /** @cond doxygenLibsbmlInternal */


### PR DESCRIPTION
Also, set the parent correctly when adding one to an existing element.