### PR TITLE
Fix memory leak in GeneProductAssociation::getFbcAssociationFor.

### DIFF
--- a/src/sbml/packages/fbc/sbml/GeneProductAssociation.cpp
+++ b/src/sbml/packages/fbc/sbml/GeneProductAssociation.cpp
@@ -282,7 +282,8 @@ FbcAssociation* GeneProductAssociation::getFbcAssociationFor(const ASTNode* astn
         delete fbcand;
         return NULL;
       }
-      if (fbcand->addAssociation(child_fbca) != LIBSBML_OPERATION_SUCCESS) {
+      if (fbcand->getListOfAssociations()->appendAndOwn(child_fbca) != LIBSBML_OPERATION_SUCCESS) {
+        delete child_fbca;
         delete fbcand;
         return NULL;
       }
@@ -296,7 +297,8 @@ FbcAssociation* GeneProductAssociation::getFbcAssociationFor(const ASTNode* astn
         delete fbcor;
         return NULL;
       }
-      if (fbcor->addAssociation(child_fbca) != LIBSBML_OPERATION_SUCCESS) {
+      if (fbcor->getListOfAssociations()->appendAndOwn(child_fbca) != LIBSBML_OPERATION_SUCCESS) {
+        delete child_fbca;
         delete fbcor;
         return NULL;
       }


### PR DESCRIPTION
'addAssociation' cloned and added the object, but didn't delete it; now we call 'appendAndOwn' directly so a) we don't leak, and b) we're more efficient.

Still need to delete the object on failure.