### PR TITLE
Add main option to converters

### DIFF
--- a/src/sbml/conversion/SBMLConverter.cpp
+++ b/src/sbml/conversion/SBMLConverter.cpp
@@ -64,6 +64,7 @@ SBMLConverter::SBMLConverter () :
   , mProps(NULL)
   , mName("")
   , mMainOption("")
+  , mRequiresTargetNamespaces(false)
 {
 }
 
@@ -73,6 +74,7 @@ SBMLConverter::SBMLConverter (const std::string& name)
   , mProps(NULL)
   , mName(name)
   , mMainOption("")
+  , mRequiresTargetNamespaces(false)
 {
 }
 
@@ -85,6 +87,7 @@ SBMLConverter::SBMLConverter(const SBMLConverter& orig) :
   , mProps(NULL)
   , mName(orig.mName)
   , mMainOption(orig.mMainOption)
+  , mRequiresTargetNamespaces(orig.mRequiresTargetNamespaces)
 {
   if (orig.mProps != NULL) 
   {
@@ -122,7 +125,9 @@ SBMLConverter::operator=(const SBMLConverter& rhs)
     mDocument = rhs.mDocument;
     mOriginalModel = rhs.mOriginalModel;
     mName = rhs.mName;
-    
+    mMainOption = rhs.mMainOption;
+    mRequiresTargetNamespaces = rhs.mRequiresTargetNamespaces;
+
     if (mProps != NULL)
     {
       delete mProps;
@@ -206,6 +211,20 @@ void
 SBMLConverter::setMainOption(const std::string& mainOption)
 {
   mMainOption = mainOption;
+}
+
+
+void 
+SBMLConverter::setRequiresTargetNamespaces(bool requiresTargetNamespaces)
+{
+  mRequiresTargetNamespaces = requiresTargetNamespaces;
+}
+
+
+bool
+SBMLConverter::getRequiresTargetNamespaces() const
+{
+  return mRequiresTargetNamespaces;
 }
 
 bool SBMLConverter::mathContainsId(const ASTNode* ast, const std::string& id) const

--- a/src/sbml/conversion/SBMLConverter.cpp
+++ b/src/sbml/conversion/SBMLConverter.cpp
@@ -63,6 +63,7 @@ SBMLConverter::SBMLConverter () :
   , mOriginalModel(NULL)
   , mProps(NULL)
   , mName("")
+  , mMainOption("")
 {
 }
 
@@ -71,6 +72,7 @@ SBMLConverter::SBMLConverter (const std::string& name)
   , mOriginalModel(NULL)
   , mProps(NULL)
   , mName(name)
+  , mMainOption("")
 {
 }
 
@@ -82,6 +84,7 @@ SBMLConverter::SBMLConverter(const SBMLConverter& orig) :
   , mOriginalModel(orig.mOriginalModel)
   , mProps(NULL)
   , mName(orig.mName)
+  , mMainOption(orig.mMainOption)
 {
   if (orig.mProps != NULL) 
   {
@@ -191,6 +194,18 @@ const std::string&
 SBMLConverter::getName() const
 {
   return mName;
+}
+
+const std::string&
+SBMLConverter::getMainOption() const
+{
+  return mMainOption;
+}
+
+void 
+SBMLConverter::setMainOption(const std::string& mainOption)
+{
+  mMainOption = mainOption;
 }
 
 bool SBMLConverter::mathContainsId(const ASTNode* ast, const std::string& id) const

--- a/src/sbml/conversion/SBMLConverter.h
+++ b/src/sbml/conversion/SBMLConverter.h
@@ -315,6 +315,19 @@ public:
    */
   const std::string& getMainOption() const;
 
+
+  /**
+   * @brief Set whether the converter requires a target namespace to be set.
+   * 
+   */
+
+  void setRequiresTargetNamespaces(bool requiresTargetNamespaces);
+
+  /**
+   * 
+   * @return true if the converter requires a target namespace to be set, false otherwise.
+   */
+  bool getRequiresTargetNamespaces() const;
 protected:
   /** @cond doxygenLibsbmlInternal */
   SBMLDocument *   mDocument;
@@ -323,6 +336,7 @@ protected:
   ConversionProperties *mProps;
   std::string mName;
   std::string mMainOption;
+  bool mRequiresTargetNamespaces;
 
   virtual ASTNode* replaceMathWithAssignedVariables(ASTNode* original);
 

--- a/src/sbml/conversion/SBMLConverter.h
+++ b/src/sbml/conversion/SBMLConverter.h
@@ -297,6 +297,24 @@ public:
 
   bool mathContainsId(const ASTNode* ast, const std::string& id) const;
 
+
+  /**
+   * @brief Set the name of the main option that is used to identify the converter.
+   * 
+   * @param mainOption the name of the main option that is used to identify the converter.
+   */
+  void setMainOption(const std::string& mainOption);
+
+  /**
+   * @brief Get the name of the main option that is used to identify the converter.
+   * 
+   * If not defined (or an empty string is returned), the converter will be identified
+   * by going through the options and checking if the converter matches the properties.
+   * 
+   * @return the name of the main option that is used to identify the converter.
+   */
+  const std::string& getMainOption() const;
+
 protected:
   /** @cond doxygenLibsbmlInternal */
   SBMLDocument *   mDocument;
@@ -304,6 +322,7 @@ protected:
 
   ConversionProperties *mProps;
   std::string mName;
+  std::string mMainOption;
 
   virtual ASTNode* replaceMathWithAssignedVariables(ASTNode* original);
 

--- a/src/sbml/conversion/SBMLFunctionDefinitionConverter.cpp
+++ b/src/sbml/conversion/SBMLFunctionDefinitionConverter.cpp
@@ -71,7 +71,7 @@ void SBMLFunctionDefinitionConverter::init()
 SBMLFunctionDefinitionConverter::SBMLFunctionDefinitionConverter() 
   : SBMLConverter("SBML Function Definition Converter")
 {
-
+  mMainOption = "expandFunctionDefinitions";
 }
 
 

--- a/src/sbml/conversion/SBMLIdConverter.cpp
+++ b/src/sbml/conversion/SBMLIdConverter.cpp
@@ -70,7 +70,7 @@ void SBMLIdConverter::init()
 SBMLIdConverter::SBMLIdConverter() 
   : SBMLConverter("SBML Id Converter")
 {
-
+  mMainOption = "renameSIds";
 }
 
 

--- a/src/sbml/conversion/SBMLInferUnitsConverter.cpp
+++ b/src/sbml/conversion/SBMLInferUnitsConverter.cpp
@@ -69,6 +69,7 @@ void SBMLInferUnitsConverter::init()
 SBMLInferUnitsConverter::SBMLInferUnitsConverter () 
   : SBMLConverter("SBML Infer Units Converter")
 {
+  mMainOption = "inferUnits";
   newIdCount = 0;
 }
 

--- a/src/sbml/conversion/SBMLInitialAssignmentConverter.cpp
+++ b/src/sbml/conversion/SBMLInitialAssignmentConverter.cpp
@@ -68,7 +68,7 @@ void SBMLInitialAssignmentConverter::init()
 SBMLInitialAssignmentConverter::SBMLInitialAssignmentConverter() 
   : SBMLConverter("SBML Initial Assignment Converter")
 {
-
+  mMainOption = "expandInitialAssignments";
 }
 
 

--- a/src/sbml/conversion/SBMLLevel1Version1Converter.cpp
+++ b/src/sbml/conversion/SBMLLevel1Version1Converter.cpp
@@ -70,6 +70,7 @@ void SBMLLevel1Version1Converter::init()
 SBMLLevel1Version1Converter::SBMLLevel1Version1Converter () 
   : SBMLConverter("SBML Level 1 Version 1 Converter")
 {
+  mMainOption = "convertToL1V1";
 }
 
 
@@ -124,8 +125,6 @@ SBMLLevel1Version1Converter::getDefaultProperties() const
   }
   else
   {
-    SBMLNamespaces * sbmlns = new SBMLNamespaces(1,1); // default namespaces
-    prop.setTargetNamespaces(sbmlns); // this gets cloned
     prop.addOption("convertToL1V1", true,
       "convert the document to SBML Level 1 Version 1");
     prop.addOption("changePow", false, 
@@ -134,7 +133,9 @@ SBMLLevel1Version1Converter::getDefaultProperties() const
       "if true, occurrances of compartment ids in expressions will be replaced with their initial size");
 
 
-
+    SBMLNamespaces * sbmlns = new SBMLNamespaces(1,1); // default namespaces
+    prop.setTargetNamespaces(sbmlns); // this gets cloned
+  
     delete sbmlns;
     init = true;
     return prop;

--- a/src/sbml/conversion/SBMLLevelVersionConverter.cpp
+++ b/src/sbml/conversion/SBMLLevelVersionConverter.cpp
@@ -78,6 +78,7 @@ SBMLLevelVersionConverter::SBMLLevelVersionConverter ()
   , mMathElements (NULL)
 {
   mMainOption = "setLevelAndVersion";
+  mRequiresTargetNamespaces = true;
 }
 
 

--- a/src/sbml/conversion/SBMLLevelVersionConverter.cpp
+++ b/src/sbml/conversion/SBMLLevelVersionConverter.cpp
@@ -77,6 +77,7 @@ SBMLLevelVersionConverter::SBMLLevelVersionConverter ()
   , mSRIds (NULL)
   , mMathElements (NULL)
 {
+  mMainOption = "setLevelAndVersion";
 }
 
 
@@ -137,10 +138,10 @@ SBMLLevelVersionConverter::getDefaultProperties() const
   {
     SBMLNamespaces * sbmlns = new SBMLNamespaces(); // default namespaces
     prop.setTargetNamespaces(sbmlns); // this gets cloned
+    prop.addOption("setLevelAndVersion", true, 
+      "Convert the model to a given Level and Version of SBML");
     prop.addOption("strict", true,
                    "Whether validity should be strictly preserved");
-    prop.addOption("setLevelAndVersion", true, 
-                   "Convert the model to a given Level and Version of SBML");
     prop.addOption("addDefaultUnits", true,
                    "Whether default units should be added when converting to L3");
     delete sbmlns;

--- a/src/sbml/conversion/SBMLLocalParameterConverter.cpp
+++ b/src/sbml/conversion/SBMLLocalParameterConverter.cpp
@@ -75,7 +75,7 @@ void SBMLLocalParameterConverter::init()
 SBMLLocalParameterConverter::SBMLLocalParameterConverter() 
   : SBMLConverter("SBML Local Parameter Converter")
 {
-
+  mMainOption = "promoteLocalParameters";
 }
 
 

--- a/src/sbml/conversion/SBMLRateOfConverter.cpp
+++ b/src/sbml/conversion/SBMLRateOfConverter.cpp
@@ -73,6 +73,7 @@ void SBMLRateOfConverter::init()
 SBMLRateOfConverter::SBMLRateOfConverter() 
   : SBMLConverter("SBML Rate Of Converter")
 {
+  mMainOption = "replaceRateOf";
 }
 
 

--- a/src/sbml/conversion/SBMLRateRuleConverter.cpp
+++ b/src/sbml/conversion/SBMLRateRuleConverter.cpp
@@ -133,6 +133,7 @@ SBMLRateRuleConverter::SBMLRateRuleConverter()
   , mReactants ()
   , mModifiers ()
 {
+  mMainOption = "inferReactions";
 }
 
 SBMLRateRuleConverter::SBMLRateRuleConverter(const SBMLRateRuleConverter& orig) :

--- a/src/sbml/conversion/SBMLReactionConverter.cpp
+++ b/src/sbml/conversion/SBMLReactionConverter.cpp
@@ -70,6 +70,7 @@ void SBMLReactionConverter::init()
 SBMLReactionConverter::SBMLReactionConverter() 
   : SBMLConverter("SBML Reaction Converter")
 {
+  mMainOption = "replaceReactions";
   mReactionsToRemove.clear();
   mRateRulesMap.clear();
 }

--- a/src/sbml/conversion/SBMLRuleConverter.cpp
+++ b/src/sbml/conversion/SBMLRuleConverter.cpp
@@ -75,7 +75,7 @@ void SBMLRuleConverter::init()
 SBMLRuleConverter::SBMLRuleConverter() 
   : SBMLConverter("SBML Rule Converter")
 {
-
+  mMainOption = "sortRules";
 }
 
 SBMLRuleConverter::SBMLRuleConverter(const SBMLRuleConverter& orig) :

--- a/src/sbml/conversion/SBMLStripPackageConverter.cpp
+++ b/src/sbml/conversion/SBMLStripPackageConverter.cpp
@@ -67,6 +67,7 @@ void SBMLStripPackageConverter::init()
 SBMLStripPackageConverter::SBMLStripPackageConverter () 
   : SBMLConverter("SBML Strip Package Converter")
 {
+  mMainOption = "stripPackage";
 }
 
 

--- a/src/sbml/conversion/SBMLUnitsConverter.cpp
+++ b/src/sbml/conversion/SBMLUnitsConverter.cpp
@@ -70,6 +70,7 @@ SBMLUnitsConverter::SBMLUnitsConverter ()
   : SBMLConverter("SBML Units Converter")
 {
   newIdCount = 0;
+  mMainOption = "units";
 }
 
 

--- a/src/sbml/conversion/test/TestLevelVersionConverter.cpp
+++ b/src/sbml/conversion/test/TestLevelVersionConverter.cpp
@@ -82,6 +82,7 @@ START_TEST (test_setup)
 
   fail_unless (converter->getDefaultProperties().hasOption("setLevelAndVersion") == true);
   fail_unless (converter->getDefaultProperties().hasOption("strict") == true);
+  fail_unless (converter->getRequiresTargetNamespaces() == true);
   fail_unless (converter->getDefaultProperties().getTargetNamespaces() != NULL);
   
   delete converter;

--- a/src/sbml/conversion/test/TestSBMLConverterRegistry.cpp
+++ b/src/sbml/conversion/test/TestSBMLConverterRegistry.cpp
@@ -175,6 +175,37 @@ START_TEST (test_conversion_inline)
 }
 END_TEST
 
+
+START_TEST (test_conversion_main_option)
+{
+  string filename(TestDataDirectory);
+  filename += "00856-sbml-l3v1.xml";
+
+  SBMLDocument* doc = readSBMLFromFile(filename.c_str());
+
+  fail_unless(doc->getModel() != NULL);
+
+  // get all converters, for each one
+  // check that we have a main option set
+  // and that it exists
+
+  // this test essentially just tests that the main option
+  // is set in the constructor of the converter.
+
+  for (int i = 0; i < SBMLConverterRegistry::getInstance().getNumConverters(); ++i)
+  {
+    SBMLConverter* converter = SBMLConverterRegistry::getInstance().getConverterByIndex(i);
+    fail_unless(converter->getMainOption() != "");
+    ConversionProperties props = converter->getDefaultProperties();
+		auto* prop = props.getOption(converter->getMainOption());
+		fail_unless(prop != nullptr);
+    delete converter;
+  }
+
+  delete doc;
+}
+END_TEST
+
 Suite *
 create_suite_TestSBMLConverterRegistry (void)
 { 
@@ -188,6 +219,7 @@ create_suite_TestSBMLConverterRegistry (void)
   tcase_add_test(tcase, test_conversion_units);
   tcase_add_test(tcase, test_conversion_parameters);
   tcase_add_test(tcase, test_conversion_inline);
+  tcase_add_test(tcase, test_conversion_main_option);
 
   suite_add_tcase(suite, tcase);
 

--- a/src/sbml/packages/arrays/util/ArraysFlatteningConverter.cpp
+++ b/src/sbml/packages/arrays/util/ArraysFlatteningConverter.cpp
@@ -147,6 +147,7 @@ void ArraysFlatteningConverter::init()
 ArraysFlatteningConverter::ArraysFlatteningConverter() 
   : SBMLConverter("SBML Arrays Flattening Converter")
 {
+  mMainOption = "flatten arrays";
 }
 
 

--- a/src/sbml/packages/comp/util/CompFlatteningConverter.cpp
+++ b/src/sbml/packages/comp/util/CompFlatteningConverter.cpp
@@ -78,6 +78,7 @@ CompFlatteningConverter::CompFlatteningConverter()
   : SBMLConverter("SBML Comp Flattening Converter")
   , mPkgsToStrip (NULL)
 {
+  mMainOption = "flatten comp";
   mDisabledPackages.clear();
 }
 

--- a/src/sbml/packages/distrib/util/AnnotationToDistribConverter.cpp
+++ b/src/sbml/packages/distrib/util/AnnotationToDistribConverter.cpp
@@ -70,6 +70,7 @@ AnnotationToDistribConverter::AnnotationToDistribConverter()
   : SBMLConverter("SBML Distributions Annotations Converter")
   , mKeepFunctions()
 {
+  mMainOption = "convert distrib annotations";
 }
 
 

--- a/src/sbml/packages/distrib/util/DistribToAnnotationConverter.cpp
+++ b/src/sbml/packages/distrib/util/DistribToAnnotationConverter.cpp
@@ -73,6 +73,7 @@ DistribToAnnotationConverter::DistribToAnnotationConverter()
   : SBMLConverter("SBML Distributions Annotations Converter")
   , mCreatedFunctions()
 {
+  mMainOption = "convert distrib to annotations";
 }
 
 

--- a/src/sbml/packages/fbc/util/CobraToFbcConverter.cpp
+++ b/src/sbml/packages/fbc/util/CobraToFbcConverter.cpp
@@ -68,6 +68,7 @@ void CobraToFbcConverter::init()
 CobraToFbcConverter::CobraToFbcConverter() 
  : SBMLConverter("SBML COBRA to FBC Converter")
 {
+  mMainOption = "convert cobra";
 
 }
 

--- a/src/sbml/packages/fbc/util/FbcToCobraConverter.cpp
+++ b/src/sbml/packages/fbc/util/FbcToCobraConverter.cpp
@@ -69,7 +69,7 @@ void FbcToCobraConverter::init()
 FbcToCobraConverter::FbcToCobraConverter() 
  : SBMLConverter("SBML FBC to COBRA Converter")
 {
-
+  mMainOption = "convert fbc to cobra";
 }
 
 

--- a/src/sbml/packages/fbc/util/FbcV1ToV2Converter.cpp
+++ b/src/sbml/packages/fbc/util/FbcV1ToV2Converter.cpp
@@ -68,6 +68,7 @@ LIBSBML_CPP_NAMESPACE_BEGIN
 FbcV1ToV2Converter::FbcV1ToV2Converter()
   : SBMLConverter("SBML FBC v1 to FBC v2 Converter")
 {
+  mMainOption = "convert fbc v1 to fbc v2";
 }
 
 FbcV1ToV2Converter::FbcV1ToV2Converter(const FbcV1ToV2Converter& orig) :

--- a/src/sbml/packages/fbc/util/FbcV2ToV1Converter.cpp
+++ b/src/sbml/packages/fbc/util/FbcV2ToV1Converter.cpp
@@ -67,6 +67,7 @@ LIBSBML_CPP_NAMESPACE_BEGIN
 FbcV2ToV1Converter::FbcV2ToV1Converter()
   : SBMLConverter("SBML FBC v2 to FBC v1 Converter")
 {
+  mMainOption = "convert fbc v2 to fbc v1";
 }
 
 FbcV2ToV1Converter::FbcV2ToV1Converter(const FbcV2ToV1Converter& orig) :

--- a/src/sbml/packages/render/util/RenderLayoutConverter.cpp
+++ b/src/sbml/packages/render/util/RenderLayoutConverter.cpp
@@ -71,7 +71,7 @@ void RenderLayoutConverter::init()
 RenderLayoutConverter::RenderLayoutConverter() 
   : SBMLConverter("Layout Converter L2 <=> L3")
 {
-
+  mMainOption = "convert layout";
 }
 
 

--- a/src/sbml/packages/render/util/RenderLayoutConverter.cpp
+++ b/src/sbml/packages/render/util/RenderLayoutConverter.cpp
@@ -72,6 +72,7 @@ RenderLayoutConverter::RenderLayoutConverter()
   : SBMLConverter("Layout Converter L2 <=> L3")
 {
   mMainOption = "convert layout";
+  mRequiresTargetNamespaces = true;
 }
 
 


### PR DESCRIPTION
## Description
Currently, there is no way of knowing, which conversion property, is really something to be configured, or 
just a way of choosing which converter to use. 

## Motivation and Context
it makes it easier to write a UI, for converters, as it becomes clear which options matter

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Change in documentation

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] I have updated all documentation necessary.
- [ ] I have checked spelling in (new) comments.

## Testing
- [X] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically <!-- describe how it has been tested -->

