### PR TITLE
Fix #354: Remove empty RDF Description nodes after unsetModifiedDates

### DIFF
--- a/src/sbml/SBase.cpp
+++ b/src/sbml/SBase.cpp
@@ -6470,6 +6470,32 @@ SBase::reconstructRDFAnnotation()
    }
 }
 
+if (mAnnotation != NULL)
+  {
+    int rdfIndex = mAnnotation->getIndex("RDF");
+    if (rdfIndex >= 0)
+    {
+      XMLNode& rdfNode = mAnnotation->getChild((unsigned int)rdfIndex);
+      
+      // Iterate backwards since we are removing items from the list
+      for (int i = (int)rdfNode.getNumChildren() - 1; i >= 0; i--)
+      {
+        XMLNode& child = rdfNode.getChild((unsigned int)i);
+        
+        // If the Description node has no inner children, delete it
+        if (child.getName() == "Description" && child.getNumChildren() == 0)
+        {
+          delete rdfNode.removeChild((unsigned int)i);
+        }
+      }
+      
+      // If the RDF node itself is now completely empty, delete it as well
+      if (rdfNode.getNumChildren() == 0)
+      {
+        delete mAnnotation->removeChild((unsigned int)rdfIndex);
+      }
+    }
+  }
 
   if (history != NULL) delete history;
   if (cvTerms != NULL) delete cvTerms;

--- a/src/sbml/SBase.cpp
+++ b/src/sbml/SBase.cpp
@@ -6477,19 +6477,15 @@ if (mAnnotation != NULL)
     {
       XMLNode& rdfNode = mAnnotation->getChild((unsigned int)rdfIndex);
       
-      // Iterate backwards since we are removing items from the list
       for (int i = (int)rdfNode.getNumChildren() - 1; i >= 0; i--)
       {
         XMLNode& child = rdfNode.getChild((unsigned int)i);
-        
-        // If the Description node has no inner children, delete it
         if (child.getName() == "Description" && child.getNumChildren() == 0)
         {
           delete rdfNode.removeChild((unsigned int)i);
         }
       }
       
-      // If the RDF node itself is now completely empty, delete it as well
       if (rdfNode.getNumChildren() == 0)
       {
         delete mAnnotation->removeChild((unsigned int)rdfIndex);

--- a/src/sbml/test/TestSBase.cpp
+++ b/src/sbml/test/TestSBase.cpp
@@ -2665,20 +2665,19 @@ START_TEST (test_SBase_unsetModifiedDates_issue354)
   
   m->setModelHistory(h);
   
-  // Ensure the date was successfully added
-  fail_unless(m->getNumModifiedDates() == 1);
+  fail_unless(m->getModelHistory()->getNumModifiedDates() == 1);
   
-  // Unset the dates (This triggers the new cleanup logic we wrote in SBase.cpp)
-  m->unsetModifiedDates();
+  ModelHistory* h_ref = m->getModelHistory();
+  h_ref->unsetModifiedDates();
+  m->setModelHistory(h_ref); 
   
-  // Force the annotation to sync and generate the XML string
   std::string annotation = m->getAnnotationString();
   
-  // Assert that the empty Description detritus was completely removed
-  size_t found = annotation.find("<rdf:Description rdf:about=\"#foo\"/>");
+  size_t found = annotation.find("rdf:about=\"#foo\"");
   fail_unless(found == std::string::npos);
   
   delete d;
+  delete h;
   delete m;
 }
 END_TEST

--- a/src/sbml/test/TestSBase.cpp
+++ b/src/sbml/test/TestSBase.cpp
@@ -2665,17 +2665,20 @@ START_TEST (test_SBase_unsetModifiedDates_issue354)
   
   m->setModelHistory(h);
   
-  fail_unless(m->getModelHistory()->getNumModifiedDates() == 1);
+  // Verify the date is successfully added (called correctly on the Model)
+  fail_unless(m->getNumModifiedDates() == 1);
   
-  ModelHistory* h_ref = m->getModelHistory();
-  h_ref->unsetModifiedDates();
-  m->setModelHistory(h_ref); 
+  // Unset the dates (called correctly on the Model, inherited from SBase)
+  m->unsetModifiedDates();
   
+  // Force the annotation to sync and generate the XML string
   std::string annotation = m->getAnnotationString();
   
+  // Assert that the empty Description detritus was completely removed
   size_t found = annotation.find("rdf:about=\"#foo\"");
   fail_unless(found == std::string::npos);
   
+  // Clean up to prevent memory leaks during testing
   delete d;
   delete h;
   delete m;

--- a/src/sbml/test/TestSBase.cpp
+++ b/src/sbml/test/TestSBase.cpp
@@ -2654,6 +2654,35 @@ START_TEST(test_SBase_userData1)
 }
 END_TEST
 
+START_TEST (test_SBase_unsetModifiedDates_issue354)
+{
+  Model* m = new Model(3, 2);
+  m->setMetaId("foo");
+  
+  ModelHistory* h = new ModelHistory();
+  Date* d = new Date("2019-07-29T10:53:09Z");
+  h->addModifiedDate(d);
+  
+  m->setModelHistory(h);
+  
+  // Ensure the date was successfully added
+  fail_unless(m->getNumModifiedDates() == 1);
+  
+  // Unset the dates (This triggers the new cleanup logic we wrote in SBase.cpp)
+  m->unsetModifiedDates();
+  
+  // Force the annotation to sync and generate the XML string
+  std::string annotation = m->getAnnotationString();
+  
+  // Assert that the empty Description detritus was completely removed
+  size_t found = annotation.find("<rdf:Description rdf:about=\"#foo\"/>");
+  fail_unless(found == std::string::npos);
+  
+  delete d;
+  delete m;
+}
+END_TEST
+
 Suite *
 create_suite_SBase (void)
 {
@@ -2709,6 +2738,7 @@ create_suite_SBase (void)
   tcase_add_test(tcase, test_SBase_userData1);
 
   tcase_add_test(tcase, test_SBase_prefixMetaIdSBO);
+  tcase_add_test(tcase, test_SBase_unsetModifiedDates_issue354);
 
   suite_add_tcase(suite, tcase);
 


### PR DESCRIPTION
## Description
Updated the `SBase::reconstructRDFAnnotation()` cleanup logic in `src/sbml/SBase.cpp`. Added a routine at the end of the function to iterate backwards through the `RDF` node's children and delete any `<rdf:Description>` elements that have zero inner children. If the parent `<rdf:RDF>` block becomes completely empty as a result, it is also safely removed. 
I also added a unit test (`test_SBase_unsetModifiedDates_issue354`) in `src/sbml/test/TestSBase.cpp` to explicitly verify that no detritus is left behind when dates are removed.

## Motivation and Context
Previously, calling `unsetModifiedDates` would successfully remove the date nodes but leave behind empty `<rdf:Description rdf:about="#foo"/>` elements in the XML tree. Over multiple cycles, these empty tags would accumulate as detritus in the model's annotation. This change ensures the XML tree remains clean after node removal.
Fixes #354

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Change in documentation

## Checklist:
- [ ] I have updated all documentation necessary.
- [x] I have checked spelling in (new) comments.

## Testing
- [x] Testing is done automatically and codecov shows test coverage
- [ ] This cannot be tested automatically ```