### PR TITLE
Use python 3.11 instead of 3.8 to build on manylinux

### DIFF
--- a/.github/workflows/brief.yml
+++ b/.github/workflows/brief.yml
@@ -216,9 +216,9 @@ jobs:
           swig -version
       - name: install CMake using pip
         run: |
-          /opt/python/cp38-cp38/bin/pip install cmake
-          ln -s /opt/python/cp38-cp38/bin/cmake /usr/bin/cmake
-          ln -s /opt/python/cp38-cp38/bin/ctest /usr/bin/ctest
+          /opt/python/cp311-cp311/bin/pip install cmake
+          ln -s /opt/python/cp311-cp311/bin/cmake /usr/bin/cmake
+          ln -s /opt/python/cp311-cp311/bin/ctest /usr/bin/ctest
           cmake --version
           ctest --version
       - name: Install dependencies, configure, build
@@ -238,8 +238,8 @@ jobs:
           ${{matrix.xml_parser_option}}=True \
           ${{matrix.package_option}} \
           ${{matrix.language_bindings}} \
-          -DPYTHON_EXECUTABLE=/opt/python/cp38-cp38/bin/python \
-          -DPYTHON_INCLUDE_DIR=/opt/python/cp38-cp38/include/python3.8/ \
+          -DPYTHON_EXECUTABLE=/opt/python/cp311-cp311/bin/python \
+          -DPYTHON_INCLUDE_DIR=/opt/python/cp311-cp311/include/python3.8/ \
           -DWITH_STATIC_RUNTIME=ON \
           -DPYTHON_USE_DYNAMIC_LOOKUP=ON
           cmake --build . --config $BUILD_TYPE

--- a/.github/workflows/brief.yml
+++ b/.github/workflows/brief.yml
@@ -239,7 +239,7 @@ jobs:
           ${{matrix.package_option}} \
           ${{matrix.language_bindings}} \
           -DPYTHON_EXECUTABLE=/opt/python/cp311-cp311/bin/python \
-          -DPYTHON_INCLUDE_DIR=/opt/python/cp311-cp311/include/python3.8/ \
+          -DPYTHON_INCLUDE_DIR=/opt/python/cp311-cp311/include/python3.11/ \
           -DWITH_STATIC_RUNTIME=ON \
           -DPYTHON_USE_DYNAMIC_LOOKUP=ON
           cmake --build . --config $BUILD_TYPE

--- a/.github/workflows/store-artefact.yml
+++ b/.github/workflows/store-artefact.yml
@@ -247,11 +247,11 @@ jobs:
 
       - name: install CMake, ninja and swig using pip
         run: |
-          /opt/python/cp38-cp38/bin/pip install cmake swig ninja
-          ln -s /opt/python/cp38-cp38/bin/cmake /usr/bin/cmake
-          ln -s /opt/python/cp38-cp38/bin/ctest /usr/bin/ctest
-          ln -s /opt/python/cp38-cp38/bin/swig /usr/bin/swig
-          ln -s /opt/python/cp38-cp38/bin/ninja /usr/bin/ninja
+          /opt/python/cp311-cp311/bin/pip install cmake swig ninja
+          ln -s /opt/python/cp311-cp311/bin/cmake /usr/bin/cmake
+          ln -s /opt/python/cp311-cp311/bin/ctest /usr/bin/ctest
+          ln -s /opt/python/cp311-cp311/bin/swig /usr/bin/swig
+          ln -s /opt/python/cp311-cp311/bin/ninja /usr/bin/ninja
           cmake --version
           ctest --version
           swig -version
@@ -281,8 +281,8 @@ jobs:
           ${{matrix.xml_parser_option}} \
           ${{matrix.package_option}} \
           ${{matrix.language_bindings}} \
-          -DPYTHON_EXECUTABLE=/opt/python/cp38-cp38/bin/python \
-          -DPYTHON_INCLUDE_DIR=/opt/python/cp38-cp38/include/python3.8/ \
+          -DPYTHON_EXECUTABLE=/opt/python/cp311-cp311/bin/python \
+          -DPYTHON_INCLUDE_DIR=/opt/python/cp311-cp311/include/python3.8/ \
           -DWITH_STATIC_RUNTIME=ON \
           -DLIBSBML_DEPENDENCY_DIR=$DEPENDENCY_DIR \
           -DEXPAT_LIBRARY=$DEPENDENCY_DIR/lib64/libexpat.a \

--- a/.github/workflows/store-artefact.yml
+++ b/.github/workflows/store-artefact.yml
@@ -282,7 +282,7 @@ jobs:
           ${{matrix.package_option}} \
           ${{matrix.language_bindings}} \
           -DPYTHON_EXECUTABLE=/opt/python/cp311-cp311/bin/python \
-          -DPYTHON_INCLUDE_DIR=/opt/python/cp311-cp311/include/python3.8/ \
+          -DPYTHON_INCLUDE_DIR=/opt/python/cp311-cp311/include/python3.11/ \
           -DWITH_STATIC_RUNTIME=ON \
           -DLIBSBML_DEPENDENCY_DIR=$DEPENDENCY_DIR \
           -DEXPAT_LIBRARY=$DEPENDENCY_DIR/lib64/libexpat.a \


### PR DESCRIPTION
## Description
Current manylinux images have dropped py38, so the uggrade is necessary.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here, using the 'fixes #<issue>' syntax. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Change in documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have updated all documentation necessary.
- [ ] I have checked spelling in (new) comments.

## Testing
- [X] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested -->

